### PR TITLE
fix decorator and whitespace

### DIFF
--- a/src/kfactory/kcell.py
+++ b/src/kfactory/kcell.py
@@ -101,7 +101,7 @@ class PortLayerMismatch(ValueError):
     @config.logger.catch
     def __init__(
         self,
-        lib: "KCLayout ",
+        lib: "KCLayout",
         inst: "Instance",
         other_inst: "Instance | Port",
         p1: "Port",
@@ -201,11 +201,11 @@ class KCLayout(kdb.Layout):
         kdb.Layout.__init__(self, editable)
         self.rename_function: Callable[..., None] = rename_clockwise
 
-    def dup(self, init_cells: bool = True) -> "KCLayout ":
-        """Create a duplication of the `~KCLayout ` object.
+    def dup(self, init_cells: bool = True) -> "KCLayout":
+        """Create a duplication of the `~KCLayout` object.
 
         Args:
-            init_cells: initialize the all cells in the new KCLayout  object
+            init_cells: initialize the all cells in the new KCLayout object
 
         Returns:
             Copy of itself
@@ -870,7 +870,7 @@ class KCell:
     :py:attr:`KCell._kdb_cell`.
 
     Attributes:
-        kcl : Library object that is the manager of the KLayout
+        kcl: Library object that is the manager of the KLayout
             :py:class:`kdb.Layout`
         settings: A dictionary containing settings populated by:py:func:`autocell`
         info: Dictionary for storing additional info if necessary. This is not
@@ -895,7 +895,7 @@ class KCell:
         Args:
             name: Name of the cell, if None will autogenerate name to
                 "Unnamed_<cell_index>".
-            kcl: KCLayout  the cell should be attached to.
+            kcl: KCLayout the cell should be attached to.
             kdb_cell: If not `None`, a KCell will be created from and existing
                 KLayout Cell
             ports: Attach an existing :py:class:`~Ports` object to the KCell,
@@ -1490,7 +1490,7 @@ class KCell:
     def write(
         self, filename: str | Path, save_options: kdb.SaveLayoutOptions = default_save()
     ) -> None:
-        """Write a KCell to a GDS. See :py:func:`KCLayout .write` for more info."""
+        """Write a KCell to a GDS. See :py:func:`KCLayout.write` for more info."""
         return self._kdb_cell.write(str(filename), save_options)
 
     @classmethod
@@ -2527,7 +2527,7 @@ __all__ = [
     "autocell",
     "cell",
     "kcl ",
-    "KCLayout ",
+    "KCLayout",
     "default_save",
     "LayerEnum",
 ]

--- a/src/kfactory/kcell.py
+++ b/src/kfactory/kcell.py
@@ -17,7 +17,7 @@ from collections.abc import Callable, Hashable, Iterable, Iterator
 # from enum import IntEnum
 from enum import Enum, IntEnum
 from hashlib import sha3_512
-from inspect import signature
+from inspect import Parameter, signature
 from pathlib import Path
 from tempfile import gettempdir
 from typing import Any, Literal, TypeVar, cast, overload  # ParamSpec, # >= python 3.10
@@ -2312,9 +2312,16 @@ def cell(
                 params[k] = args[i]
             params.update(kwargs)
 
+            del_parameters: list[str] = []
+
             for key, value in params.items():
                 if isinstance(value, dict):
                     params[key] = dict_to_frozen_set(value)
+                if value == Parameter.empty:
+                    del_parameters.append(key)
+
+            for param in del_parameters:
+                del params[param]
 
             @cachetools.cached(cache=cache)
             @functools.wraps(f)


### PR DESCRIPTION
fix 'kcl ' -> 'kcl', 'KCLayout ' -> 'KCLayout' and @cell decorator using <Parameter.empty> for unsuplied parameters