### PR TITLE
rename autorename_ports to auto_rename_ports

### DIFF
--- a/docs/source/complex_cell.py
+++ b/docs/source/complex_cell.py
@@ -35,7 +35,7 @@ def composite_cell() -> kf.KCell:
     c.add_port(name="1", port=bend.ports["o1"])
     c.add_port(name="2", port=wg.ports["o2"])
 
-    c.autorename_ports()
+    c.auto_rename_ports()
 
     c.draw_ports()
 

--- a/docs/source/intro.md
+++ b/docs/source/intro.md
@@ -58,7 +58,7 @@ def straight(width: int, length: int, width_exclude: int) -> kf.KCell:
         layer=LAYER.SI,
     )
 
-    c.autorename_ports()
+    c.auto_rename_ports()
 
     return c
 
@@ -99,7 +99,7 @@ def straight(width: int, length: int, width_exclude: int) -> kf.KCell:
         layer=LAYER.SI,
     )
 
-    c.autorename_ports()
+    c.auto_rename_ports()
 
     return c
 

--- a/docs/source/notebooks/01_references.py
+++ b/docs/source/notebooks/01_references.py
@@ -175,7 +175,7 @@ c.ports
 # You can also auto_rename ports using gdsfactory default convention, where ports are numbered clockwise starting from the bottom left
 
 # %%
-c.autorename_ports()
+c.auto_rename_ports()
 
 # %%
 c.ports

--- a/docs/source/waveguide.py
+++ b/docs/source/waveguide.py
@@ -22,7 +22,7 @@ def straight(width: int, length: int, width_exclude: int) -> kf.KCell:
         layer=LAYER.SI,
     )
 
-    c.autorename_ports()
+    c.auto_rename_ports()
 
     return c
 

--- a/src/kfactory/cells/bezier.py
+++ b/src/kfactory/cells/bezier.py
@@ -106,7 +106,7 @@ class BendS:
             port_type="optical",
         )
 
-        c.autorename_ports()
+        c.auto_rename_ports()
 
         return c
 

--- a/src/kfactory/cells/circular.py
+++ b/src/kfactory/cells/circular.py
@@ -100,7 +100,7 @@ class BendCircular:
             dwidth=width,
             layer=layer,
         )
-        c.autorename_ports()
+        c.auto_rename_ports()
         c.boundary = center_path
         return c
 

--- a/src/kfactory/cells/dbu/straight.py
+++ b/src/kfactory/cells/dbu/straight.py
@@ -110,7 +110,7 @@ class Straight:
         )
 
         c.boundary = c.dbbox()
-        c.autorename_ports()
+        c.auto_rename_ports()
         return c
 
 

--- a/src/kfactory/cells/dbu/taper.py
+++ b/src/kfactory/cells/dbu/taper.py
@@ -98,7 +98,7 @@ class Taper:
                 "length_dbu": length,
             }
         )
-        c.autorename_ports()
+        c.auto_rename_ports()
         c.boundary = taper.dpolygon
 
         return c

--- a/src/kfactory/cells/euler.py
+++ b/src/kfactory/cells/euler.py
@@ -231,7 +231,7 @@ class BendEulerCustom:
 
         c.boundary = center_path
 
-        c.autorename_ports()
+        c.auto_rename_ports()
         return c
 
 
@@ -303,7 +303,7 @@ class BendEuler:
 
         c.boundary = center_path
 
-        c.autorename_ports()
+        c.auto_rename_ports()
         return c
 
 
@@ -378,7 +378,7 @@ class BendSEuler:
         )
         c.boundary = center_path
 
-        c.autorename_ports()
+        c.auto_rename_ports()
         return c
 
 

--- a/src/kfactory/kcell.py
+++ b/src/kfactory/kcell.py
@@ -962,7 +962,7 @@ class KCell:
             h.update(_hash)
         return h.digest()
 
-    def autorename_ports(self, rename_func: Callable[..., None] | None = None) -> None:
+    def auto_rename_ports(self, rename_func: Callable[..., None] | None = None) -> None:
         """Rename the ports with the schema angle -> "NSWE" and sort by x and y.
 
         Args:

--- a/src/kfactory/kcell.py
+++ b/src/kfactory/kcell.py
@@ -3580,6 +3580,54 @@ class UMInstance:
             kdb.DTrans(0.0, __val - self.parent._instance.dbbox().top)
         )
 
+    @property
+    def x(self) -> float:
+        """Returns the x-coordinate center of the bounding box."""
+        return self.parent._instance.dbbox().center().x
+
+    @x.setter
+    def x(self, __val: float) -> None:
+        """Moves the instance so that the bbox's center x-coordinate."""
+        self.parent.transform(
+            kdb.DTrans(__val - self.parent._instance.dbbox().center().x, 0.0)
+        )
+
+    @property
+    def y(self) -> float:
+        """Returns the x-coordinate center of the bounding box."""
+        return self.parent._instance.dbbox().center().y
+
+    @y.setter
+    def y(self, __val: float) -> None:
+        """Moves the instance so that the bbox's center x-coordinate."""
+        self.parent.transform(
+            kdb.DTrans(0.0, __val - self.parent._instance.dbbox().center().y)
+        )
+
+    @property
+    def center(self) -> kdb.DPoint:
+        """Returns the coordinate center of the bounding box."""
+        return self.parent._instance.dbbox().center()
+
+    @center.setter
+    def center(self, val: tuple[float, float] | kdb.DPoint) -> None:
+        """Moves the instance so that the bbox's center coordinate."""
+        if isinstance(val, kdb.DPoint | kdb.DVector):
+            self.parent.transform(
+                kdb.DTrans(val - self.parent._instance.dbbox().center())
+            )
+        elif isinstance(val, tuple | list):
+            self.parent.transform(
+                kdb.DTrans(
+                    kdb.DPoint(val[0], val[1]) - self.parent._instance.dbbox().center()
+                )
+            )
+        else:
+            raise ValueError(
+                f"Type {type(val)} not supported for center setter {val}. "
+                "Not a tuple, list, kdb.Point or kdb.Vector."
+            )
+
 
 class Instances:
     """Holder for instances.

--- a/src/kfactory/kcell.py
+++ b/src/kfactory/kcell.py
@@ -3000,7 +3000,11 @@ class Instance:
     def name(self) -> str | None:
         """Name of instance in GDS."""
         prop = self.property(PROPID.NAME)
-        return str(prop) if prop is not None else None
+        return (
+            str(prop)
+            if prop is not None
+            else f"{self.kcl[self.cell_index].name}_{self.x}_{self.y}"
+        )
 
     @name.setter
     def name(self, value: str) -> None:

--- a/src/kfactory/kcell.py
+++ b/src/kfactory/kcell.py
@@ -2997,7 +2997,7 @@ class Instance:
         return getattr(self._instance, name)
 
     @property
-    def name(self) -> str | None:
+    def name(self) -> str:
         """Name of instance in GDS."""
         prop = self.property(PROPID.NAME)
         return (

--- a/src/kfactory/kcell.py
+++ b/src/kfactory/kcell.py
@@ -3000,11 +3000,7 @@ class Instance:
     def name(self) -> str:
         """Name of instance in GDS."""
         prop = self.property(PROPID.NAME)
-        return (
-            str(prop)
-            if prop is not None
-            else f"{self.kcl[self.cell_index].name}_{self.x}_{self.y}"
-        )
+        return str(prop) if prop is not None else f"{self.cell.name}_{self.x}_{self.y}"
 
     @name.setter
     def name(self, value: str) -> None:

--- a/tests/test_netlist.py
+++ b/tests/test_netlist.py
@@ -94,7 +94,7 @@ import pytest
 #     c.add_port(s2.ports["o2"])
 #     c.add_port(sc2.ports["o2"])
 
-#     c.autorename_ports()
+#     c.auto_rename_ports()
 
 #     print(c.netlist())
 

--- a/tests/test_rename.py
+++ b/tests/test_rename.py
@@ -32,9 +32,9 @@ def port_tests(rename_f: Optional[Callable[..., None]] = None) -> kf.KCell:
                 width=1 / c.kcl.dbu,
             )
     if rename_f is None:
-        c.autorename_ports()
+        c.auto_rename_ports()
     else:
-        c.autorename_ports(rename_f)
+        c.auto_rename_ports(rename_f)
     c.draw_ports()
     return c
 
@@ -121,7 +121,7 @@ def test_rename_setter() -> None:
             name=name,
         )
 
-    c1.autorename_ports()
+    c1.auto_rename_ports()
 
     for i, _port in enumerate(c1.ports):
         match i % 4:
@@ -160,7 +160,7 @@ def test_rename_setter() -> None:
             layer=kcl.layer(1, 0),
             name=name,
         )
-    c2.autorename_ports()
+    c2.auto_rename_ports()
     for i, _port in enumerate(c2.ports):
         match i % 4:
             case 1:


### PR DESCRIPTION
- rename autorename_ports to auto_rename_ports 
- add UMInstance center, x, y getter and setter
- add default name to Instance by using parent_cell_name_x_y
 fixes https://github.com/gdsfactory/kfactory/issues/197