### PR TITLE
allow gui mode in kfactory

### DIFF
--- a/src/kfactory/__init__.py
+++ b/src/kfactory/__init__.py
@@ -9,6 +9,7 @@ Uses the klayout package as a backend.
 
 try:
     import pya
+
     kdb = pya
     lay = pya
     rdb = pya

--- a/src/kfactory/__init__.py
+++ b/src/kfactory/__init__.py
@@ -7,9 +7,15 @@ Uses the klayout package as a backend.
 # The import order matters, we need to first import the important stuff.
 # isort:skip_file
 
-import klayout.dbcore as kdb
-import klayout.lay as lay
-import klayout.rdb as rdb
+try:
+    import pya
+    kdb = pya
+    lay = pya
+    rdb = pya
+except ImportError:
+    import klayout.dbcore as kdb
+    import klayout.lay as lay
+    import klayout.rdb as rdb
 from .kcell import (
     KCell,
     Instance,


### PR DESCRIPTION
allow using GUI mode in klayout, you just have to make sure you don't install klayout

it would be great to support PCells this way

similar to the functionality we had with [flayout](https://github.com/flaport/flayout)

fixes https://github.com/gdsfactory/kfactory/issues/53

@proppy
@flaport
@sebastian-goeldi 
@SkandanC 