### PR TITLE
Add port access for instance arrays and pretty print for ports

### DIFF
--- a/docs/source/notebooks/01_references.py
+++ b/docs/source/notebooks/01_references.py
@@ -192,13 +192,27 @@ c
 # Let's make a new Cell and put a big array of our Cell `c` in it:
 
 # %%
-# not converted yet
+import kfactory as kf
 
-c3 = kf.KCell("array_of_instances")  # Create a new blank Cell
+print(kf.__version__)
+c = kf.cells.straight.straight(length=10, width=0.6, layer=kf.kcl.layer(1, 0))
+c3 = kf.KCell()  # Create a new blank Cell
 aref = c3.create_inst(
-    c, na=6, nb=3, a=kf.kdb.Vector(20000, 0), b=kf.kdb.Vector(0, 15000)
-)  # instance the Cell "c" 3 instances in it with a 3 rows, 6 columns array
-c3
+    c, na=1, nb=3, a=kf.kdb.Vector(20000, 0), b=kf.kdb.Vector(0, 15000)
+)  # instance the Cell "c" 3 instances in it with a 3 rows, 1 columns array
+
+c3.add_ports(aref.ports)
+c3.draw_ports()
+c3.plot()
+
+# %% [markdown]
+# You can still access the ports for each instance
+
+# %%
+aref['o1', 0, 1]
+
+# %%
+c.ports
 
 # %% [markdown]
 # ## connect instances

--- a/src/kfactory/conf.py
+++ b/src/kfactory/conf.py
@@ -11,6 +11,7 @@ from itertools import takewhile
 from typing import TYPE_CHECKING, Any, ClassVar, Literal
 
 import loguru
+import rich.console
 from loguru import logger as logger
 from pydantic import BaseModel, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -133,6 +134,7 @@ class Settings(
     logfilter: LogFilter = Field(default_factory=LogFilter)
     display_type: Literal["widget", "image", "docs"] = "image"
     meta_format: Literal["v2", "v1"] = "v2"
+    console: rich.console.Console = Field(default_factory=rich.console.Console)
     """The format of the saving of metadata.
 
     v1: Transformations and other KLayout objects are stored as a string. In

--- a/src/kfactory/kcell.py
+++ b/src/kfactory/kcell.py
@@ -3632,7 +3632,20 @@ class Instance:
     def __getitem__(
         self, key: int | str | None | tuple[int | str | None, int, int]
     ) -> Port:
-        """Returns port from instance."""
+        """Returns port from instance.
+
+        The key can either be an integer, in which case the nth port is
+        returned, or a string in which case the first port with a matching
+        name is returned.
+
+        If the instance is an array, the key can also be a tuple in the
+        form of `c.ports[key_name, i_a, i_b]`, where `i_a` is the index in
+        the `instance.a` direction and `i_b` the `instance.b` direction.
+
+        E.g. `c.ports["a", 3, 5]`, accesses the ports of the instance which is
+        3 times in `a` direction (4th index in the array), and 5 times in `b` direction
+        (5th index in the array).
+        """
         return self.ports[key]
 
     def __getattr__(self, name):  # type: ignore[no-untyped-def]
@@ -4683,7 +4696,20 @@ class InstancePorts:
     def __getitem__(
         self, key: int | str | None | tuple[int | str | None, int, int]
     ) -> Port:
-        """Get a port by name."""
+        """Returns port from instance.
+
+        The key can either be an integer, in which case the nth port is
+        returned, or a string in which case the first port with a matching
+        name is returned.
+
+        If the instance is an array, the key can also be a tuple in the
+        form of `c.ports[key_name, i_a, i_b]`, where `i_a` is the index in
+        the `instance.a` direction and `i_b` the `instance.b` direction.
+
+        E.g. `c.ports["a", 3, 5]`, accesses the ports of the instance which is
+        3 times in `a` direction (4th index in the array), and 5 times in `b` direction
+        (5th index in the array).
+        """
         if not self.instance.is_regular_array():
             try:
                 p = self.cell_ports[cast(int | str | None, key)]

--- a/src/kfactory/kcell.py
+++ b/src/kfactory/kcell.py
@@ -4726,6 +4726,12 @@ class InstancePorts:
         else:
             if isinstance(key, tuple):
                 key, i_a, i_b = key
+                if i_a >= self.instance.na or i_b >= self.instance.nb:
+                    raise IndexError(
+                        f"The indexes {i_a=} and {i_b=} must be within the array size"
+                        f" instance.na={self.instance.na} and"
+                        f" instance.nb={self.instance.nb}"
+                    )
             else:
                 i_a = 0
                 i_b = 0

--- a/src/kfactory/kcell.py
+++ b/src/kfactory/kcell.py
@@ -28,6 +28,7 @@ from typing import Any, Literal, TypeAlias, TypeVar, cast, overload
 import cachetools.func
 import numpy as np
 import rich
+import rich.json
 import ruamel.yaml
 from aenum import Enum, constant  # type: ignore[import-untyped,unused-ignore]
 from cachetools import Cache
@@ -5222,7 +5223,7 @@ def pprint_ports(
     ports: Iterable[Port], type: Literal["dbu", "um", None] = None
 ) -> rich.table.Table:
     """Print ports as a table."""
-    table = rich.table.Table()
+    table = rich.table.Table(show_lines=True)
 
     table.add_column("Name")
     table.add_column("Width")
@@ -5231,6 +5232,7 @@ def pprint_ports(
     table.add_column("Y")
     table.add_column("Angle")
     table.add_column("Mirror")
+    table.add_column("Info")
 
     match type:
         case None:
@@ -5244,6 +5246,7 @@ def pprint_ports(
                         str(port.y),
                         str(port.angle),
                         str(port.mirror),
+                        rich.json.JSON.from_data(port.info.model_dump()),
                     )
                 else:
                     table.add_row(
@@ -5254,6 +5257,7 @@ def pprint_ports(
                         str(port.d.y),
                         str(port.d.angle),
                         str(port.d.mirror),
+                        rich.json.JSON.from_data(port.info.model_dump()),
                     )
 
     return table

--- a/tests/test_cell.py
+++ b/tests/test_cell.py
@@ -1,5 +1,9 @@
+import pytest
 import kfactory as kf
 from collections.abc import Callable
+from typing import Any
+import io
+import sys
 
 
 def test_enclosure_name(straight_factory: Callable[..., kf.KCell]) -> None:
@@ -65,6 +69,53 @@ def test_ports_cell(LAYER: kf.LayerEnum) -> None:
 
 def test_getter(LAYER: kf.LayerEnum) -> None:
     c = kf.KCell()
-    w = c << kf.cells.straight.straight(width=1, length=10, layer=LAYER.WG)
+    c << kf.cells.straight.straight(width=1, length=10, layer=LAYER.WG)
     assert c.y == 0
     assert c.d.y == 0
+
+
+def test_array(straight: kf.KCell) -> None:
+    c = kf.KCell()
+    wg_array = c.create_inst(
+        straight, a=kf.kdb.Vector(15_000, 0), b=kf.kdb.Vector(0, 3_000), na=3, nb=5
+    )
+    for b in range(5):
+        for a in range(3):
+            wg_array["o1", a, b]
+            wg_array["o1", a, b]
+    c.show()
+
+
+# def test_invalid_array(straight: kf.KCell, monkeypatch: pytest.MonkeyPatch) -> None:
+#     # Define a mock function that does nothing
+#     def mock_print(*args: Any, **kwargs: Any) -> None:
+#         "Suppress stdout for catching the loguru output"
+#         pass
+
+#     # Monkeypatch the print function to use the mock function
+#     monkeypatch.setattr("builtins.print", mock_print)
+#     monkeypatch.setattr("sys.stderr", mock_print)
+#     monkeypatch.setattr("sys.std", mock_print)
+
+#     c = kf.KCell()
+#     wg = c.create_inst(straight)
+#     with pytest.raises(KeyError):
+#         for b in range(1):
+#             for a in range(1):
+#                 wg["o1", a, b]
+#                 wg["o1", a, b]
+#     c.show()
+
+
+def test_invalid_array(monkeypatch: pytest.MonkeyPatch, straight: kf.KCell) -> None:
+    c = kf.KCell()
+    wg = c.create_inst(straight)
+    regex = kf.config.logfilter.regex
+    kf.config.logfilter.regex = r"^An error has been caught in function '__getitem__'"
+    with pytest.raises(KeyError):
+        for b in range(1):
+            for a in range(1):
+                wg["o1", a, b]
+                wg["o1", a, b]
+    kf.config.logfilter.regex = regex
+    c.show()

--- a/tests/test_cell.py
+++ b/tests/test_cell.py
@@ -83,28 +83,16 @@ def test_array(straight: kf.KCell) -> None:
         for a in range(3):
             wg_array["o1", a, b]
             wg_array["o1", a, b]
-    c.show()
 
 
-# def test_invalid_array(straight: kf.KCell, monkeypatch: pytest.MonkeyPatch) -> None:
-#     # Define a mock function that does nothing
-#     def mock_print(*args: Any, **kwargs: Any) -> None:
-#         "Suppress stdout for catching the loguru output"
-#         pass
-
-#     # Monkeypatch the print function to use the mock function
-#     monkeypatch.setattr("builtins.print", mock_print)
-#     monkeypatch.setattr("sys.stderr", mock_print)
-#     monkeypatch.setattr("sys.std", mock_print)
-
-#     c = kf.KCell()
-#     wg = c.create_inst(straight)
-#     with pytest.raises(KeyError):
-#         for b in range(1):
-#             for a in range(1):
-#                 wg["o1", a, b]
-#                 wg["o1", a, b]
-#     c.show()
+def test_array_indexerror(straight: kf.KCell) -> None:
+    c = kf.KCell()
+    wg_array = c.create_inst(
+        straight, a=kf.kdb.Vector(15_000, 0), b=kf.kdb.Vector(0, 3_000), na=3, nb=5
+    )
+    with pytest.raises(IndexError):
+        wg_array["o1", 3, 5]
+        wg_array["o1", 3, 5]
 
 
 def test_invalid_array(monkeypatch: pytest.MonkeyPatch, straight: kf.KCell) -> None:
@@ -118,4 +106,3 @@ def test_invalid_array(monkeypatch: pytest.MonkeyPatch, straight: kf.KCell) -> N
                 wg["o1", a, b]
                 wg["o1", a, b]
     kf.config.logfilter.regex = regex
-    c.show()

--- a/tests/test_cell.py
+++ b/tests/test_cell.py
@@ -84,6 +84,8 @@ def test_array(straight: kf.KCell) -> None:
             wg_array["o1", a, b]
             wg_array["o1", a, b]
 
+    wg_array.ports[0].print()
+
 
 def test_array_indexerror(straight: kf.KCell) -> None:
     c = kf.KCell()

--- a/tests/test_cell.py
+++ b/tests/test_cell.py
@@ -84,17 +84,18 @@ def test_array(straight: kf.KCell) -> None:
             wg_array["o1", a, b]
             wg_array["o1", a, b]
 
-    wg_array.ports[0].print()
-
 
 def test_array_indexerror(straight: kf.KCell) -> None:
     c = kf.KCell()
     wg_array = c.create_inst(
         straight, a=kf.kdb.Vector(15_000, 0), b=kf.kdb.Vector(0, 3_000), na=3, nb=5
     )
+    regex = kf.config.logfilter.regex
+    kf.config.logfilter.regex = r"^An error has been caught in function '__getitem__'"
     with pytest.raises(IndexError):
         wg_array["o1", 3, 5]
         wg_array["o1", 3, 5]
+    kf.config.logfilter.regex = regex
 
 
 def test_invalid_array(monkeypatch: pytest.MonkeyPatch, straight: kf.KCell) -> None:

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -91,7 +91,9 @@ def test_metainfo_read_cell(straight: kf.KCell) -> None:
 
         kcl = kf.KCLayout("TEST_META")
         kcell = kcl.kcell(straight.name)
+        kf.config.logfilter.regex = r"KLayout <=0.28.15 \(last update 2024-02-02\) cannot read LayoutMetaInfo on 'Cell.read'. kfactory uses these extensively for ports, info, and settings. Therefore proceed at your own risk."
         kcell.read(t.name)
+        kf.config.logfilter.regex = ""
 
         # TODO: wait for KLayout update https://github.com/KLayout/klayout/issues/1609
 

--- a/tests/test_netlist.py
+++ b/tests/test_netlist.py
@@ -120,4 +120,4 @@ def test_l2n(LAYER: kf.LayerEnum) -> None:
 
     c.show()
     nl = c.l2n()
-    print(nl)
+    # print(nl)


### PR DESCRIPTION
Fixes #203 

Usage:

```python
inst = c.creat_inst(..., a=kf.kdb.Vector(x1, y1), b=kf.kdb.Vector(x2, y2), na=4, nb=5)
inst[port_name, 3, 5]
```