### PR TITLE
Add automatic registering of KCell-functions to the KCLayout.factories

### DIFF
--- a/src/kfactory/cells/euler.py
+++ b/src/kfactory/cells/euler.py
@@ -17,7 +17,7 @@ from scipy.special import fresnel  # type:ignore[import-untyped,unused-ignore]
 from .. import kdb
 from ..conf import config
 from ..enclosure import LayerEnclosure, extrude_path
-from ..kcell import KCell, KCLayout, LayerEnum, cell, kcl
+from ..kcell import KCell, KCLayout, LayerEnum, kcl
 
 __all__ = [
     "euler_bend_points",
@@ -295,7 +295,6 @@ class BendSEuler:
             basename=basename or self.__class__.__name__, **cell_kwargs
         )(self._kcell)
 
-    @cell
     def __call__(
         self,
         offset: float,


### PR DESCRIPTION
```python
import kfactory as kf

@kf.kcl.cell
def my_cell_function(...) -> kf.KCell:
    ...
```
Will now register the function at `kf.kcl.factories.my_cell_function`
```python
import kfactory as kf

@kf.kcl.cell(register_factory=False)
def my_cell_function(...) -> kf.KCell:
    ...
```
Will not add it to `kf.ckl.factories`

Note: It's vital to use the proper KCLayout for registration:


```python
import kfactory as kf
from my_package import MyPDK # Custom KCLayout instance (!=kf.kcl)


### Correct
@MyPDK.cell
def my_cell_function(...) -> kf.KCell:
    c = MyPDK.kcell() # or kf.KCell(kcl=MyPDK)
    ...
    return c

### Throws an error because we are trying to register a KCell belonging to `MyPDK` in `kf.kcl`
@kf.cell # or @kf.kcl.cell
def my_cell_function(...) -> kf.KCell:
    c = MyPDK.kcell()
    ...
    return c

### Throws an error because we are trying to register a KCell belonging to `kf.kcl` in `MyPDK`
@MyPDK.cell
def my_cell_function(...) -> kf.KCell:
    c = kf.KCell() # or kf.kcl.kcell()
    ...
    return c
```