### PR TITLE
Fix route_smart ignoring bounding boxes at the end of the routes

### DIFF
--- a/src/kfactory/routing/manhattan.py
+++ b/src/kfactory/routing/manhattan.py
@@ -597,7 +597,7 @@ def route_smart(
     box_region = kdb.Region()
     if bboxes:
         for box in bboxes:
-            box_region.insert(box)
+            box_region.insert(box.enlarged(separation))
             box_region.merge()
 
     all_routers: list[ManhattanRouter] = []
@@ -791,7 +791,7 @@ def route_smart(
                     routers_anticlockwise.extend(new_routers)
                     angle = new_angle
             route_to_bbox([router.start for router in sorted_routers], total_bbox)
-            route_loosely(sorted_routers, separation=separation)
+            route_loosely(sorted_routers, separation=separation, end_bbox=end_bbox)
         else:
             routers = router_groups[0][1]
             r = routers[0]
@@ -826,7 +826,7 @@ def route_smart(
                     )
 
             route_to_bbox([router.start for router in router_bundle], total_bbox)
-            route_loosely(routers, separation=separation)
+            route_loosely(routers, separation=separation, end_bbox=end_bbox)
 
     return all_routers
 

--- a/tests/test_smart_routing.py
+++ b/tests/test_smart_routing.py
@@ -192,8 +192,17 @@ for angle in [0]:
 b = kf.cells.circular.bend_circular(width=1, radius=10, layer=kf.kcl.layer(1, 0))
 s = partial(kf.cells.straight.straight_dbu, width=1000, layer=kf.kcl.layer(1, 0))
 
+c.shapes(kf.kcl.layer(5, 0)).insert(kf.kdb.Box(1_900_000, -102_000, 2_100_000, 175_000))
+c.shapes(kf.kcl.layer(6, 0)).insert(kf.kdb.Box(-1_300_000, 300_000, -900_000, 450_000))
+
 routes = kf.routing.optical.route_bundle(
-    c, start_ports=ps, end_ports=pe, bend90_cell=b, separation=2000, straight_factory=s
+    c,
+    start_ports=ps,
+    end_ports=pe,
+    bend90_cell=b,
+    separation=2000,
+    straight_factory=s,
+    bboxes=[c.bbox(kf.kcl.layer(5, 0)), c.bbox(kf.kcl.layer(6, 0))],
 )
 
 # routers = kf.routing.manhattan.route_smart(


### PR DESCRIPTION
Fixes it avoiding the red bbox in the example

![image](https://github.com/gdsfactory/kfactory/assets/44963764/2ea743a0-76f0-4d10-94ca-723dae6d08d3)
