### PR TITLE
Add Schematic Cells

### DIFF
--- a/src/kfactory/factories/__init__.py
+++ b/src/kfactory/factories/__init__.py
@@ -1,25 +1,6 @@
 """Factories for generating functions which can produce KCells or VKCells."""
 
-from typing import Protocol
-
-from .. import KCell
 from . import bezier, circular, euler, straight, taper, virtual
-
-
-class StraightFactory(Protocol):
-    """Factory Protocol for routing.
-
-    A straight factory must return a KCell with only a width and length given.
-    """
-
-    def __call__(self, width: int, length: int) -> KCell:
-        """Produces the KCell.
-
-        E.g. in a function this would amount to
-        `straight_factory(length=10_000, width=1000)`
-        """
-        ...
-
 
 __all__ = [
     "bezier",

--- a/src/kfactory/kf_types.py
+++ b/src/kfactory/kf_types.py
@@ -3,9 +3,25 @@
 Mainly units for annotating types.
 """
 
-from typing import Annotated
+from __future__ import annotations
 
-from .kcell import LayerEnum
+from typing import TYPE_CHECKING, Annotated, Protocol
+
+from . import kdb
+
+if TYPE_CHECKING:
+    from .kcell import KCell, LayerEnum, Port  # noqa: F401
+    from .routing.optical import OpticalManhattanRoute
+
+__all__ = [
+    "um",
+    "dbu",
+    "rad",
+    "deg",
+    "layer",
+    "ManhattanRoutePathFunction",
+    "ManhattanRoutePathFunction180",
+]
 
 um = Annotated[float, "um"]
 """Float in micrometer."""
@@ -15,5 +31,69 @@ deg = Annotated[float, "deg"]
 """Float in degrees."""
 rad = Annotated[float, "rad"]
 """Float in radians."""
-layer = Annotated[int | LayerEnum, "layer"]
+layer = Annotated["int | LayerEnum", "layer"]
 """Integer or enum index of a Layer."""
+
+
+class StraightFactory(Protocol):
+    """Factory Protocol for routing.
+
+    A straight factory must return a KCell with only a width and length given.
+    """
+
+    def __call__(self, width: int, length: int) -> KCell:
+        """Produces the KCell.
+
+        E.g. in a function this would amount to
+        `straight_factory(length=10_000, width=1000)`
+        """
+        ...
+
+
+class ManhattanRoutePathFunction(Protocol):
+    """Minimal signature of a manhattan function."""
+
+    def __call__(
+        self,
+        port1: Port | kdb.Trans,
+        port2: Port | kdb.Trans,
+        bend90_radius: int,
+        start_straight: int,
+        end_straight: int,
+    ) -> list[kdb.Point]:
+        """Minimal kwargs of a manhattan route function."""
+        ...
+
+
+class ManhattanRoutePathFunction180(Protocol):
+    """Minimal signature of a manhattan function with 180° bend routing."""
+
+    def __call__(
+        self,
+        port1: Port | kdb.Trans,
+        port2: Port | kdb.Trans,
+        bend90_radius: int,
+        bend180_radius: int,
+        start_straight: int,
+        end_straight: int,
+    ) -> list[kdb.Point]:
+        """Minimal kwargs of a manhattan route function with 180° bend."""
+        ...
+
+
+class RouteFunction(Protocol):
+    def __call__(
+        self,
+        start_ports: list[Port],
+        end_ports: list[Port],
+        separation: int,
+        straight_factory: StraightFactory,
+        bend90_cell: KCell,
+        taper_cell: KCell | None = None,
+        start_straights: int | list[int] = 0,
+        end_straights: int | list[int] = 0,
+        place_port_type: str = "optical",
+        bboxes: list[kdb.Box] = [],
+        allow_different_port_widths: bool = False,
+        route_width: int | list[int] | None = None,
+    ) -> list[OpticalManhattanRoute]: ...

--- a/src/kfactory/routing/electrical.py
+++ b/src/kfactory/routing/electrical.py
@@ -4,7 +4,8 @@ from collections.abc import Callable
 
 from .. import kdb
 from ..kcell import Instance, KCell, Port
-from .manhattan import ManhattanRoutePathFunction, route_manhattan
+from ..kf_types import ManhattanRoutePathFunction
+from .manhattan import route_manhattan
 
 
 def route_elec(

--- a/src/kfactory/routing/manhattan.py
+++ b/src/kfactory/routing/manhattan.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable, Sequence
 from dataclasses import InitVar, dataclass, field
-from typing import Literal, Protocol
+from typing import Literal
 
 import numpy as np
 
@@ -17,40 +17,7 @@ __all__ = [
     "route_manhattan",
     "route_manhattan_180",
     "clean_points",
-    "ManhattanRoutePathFunction",
-    "ManhattanRoutePathFunction180",
 ]
-
-
-class ManhattanRoutePathFunction(Protocol):
-    """Minimal signature of a manhattan function."""
-
-    def __call__(
-        self,
-        port1: Port | kdb.Trans,
-        port2: Port | kdb.Trans,
-        bend90_radius: int,
-        start_straight: int,
-        end_straight: int,
-    ) -> list[kdb.Point]:
-        """Minimal kwargs of a manhattan route function."""
-        ...
-
-
-class ManhattanRoutePathFunction180(Protocol):
-    """Minimal signature of a manhattan function with 180° bend routing."""
-
-    def __call__(
-        self,
-        port1: Port | kdb.Trans,
-        port2: Port | kdb.Trans,
-        bend90_radius: int,
-        bend180_radius: int,
-        start_straight: int,
-        end_straight: int,
-    ) -> list[kdb.Point]:
-        """Minimal kwargs of a manhattan route function with 180° bend."""
-        ...
 
 
 def droute_manhattan_180(

--- a/src/kfactory/routing/optical.py
+++ b/src/kfactory/routing/optical.py
@@ -1,19 +1,20 @@
 """Optical routing allows the creation of photonic (or any route using bends)."""
 
 from collections.abc import Sequence
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 from pydantic import BaseModel
 
 from .. import kdb, rdb
 from ..conf import config
-from ..factories import StraightFactory
 from ..kcell import Instance, KCell, LayerEnum, Port
 from .manhattan import (
-    ManhattanRoutePathFunction,
     route_manhattan,
     route_smart,
 )
+
+if TYPE_CHECKING:
+    from ..kf_types import ManhattanRoutePathFunction, StraightFactory
 
 __all__ = [
     "OpticalManhattanRoute",
@@ -193,13 +194,13 @@ def route(
     c: KCell,
     p1: Port,
     p2: Port,
-    straight_factory: StraightFactory,
+    straight_factory: "StraightFactory",
     bend90_cell: KCell,
     bend180_cell: KCell | None = None,
     taper_cell: KCell | None = None,
     start_straight: int = 0,
     end_straight: int = 0,
-    route_path_function: ManhattanRoutePathFunction = route_manhattan,
+    route_path_function: "ManhattanRoutePathFunction" = route_manhattan,
     port_type: str = "optical",
     allow_small_routes: bool = False,
     route_kwargs: dict[str, Any] | None = {},
@@ -468,7 +469,7 @@ def route_bundle(
     start_ports: list[Port],
     end_ports: list[Port],
     separation: int,
-    straight_factory: StraightFactory,
+    straight_factory: "StraightFactory",
     bend90_cell: KCell,
     taper_cell: KCell | None = None,
     start_straights: int | list[int] = 0,
@@ -664,7 +665,7 @@ def place90(
     p1: Port,
     p2: Port,
     pts: Sequence[kdb.Point],
-    straight_factory: StraightFactory,
+    straight_factory: "StraightFactory",
     bend90_cell: KCell,
     taper_cell: KCell | None = None,
     port_type: str = "optical",


### PR DESCRIPTION
 This will allow to use a more schematic approach compared to the current iterative procedure:
 
 ```python
@pdk.schematic_cell
def my_schematic_cell(c: SchematicCell, *args: SchematicParams.args, **kwargs: SchematicParams.kwargs) -> None:
    anchor_inst = c << my_kcell(param1,param2=param2,...)
    c.anchor(anchor_inst, dest=kdb.Trans(500_000,0) # put the instance with origin at 500,0
    inst2 = c << my_kcell2()
    c.add_connection(inst2, "o1", anchor_inst, "o2") # equivalent to `c.add_connection(anchor_inst, "o2", inst2, "o1")`, which one is picked doesn't matter
    c.add_route(inst2, "o2", anchor_inst, "o1") # not equivalent to the swapped because the route function might route different if end and start are swapped
    # ...
```

Which should be equivalent to this:

```python
@pdk.schematic_cell
def my_schematic_cell(c: SchematicCell, *args: SchematicParams.args, **kwargs: SchematicParams.kwargs) -> None:
    inst2 = c << my_kcell2()
    anchor_inst = c << my_kcell(param1,param2=param2,...)
    
    
    c.add_route(inst2, "o2", anchor_inst, "o1") # not equivalent to the swapped because the route function might route different if end and start are swapped
    c.anchor(anchor_inst, dest=kdb.Trans(500_000,0) # put the instance with origin at 500,0
    c.add_connection(inst2, "o1", anchor_inst, "o2") # equivalent to `c.add_connection(anchor_inst, "o2", inst2, "o1")`, which one is picked doesn't matter
    # ...
```