### PR TITLE
Improve fill tiled with row/column vectors

### DIFF
--- a/src/kfactory/kcell.py
+++ b/src/kfactory/kcell.py
@@ -6618,36 +6618,32 @@ def clean_value(
         return dict2name(**value)
     elif hasattr(value, "name"):
         return clean_name(value.name)
-    elif (
-        callable(value)
-        and isinstance(value, FunctionType)
-        and value.__name__ == "<lambda>"
-    ):
-        raise ValueError(
-            "Unable to serialize lambda function. Use a named function instead."
-        )
-    elif callable(value) and isinstance(value, functools.partial):
-        sig = inspect.signature(value.func)
-        args_as_kwargs = dict(zip(sig.parameters.keys(), value.args))
-        args_as_kwargs.update(**value.keywords)
-        args_as_kwargs = clean_dict(args_as_kwargs)
-        # args_as_kwargs.pop("function", None)
-        func = value.func
-        while hasattr(func, "func"):
-            func = func.func
-        v = {
-            "function": func.__name__,
-            "module": func.__module__,
-            "settings": args_as_kwargs,
-        }
-        return clean_value(v)
-    elif callable(value) and isinstance(value, toolz.functoolz.Compose):
-        return "_".join(
-            [clean_value(value.first)] + [clean_value(func) for func in value.funcs]
-        )
-
     elif callable(value):
-        return getattr(value, "__name__", value.__class__.__name__)
+        if isinstance(value, FunctionType) and value.__name__ == "<lambda>":
+            raise ValueError(
+                "Unable to serialize lambda function. Use a named function instead."
+            )
+        if isinstance(value, functools.partial):
+            sig = inspect.signature(value.func)
+            args_as_kwargs = dict(zip(sig.parameters.keys(), value.args))
+            args_as_kwargs.update(**value.keywords)
+            args_as_kwargs = clean_dict(args_as_kwargs)
+            # args_as_kwargs.pop("function", None)
+            func = value.func
+            while hasattr(func, "func"):
+                func = func.func
+            v = {
+                "function": func.__name__,
+                "module": func.__module__,
+                "settings": args_as_kwargs,
+            }
+            return clean_value(v)
+        elif isinstance(value, toolz.functoolz.Compose):
+            return "_".join(
+                [clean_value(value.first)] + [clean_value(func) for func in value.funcs]
+            )
+        else:
+            return getattr(value, "__name__", value.__class__.__name__)
     else:
         return clean_name(str(value))
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -141,3 +141,12 @@ def pdk(LAYER: LAYER_CLASS) -> kf.KCLayout:
     )
     kcl = kf.KCLayout("Test_PDK", layer_stack=layerstack)
     return kcl
+
+
+@pytest.fixture
+@kf.cell
+def fill_cell() -> kf.KCell:
+    fc = kf.KCell()
+    fc.shapes(fc.kcl.layer(2, 0)).insert(kf.kdb.DBox(20, 40))
+    fc.shapes(fc.kcl.layer(3, 0)).insert(kf.kdb.DBox(30, 15))
+    return fc

--- a/tests/test_fill.py
+++ b/tests/test_fill.py
@@ -1,0 +1,66 @@
+import kfactory as kf
+
+
+def test_tiled_fill_space(fill_cell: kf.KCell) -> None:
+    c = kf.KCell()
+    c.shapes(kf.kcl.layer(1, 0)).insert(
+        kf.kdb.DPolygon.ellipse(kf.kdb.DBox(5000, 3000), 512)
+    )
+    c.shapes(kf.kcl.layer(10, 0)).insert(
+        kf.kdb.DPolygon(
+            [kf.kdb.DPoint(0, 0), kf.kdb.DPoint(5000, 0), kf.kdb.DPoint(5000, 3000)]
+        )
+    )
+    kf.utils.fill_tiled(
+        c,
+        fill_cell,
+        [(kf.kcl.layer(1, 0), 0)],
+        exclude_layers=[
+            (kf.kcl.layer(10, 0), 100),
+            (kf.kcl.layer(2, 0), 0),
+            (kf.kcl.layer(3, 0), 0),
+        ],
+        x_space=5,
+        y_space=5,
+    )
+    c.show()
+
+
+def test_tiled_fill_vector(fill_cell: kf.KCell) -> None:
+    c = kf.KCell()
+    c.shapes(kf.kcl.layer(1, 0)).insert(
+        kf.kdb.DPolygon.ellipse(kf.kdb.DBox(5000, 3000), 512)
+    )
+    c.shapes(kf.kcl.layer(10, 0)).insert(
+        kf.kdb.DPolygon(
+            [kf.kdb.DPoint(0, 0), kf.kdb.DPoint(5000, 0), kf.kdb.DPoint(5000, 3000)]
+        )
+    )
+
+    poly = kf.kdb.DPolygon(
+        [
+            kf.kdb.DPoint(-2000, 400),
+            kf.kdb.DPoint(-1000, 400),
+            kf.kdb.DPoint(-1000, -400),
+            kf.kdb.DPoint(-2000, -400),
+        ]
+    )
+
+    poly.insert_hole(kf.kdb.DBox(-1800, -200, -1200, 200))
+
+    c.shapes(kf.kcl.layer(10, 0)).insert(poly)
+    kf.utils.fill_tiled(
+        c,
+        fill_cell,
+        [(kf.kcl.layer(1, 0), 0)],
+        exclude_layers=[
+            (kf.kcl.layer(10, 0), 100),
+            (kf.kcl.layer(2, 0), 0),
+            (kf.kcl.layer(3, 0), 0),
+        ],
+        row_step=kf.kdb.DVector(35, 5),
+        col_step=kf.kdb.DVector(-5, 50),
+        tile_border=(fill_cell.dbbox().width(), fill_cell.dbbox().height()),
+        tile_size=(500, 500),
+    )
+    c.show()


### PR DESCRIPTION
This allows staggered fill and also fixes some minor fill pattern errors which could occur on tile borders.

![image](https://github.com/gdsfactory/kfactory/assets/44963764/fe5ee1ad-7684-44e6-8db5-193837e37882)

```python
@kf.cell
def fill_cell() -> kf.KCell:
    fc = kf.KCell()
    fc.shapes(fc.kcl.layer(2, 0)).insert(kf.kdb.DBox(20, 40))
    fc.shapes(fc.kcl.layer(3, 0)).insert(kf.kdb.DBox(30, 15))
    return fc

def test_tiled_fill_vector(fill_cell: kf.KCell) -> None:
    c = kf.KCell()
    c.shapes(kf.kcl.layer(1, 0)).insert(
        kf.kdb.DPolygon.ellipse(kf.kdb.DBox(5000, 3000), 512)
    )
    c.shapes(kf.kcl.layer(10, 0)).insert(
        kf.kdb.DPolygon(
            [kf.kdb.DPoint(0, 0), kf.kdb.DPoint(5000, 0), kf.kdb.DPoint(5000, 3000)]
        )
    )

    poly = kf.kdb.DPolygon(
        [
            kf.kdb.DPoint(-2000, 400),
            kf.kdb.DPoint(-1000, 400),
            kf.kdb.DPoint(-1000, -400),
            kf.kdb.DPoint(-2000, -400),
        ]
    )

    poly.insert_hole(kf.kdb.DBox(-1800, -200, -1200, 200))

    c.shapes(kf.kcl.layer(10, 0)).insert(poly)
    kf.utils.fill_tiled(
        c,
        fill_cell,
        [(kf.kcl.layer(1, 0), 0)],
        exclude_layers=[
            (kf.kcl.layer(10, 0), 100),
            (kf.kcl.layer(2, 0), 0),
            (kf.kcl.layer(3, 0), 0),
        ],
        row_step=kf.kdb.DVector(35, 5),
        col_step=kf.kdb.DVector(-5, 50),
        tile_border=(fill_cell.dbbox().width(), fill_cell.dbbox().height()),
        tile_size=(500, 500),
    )
    c.show()
```

@joamatab 
@gdspaul 