### PR TITLE
Add enum for handling check_instances

### DIFF
--- a/src/kfactory/conf.py
+++ b/src/kfactory/conf.py
@@ -66,6 +66,13 @@ class LogLevel(str, Enum):
     CRITICAL = "CRITICAL"
 
 
+class CHECK_INSTANCES(str, Enum):
+    ERROR = "error"
+    FLATTEN = "flatten"
+    VINSTANCE = "vinstance"
+    NONE = "none"
+
+
 class LogFilter(BaseModel):
     """Filter certain messages by log level or regex.
 
@@ -102,9 +109,7 @@ def get_affinity() -> int:
         return threads
 
 
-class Settings(
-    BaseSettings,
-):
+class Settings(BaseSettings):
     """KFactory settings object.
 
     Attrs:
@@ -145,6 +150,7 @@ class Settings(
     allow_width_mismatch: bool = False
     allow_layer_mismatch: bool = False
     allow_type_mismatch: bool = False
+    check_instances: CHECK_INSTANCES = CHECK_INSTANCES.ERROR
     connect_use_mirror: bool = True
     connect_use_angle: bool = True
     """The format of the saving of metadata.

--- a/src/kfactory/conf.py
+++ b/src/kfactory/conf.py
@@ -69,7 +69,7 @@ class LogLevel(str, Enum):
 class CHECK_INSTANCES(str, Enum):
     ERROR = "error"
     FLATTEN = "flatten"
-    VINSTANCE = "vinstance"
+    VINSTANCES = "vinstances"
     NONE = "none"
 
 

--- a/src/kfactory/kcell.py
+++ b/src/kfactory/kcell.py
@@ -3112,7 +3112,7 @@ class KCLayout(BaseModel, arbitrary_types_allowed=True, extra="allow"):
                         case CHECK_INSTANCES.FLATTEN:
                             if any(inst.is_complex() for inst in cell.each_inst()):
                                 cell.flatten()
-                        case CHECK_INSTANCES.VINSTANCE:
+                        case CHECK_INSTANCES.VINSTANCES:
                             if any(inst.is_complex() for inst in cell.each_inst()):
                                 complex_insts = [
                                     inst


### PR DESCRIPTION
Allows different handling  if any instance in the `@cell` decorated cell is off-grid or a non-90° rotation:
- `CHECK_INSTANCES.ERROR` (`"error"`): Throw an error (default)
- `CHECK_INSTANCES.FLATTEN` (`"flatten"`): Flatten the cell
- `CHECK_INSTANCES.VINSTANCES` (`"vinstances"`): Convert any offending instance to a VInstance
- `CHECK_INSTANCES.NONE` (`none`): Do nothing and continue

Example usage:

<details open>

<summary>test.py</summary>

```python
import kfactory as kf


@kf.kcl.cell
def rotated_bend() -> kf.KCell:
    c = kf.KCell()

    bend = c << kf.cells.euler.bend_euler(width=1, radius=10, layer=kf.kcl.layer(1, 0))
    bend.drotate(30)
    straight = c << kf.cells.straight.straight(
        width=1, length=10, layer=kf.kcl.layer(2, 0)
    )
    straight.connect("o1", bend, "o2")

    return c


rotated_bend().show()
```

</details>

Run:
```bash
KFACTORY_CHECK_INSTANCES='vinstances' KFACTORY_LOGFILTER_LEVEL="DEBUG" KFACTORY_ALLOW_LAYER_MISMATCH=on python test.py
```

Or for single usage:

`@cell(check_instances=config.CHECK_INSTANCES.VINSTANCES)`

@tvt173 