### PR TITLE
Add `overwrite_existing` and `layout_cache` options to the cell decorator

### DIFF
--- a/src/kfactory/conf.py
+++ b/src/kfactory/conf.py
@@ -153,6 +153,8 @@ class Settings(BaseSettings):
     check_instances: CHECK_INSTANCES = CHECK_INSTANCES.ERROR
     connect_use_mirror: bool = True
     connect_use_angle: bool = True
+    cell_overwrite_existing: bool = False
+    cell_layout_cache: bool = False
     """The format of the saving of metadata.
 
     v1: Transformations and other KLayout objects are stored as a string. In

--- a/src/kfactory/conf.py
+++ b/src/kfactory/conf.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, Literal
 import loguru
 import rich.console
 from loguru import logger as logger
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ValidationInfo, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 if TYPE_CHECKING:
@@ -50,7 +50,7 @@ def tracing_formatter(record: loguru.Record) -> str:
         return (
             "<green>{time:YYYY-MM-DD HH:mm:ss.SSS}</green> | <level>{level: <8}"
             "</level> | <cyan>{name}</cyan>:<cyan>{function}</cyan>:<cyan>{line}</cyan>"
-            " - <level>{message}</level>\n{exception}"
+            " - <level>{message}</level>"
         )
 
 
@@ -67,10 +67,10 @@ class LogLevel(str, Enum):
 
 
 class CHECK_INSTANCES(str, Enum):
-    ERROR = "error"
+    RAISE = "error"
     FLATTEN = "flatten"
     VINSTANCES = "vinstances"
-    NONE = "none"
+    IGNORE = "ignore"
 
 
 class LogFilter(BaseModel):
@@ -135,13 +135,24 @@ class Settings(BaseSettings):
         env_prefix="kfactory_",
         env_nested_delimiter="_",
         extra="allow",
+        validate_assignment=True,
     )
 
     n_threads: int = get_affinity()
+    """Number of threads to use for multithreaded operations."""
     logger: ClassVar[Logger] = logger
+    """Logger used by kfactory."""
     logfilter: LogFilter = Field(default_factory=LogFilter)
+    """Can configure the logger to ignore certain levels or by regex."""
     display_type: Literal["widget", "image", "docs"] = "image"
+    """The default behavior for displaying cells in jupyter."""
     meta_format: Literal["v2", "v1"] = "v2"
+    """The format of the saving of metadata.
+
+    v1: Transformations and other KLayout objects are stored as a string. In
+        case of ports they are converted back to KLayout objects on read.
+    v2: All objects can be stored in the nativ KLayout format (klayout>=0.28.13)
+    """
     console: rich.console.Console = Field(default_factory=rich.console.Console)
     max_cellname_length: int = 99
     write_context_info: bool = True
@@ -150,17 +161,44 @@ class Settings(BaseSettings):
     allow_width_mismatch: bool = False
     allow_layer_mismatch: bool = False
     allow_type_mismatch: bool = False
-    check_instances: CHECK_INSTANCES = CHECK_INSTANCES.ERROR
+    check_instances: CHECK_INSTANCES = CHECK_INSTANCES.RAISE
     connect_use_mirror: bool = True
     connect_use_angle: bool = True
     cell_overwrite_existing: bool = False
     cell_layout_cache: bool = False
-    """The format of the saving of metadata.
 
-    v1: Transformations and other KLayout objects are stored as a string. In
-        case of ports they are converted back to KLayout objects on read.
-    v2: All objects can be stored in the nativ KLayout format (klayout>=0.28.13)
-    """
+    @field_validator("cell_overwrite_existing")
+    @classmethod
+    def _validate_overwrite_and_cache(cls, v: bool, info: ValidationInfo) -> bool:
+        if v is True:
+            logger.warning(
+                "'overwrite_existing' has been set to True. This might cause "
+                "unintended behavior when overwriting existing cells and delete any "
+                "existing instances of them."
+            )
+        return v
+
+    @field_validator("cell_layout_cache")
+    @classmethod
+    def _validate_layout_cache(cls, v: bool, info: ValidationInfo) -> bool:
+        if v is True:
+            logger.warning(
+                "'cell_layout_cache' has been set to True. This might cause when "
+                "as any cell names generated automatically are loaded from the layout"
+                " instead of created. This could happen e.g. after reading a gds file"
+                " into the layout."
+            )
+        return v
+
+    @field_validator(
+        "allow_width_mismatch", "allow_layer_mismatch", "allow_type_mismatch"
+    )
+    @classmethod
+    def _debug_info_on_global_setting(cls, v: Any, info: ValidationInfo) -> Any:
+        logger.bind(with_traceback=True).debug(
+            "'{}' set globally to '{}'", info.field_name, v
+        )
+        return v
 
     def __init__(self, **data: Any):
         """Set log filter and run pydantic."""
@@ -168,6 +206,7 @@ class Settings(BaseSettings):
         self.logger.remove()
         self.logger.add(sys.stdout, format=tracing_formatter, filter=self.logfilter)
         self.logger.debug("LogLevel: {}", self.logfilter.level)
+        self.logger.patch(add_traceback)
 
 
 config = Settings()

--- a/src/kfactory/kcell.py
+++ b/src/kfactory/kcell.py
@@ -3118,7 +3118,7 @@ class KCLayout(BaseModel, arbitrary_types_allowed=True, extra="allow"):
                     if overwrite_existing:
                         for c in list(self.layout.cells(cell.name)):
                             if c is not cell._kdb_cell:
-                                self[cell.cell_index()].delete()
+                                self[c.cell_index()].delete()
                     dbu = cell.kcl.layout.dbu
                     if cell._locked:
                         # If the cell is locked, it comes from a cache (most likely)

--- a/src/kfactory/kcell.py
+++ b/src/kfactory/kcell.py
@@ -3104,6 +3104,9 @@ class KCLayout(BaseModel, arbitrary_types_allowed=True, extra="allow"):
                         else:
                             name = get_cell_name(f.__name__, **params)
                         self.future_cell_name = name
+                        config.logger.debug(
+                            "Concstructing or retrieving Cell {}", self.future_cell_name
+                        )
                         if layout_cache:
                             c = self.layout.cell(self.future_cell_name)
                             if c is not None:
@@ -3114,7 +3117,7 @@ class KCLayout(BaseModel, arbitrary_types_allowed=True, extra="allow"):
                         self.future_cell_name = None
                     if overwrite_existing:
                         for c in list(self.layout.cells(cell.name)):
-                            if cell is not cell:
+                            if c is not cell._kdb_cell:
                                 self[cell.cell_index()].delete()
                     dbu = cell.kcl.layout.dbu
                     if cell._locked:

--- a/src/kfactory/kcell.py
+++ b/src/kfactory/kcell.py
@@ -3058,8 +3058,9 @@ class KCLayout(BaseModel, arbitrary_types_allowed=True, extra="allow"):
         ) -> Callable[KCellParams, KCell]:
             sig = inspect.signature(f)
 
-            # previously was a KCellCache, but dict should do for most case
-            _cache: Cache[_HashedTuple, KCell] | dict[_HashedTuple, KCell] = cache or {}
+            _cache: Cache[_HashedTuple, KCell] | dict[_HashedTuple, KCell] = (
+                cache or Cache(maxsize=float("inf"))
+            )
 
             @functools.wraps(f)
             def wrapper_autocell(

--- a/src/kfactory/utils/fill.py
+++ b/src/kfactory/utils/fill.py
@@ -237,7 +237,9 @@ def fill_tiled(
         tp.queue(queue_str)
         c.kcl.start_changes()
         try:
-            config.logger.info("filling {} with {}", c.name, fill_cell.name)
+            config.logger.debug(
+                "Filling {} with {}", c.kcl.future_cell_name or c.name, fill_cell.name
+            )
             config.logger.debug("fill string: '{}'", queue_str)
             tp.execute(f"Fill {c.name}")
             config.logger.info("done with filling {}", c.name)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ import pytest
 import kfactory as kf
 from collections.abc import Callable
 
-kf.config.logfilter.level = kf.conf.LogLevel.ERROR
+# kf.config.logfilter.level = kf.conf.LogLevel.ERROR
 
 
 class LAYER_CLASS(kf.LayerEnum):

--- a/tests/test_cell.py
+++ b/tests/test_cell.py
@@ -159,3 +159,24 @@ def test_size_info(LAYER: kf.LayerEnum) -> None:
     ref = c << kf.cells.straight.straight(width=1, length=10, layer=LAYER.WG)
     assert ref.size_info.ne[0] == 10000
     assert ref.dsize_info.ne[0] == 10
+
+
+def test_overwrite() -> None:
+    kcl = kf.KCLayout("CELL_OVERWRITE")
+
+    @kcl.cell
+    def test_overwrite_cell() -> kf.KCell:
+        c = kcl.kcell()
+        return c
+
+    c1 = test_overwrite_cell()
+
+    @kcl.cell(overwrite_existing=True)  # type: ignore[no-redef]
+    def test_overwrite_cell() -> kf.KCell:
+        c = kcl.kcell()
+        return c
+
+    c2 = test_overwrite_cell()
+
+    assert c2 is not c1
+    assert c1._destroyed()

--- a/tests/test_cell.py
+++ b/tests/test_cell.py
@@ -134,8 +134,13 @@ def test_cell_decorator_error() -> None:
         c = kcl2.kcell("wrong_test")
         return c
 
+    regex = kf.config.logfilter.regex
+    kf.config.logfilter.regex = (
+        r"^An error has been caught in function 'wrapper_autocell'"
+    )
     with pytest.raises(ValueError):
         wrong_cell()
+    kf.config.logfilter.regex = regex
 
 
 def test_info() -> None:

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -62,7 +62,7 @@ def test_route_bend90(
     p2.trans = kf.kdb.Trans(angle2, False, x, y)
     b90r = abs(bend90.ports._ports[0].x - bend90.ports._ports[1].x)
     if abs(x) < b90r or abs(y) < b90r:
-        kf.config.logfilter.regex = f"Potential collision in routing due to small distance between the port in relation to bend radius x={x}/{b90r}, y={y}/{b90r}"
+        kf.config.logfilter.regex = "route is too small, potential collisions:"
     kf.routing.optical.route(
         c,
         p1,
@@ -105,7 +105,7 @@ def test_route_bend90_invert(
     p2.trans = kf.kdb.Trans(angle2, False, x, y)
     b90r = abs(bend90.ports._ports[0].x - bend90.ports._ports[1].x)
     if abs(x) < b90r or abs(y) < b90r:
-        kf.config.logfilter.regex = f"Potential collision in routing due to small distance between the port in relation to bend radius x={x}/{b90r}, y={y}/{b90r}"
+        kf.config.logfilter.regex = "route is too small, potential collisions:"
     kf.routing.optical.route(
         c,
         p1,
@@ -140,7 +140,7 @@ def test_route_bend90_euler(
     p2.trans = kf.kdb.Trans(angle2, False, x, y)
     b90r = abs(bend90_euler.ports._ports[0].x - bend90_euler.ports._ports[1].x)
     if abs(x) < b90r or abs(y) < b90r:
-        kf.config.logfilter.regex = f"Potential collision in routing due to small distance between the port in relation to bend radius x={x}/{b90r}, y={y}/{b90r}"
+        kf.config.logfilter.regex = "route is too small, potential collisions:"
     kf.routing.optical.route(
         c,
         p1,
@@ -213,7 +213,7 @@ def test_route_length(
     p2.trans = kf.kdb.Trans(angle2, False, x, y)
     b90r = abs(bend90_euler.ports._ports[0].x - bend90_euler.ports._ports[1].x)
     if abs(x) < b90r or abs(y) < b90r:
-        kf.config.logfilter.regex = f"Potential collision in routing due to small distance between the port in relation to bend radius x={x}/{b90r}, y={y}/{b90r}"
+        kf.config.logfilter.regex = "route is too small, potential collisions:"
     route = kf.routing.optical.route(
         c,
         p1,


### PR DESCRIPTION
- `KCLayout.cell(overwrite_existing)` will make sure that when we are creating a new cell any pre-existing cell with the same name will be deleted.
  WARNING: This might cause unwanted sideeffects like suddenly deleted references etc if an overwrite was performed, as all those cells will be deleted and therefore any instance of them as well.
- `KCLayout.cell(layout_cache)`  will use the current KCLayout as its cache. This means if a cell is already existant in the layout, this will use that cell instead of creating one.