### PR TITLE
Use tempfile if called from IPython

### DIFF
--- a/src/kfactory/kcell.py
+++ b/src/kfactory/kcell.py
@@ -7597,7 +7597,6 @@ def show(
     _kcl_paths: list[dict[str, str]] = []
 
     if isinstance(layout, KCLayout):
-        # print("\tCase 1: type(layout)==KCLayout")
         file: Path | None = None
         spec = importlib.util.find_spec("git")
         if spec is not None:

--- a/src/kfactory/kcell.py
+++ b/src/kfactory/kcell.py
@@ -7580,8 +7580,7 @@ def show(
         frame = stk[2]
         frame_filename_stem = Path(frame.filename).stem
         if frame_filename_stem.startswith("<ipython-input"):    # IPython Case
-            ipython_shell_id = frame_filename_stem.rstrip(">").split("-")[-1]
-            name = f"ipython-{ipython_shell_id}"
+            name = "ipython"
         else:                                                   # Normal Python kernel case
             if frame.function != "<module>":
                 name = frame_filename_stem + "_" + frame.function
@@ -7662,10 +7661,7 @@ def show(
             else:
                 wtd = repo.working_tree_dir
                 if wtd is not None:
-                    if name.startswith("ipython-"):         # IPython Case: use tempfile
-                        root = Path(tempfile.gettempdir()) / "gdsfactory"
-                    else:                                   # Normal Python Kernel Case: use build directory
-                        root = Path(wtd) / "build/gds"
+                    root = Path(wtd) / "build/gds"
                     root.mkdir(parents=True, exist_ok=True)
                     tf = root / Path(name).with_suffix(".oas")
                     tf.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
This PR is meant to address https://github.com/gdsfactory/gdsfactory/issues/2782. 

It modifies `kcell` to handle the case when it is called from an IPython kernel. Currently an IPython call causes a bug when `inspect` is used to identify the calling python file. This just adds a check to see if the "filename" looks like an IPython call and if so streams to KLayout via a temporary OAS file (in `Path(tempfile.gettempdir()) / "gdsfactory"`) rather than the `build` directory in the calling file's repository. 