### PR TITLE
Add name debugging config

### DIFF
--- a/src/kfactory/conf.py
+++ b/src/kfactory/conf.py
@@ -153,19 +153,25 @@ class Settings(BaseSettings):
         case of ports they are converted back to KLayout objects on read.
     v2: All objects can be stored in the nativ KLayout format (klayout>=0.28.13)
     """
+    # console for printing
     console: rich.console.Console = Field(default_factory=rich.console.Console)
-    max_cellname_length: int = 99
-    write_context_info: bool = True
-    write_cell_properties: bool = True
-    wrtie_file_properties: bool = True
+
+    # cell decorator settings
     allow_width_mismatch: bool = False
     allow_layer_mismatch: bool = False
     allow_type_mismatch: bool = False
-    check_instances: CHECK_INSTANCES = CHECK_INSTANCES.RAISE
-    connect_use_mirror: bool = True
-    connect_use_angle: bool = True
-    cell_overwrite_existing: bool = False
     cell_layout_cache: bool = False
+    cell_overwrite_existing: bool = False
+    connect_use_angle: bool = True
+    connect_use_mirror: bool = True
+    check_instances: CHECK_INSTANCES = CHECK_INSTANCES.RAISE
+    max_cellname_length: int = 99
+    debug_names: bool = False
+
+    # default write settings
+    write_cell_properties: bool = True
+    write_context_info: bool = True
+    write_file_properties: bool = True
 
     @field_validator("logfilter")
     @classmethod

--- a/src/kfactory/kcell.py
+++ b/src/kfactory/kcell.py
@@ -3264,14 +3264,14 @@ class KCLayout(BaseModel, arbitrary_types_allowed=True, extra="allow"):
                         # and should be copied first
                         cell = cell.dup()
                     if set_name:
-                        if debug_names:
-                            if cell.kcl.layout.cell(name) is not None:
-                                logger.opt(depth=4).error(
-                                    "KCell with name {name} exists already.", name=name
-                                )
-                                raise CellNameError(
-                                    f"KCell with name {name} exists already."
-                                )
+                        if debug_names and cell.kcl.layout.cell(name) is not None:
+                            logger.opt(depth=4).error(
+                                "KCell with name {name} exists already.", name=name
+                            )
+                            raise CellNameError(
+                                f"KCell with name {name} exists already."
+                            )
+
                         cell.name = name
                         self.future_cell_name = old_future_name
                     if overwrite_existing:

--- a/src/kfactory/kcell.py
+++ b/src/kfactory/kcell.py
@@ -614,7 +614,9 @@ class PortTypeMismatch(ValueError):
 class FrozenError(AttributeError):
     """Raised if a KCell has been frozen and shouldn't be modified anymore."""
 
-    pass
+
+class CellNameError(ValueError):
+    """Raised if a KCell is created and the automatic assigned name is taken."""
 
 
 def load_layout_options(**attributes: Any) -> kdb.LoadLayoutOptions:
@@ -3108,6 +3110,7 @@ class KCLayout(BaseModel, arbitrary_types_allowed=True, extra="allow"):
         layout_cache: bool | None = None,
         info: dict[str, MetaData] | None = None,
         post_process: Iterable[Callable[[KCell], None]] = [],
+        debug_names: bool | None = None,
     ) -> Callable[[KCellFunc[KCellParams]], KCellFunc[KCellParams]]: ...
 
     def cell(
@@ -3129,6 +3132,7 @@ class KCLayout(BaseModel, arbitrary_types_allowed=True, extra="allow"):
         layout_cache: bool | None = None,
         info: dict[str, MetaData] | None = None,
         post_process: Iterable[Callable[[KCell], None]] = [],
+        debug_names: bool | None = None,
     ) -> (
         KCellFunc[KCellParams]
         | Callable[[KCellFunc[KCellParams]], KCellFunc[KCellParams]]
@@ -3173,6 +3177,8 @@ class KCLayout(BaseModel, arbitrary_types_allowed=True, extra="allow"):
                 `config.cell_overwrite_existing`.
             info: Additional metadata to put into info attribute.
             post_process: List of functions to call after the cell has been created.
+            debug_names: Check on setting the name whether a cell with this name already
+                exists.
         """
         d2fs = rec_dict_to_frozenset
         fs2d = rec_frozenset_to_dict
@@ -3183,6 +3189,8 @@ class KCLayout(BaseModel, arbitrary_types_allowed=True, extra="allow"):
             overwrite_existing = config.cell_overwrite_existing
         if layout_cache is None:
             layout_cache = config.cell_layout_cache
+        if debug_names is None:
+            debug_names = config.debug_names
 
         def decorator_autocell(
             f: Callable[KCellParams, KCell],
@@ -3222,7 +3230,7 @@ class KCLayout(BaseModel, arbitrary_types_allowed=True, extra="allow"):
                     params.pop(param, None)
                     param_units.pop(param, None)
 
-                @logger.catch(reraise=True)
+                @logger.catch(reraise=True, exclude=CellNameError)
                 @cachetools.cached(cache=_cache)
                 @functools.wraps(f)
                 def wrapped_cell(
@@ -3256,6 +3264,14 @@ class KCLayout(BaseModel, arbitrary_types_allowed=True, extra="allow"):
                         # and should be copied first
                         cell = cell.dup()
                     if set_name:
+                        if debug_names:
+                            if cell.kcl.layout.cell(name) is not None:
+                                logger.opt(depth=4).error(
+                                    "KCell with name {name} exists already.", name=name
+                                )
+                                raise CellNameError(
+                                    f"KCell with name {name} exists already."
+                                )
                         cell.name = name
                         self.future_cell_name = old_future_name
                     if overwrite_existing:


### PR DESCRIPTION
```python
import kfactory as kf


@kf.cell
def straight(
    width: int, length: int, layer: int, enclosure: kf.LayerEnclosure | None = None
) -> kf.KCell:
    c = kf.kcl.kcell()
    c.shapes(layer).insert(kf.kdb.Box(length, width))
    return c


c = kf.KCell()
c << straight(length=10_000, width=1000, layer=kf.kcl.layer(1, 0))


c << kf.cells.straight.straight_dbu(length=10_000, width=1000, layer=kf.kcl.layer(1, 0))
c.show()
```

```bash
KFACTORY_DEBUG_NAMES=1 python test.py
```

```
Traceback (most recent call last):
2024-07-15 12:19:16.782 | ERROR    | __main__:<module>:19 - KCell with name straight_W1000_L10000_L0_ENone exists already.
  File "/home/sgoeldi/repos/kfactory/src/kfactory/test.py", line 19, in <module>
    c << kf.cells.straight.straight_dbu(length=10_000, width=1000, layer=kf.kcl.layer(1, 0))
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/sgoeldi/repos/kfactory/src/kfactory/kcell.py", line 3394, in wrapper_autocell
    _cell = wrapped_cell(**params)
            ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/sgoeldi/miniforge3/envs/kf/lib/python3.12/site-packages/loguru/_logger.py", line 1277, in catch_wrapper
    return function(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/sgoeldi/miniforge3/envs/kf/lib/python3.12/site-packages/cachetools/__init__.py", line 737, in wrapper
    v = func(*args, **kwargs)
        ^^^^^^^^^^^^^^^^^^^^^
  File "/home/sgoeldi/repos/kfactory/src/kfactory/kcell.py", line 3272, in wrapped_cell
    raise CellNameError(
kfactory.kcell.CellNameError: KCell with name straight_W1000_L10000_L0_ENone exists already.
```

@joamatab 