### PR TITLE
add packing functions for Instances and KCells

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,38 +18,37 @@ authors = [
     {name = "gdsfactory community", email = "contact@gdsfactory.com"},
 ]
 dependencies = [
-  "klayout >= 0.29.3",
-  "scipy",
-  "ruamel.yaml",
+  "aenum",
   "cachetools >= 5.2.0",
   "gitpython",
+  "loguru",
+  "klayout >= 0.29.3",
   "pydantic >= 2.0.2, < 3",
   "pydantic-settings >= 2.0.1, < 3",
-  "loguru",
-  "tomli",
+  "rectangle-packer",
   "requests",
-  "typer[all]",
-  "aenum",
+  "ruamel.yaml",
+  "scipy",
+  "tomli",
   "toolz",
+  "typer[all]",
 ]
 
 [project.optional-dependencies]
-git = [
-  "gitpython",
-]
+
 dev = [
+  "kfactory[full]",
+  "ruff",
   "mypy",
   "pre-commit",
   "pylsp-mypy",
   "python-lsp-server[all]",
-  "ruff",
   "types-cachetools",
   "pytest",
-  "kfactory[git]",
-  "types-requests",
-  "types-setuptools",
   "types-docutils",
   "types-Pygments",
+  "types-requests",
+  "types-setuptools",
   "tbump",
 ]
 docs = [
@@ -69,7 +68,7 @@ ci = [
   "pytest_regressions",
   "types-cachetools",
   "types-requests",
-  "kfactory[git]",
+  "kfactory[full]",
 ]
 ipy = [
   "ipython",

--- a/src/kfactory/__init__.py
+++ b/src/kfactory/__init__.py
@@ -15,6 +15,7 @@ import klayout.rdb as rdb
 from .kcell import (
     Info,
     Instance,
+    InstanceGroup,
     KCLayout,
     KCell,
     KCellSettings,
@@ -32,7 +33,17 @@ from .kcell import (
     save_layout_options,
     show,
 )
-from . import cells, enclosure, kf_types, placer, port, routing, technology, utils
+from . import (
+    cells,
+    enclosure,
+    kf_types,
+    packing,
+    placer,
+    port,
+    routing,
+    technology,
+    utils,
+)
 from .conf import config, logger
 from .enclosure import LayerEnclosure, KCellEnclosure
 from .grid import flexgrid_dbu, flexgrid, grid_dbu, grid
@@ -43,6 +54,7 @@ from aenum import constant  # type: ignore[import-untyped,unused-ignore]
 __all__ = [
     "Info",
     "Instance",
+    "InstanceGroup",
     "KCLayout",
     "KCell",
     "KCellEnclosure",
@@ -68,6 +80,7 @@ __all__ = [
     "kdb",
     "lay",
     "logger",
+    "packing",
     "placer",
     "polygon_from_array",
     "port",

--- a/src/kfactory/kcell.py
+++ b/src/kfactory/kcell.py
@@ -8165,16 +8165,27 @@ class MergeDiff:
 
 
 class InstanceGroup(BaseModel, arbitrary_types_allowed=True):
+    """Group of Instances.
+
+    The instance group can be treated similar to a single instance
+    with regards to transformation functions and bounding boxes.
+
+    Args:
+        insts: List of the instances of the group.
+    """
+
     insts: list[Instance]
 
     def transform(
         self,
         trans: kdb.Trans | kdb.DTrans | kdb.ICplxTrans | kdb.DCplxTrans,
     ) -> None:
+        """Transform the instance group."""
         for inst in self.insts:
             inst.transform(trans)
 
     def bbox(self, layer: int | None = None) -> kdb.Box:
+        """Get the total bounding box or the bounding box of a layer in dbu."""
         bb = kdb.Box()
         if layer is not None:
             for _bb in (inst.bbox(layer) for inst in self.insts):
@@ -8186,6 +8197,7 @@ class InstanceGroup(BaseModel, arbitrary_types_allowed=True):
         return bb
 
     def dbbox(self, layer: int | None = None) -> kdb.DBox:
+        """Get the total bounding box or the bounding box of a layer in um."""
         bb = kdb.DBox()
         if layer is not None:
             for _bb in (inst.dbbox(layer) for inst in self.insts):
@@ -8221,7 +8233,7 @@ class InstanceGroup(BaseModel, arbitrary_types_allowed=True):
     def movey(self, origin: int, destination: int) -> InstanceGroup: ...
 
     def movey(self, origin: int, destination: int | None = None) -> InstanceGroup:
-        """Move the instance in y-direction in dbu.
+        """Move the instance group in y-direction in dbu.
 
         Args:
             origin: reference point to move [dbu]
@@ -8244,7 +8256,7 @@ class InstanceGroup(BaseModel, arbitrary_types_allowed=True):
     def move(
         self, origin: tuple[int, int], destination: tuple[int, int] | None = None
     ) -> InstanceGroup:
-        """Move the instance in dbu.
+        """Move the instance group in dbu.
 
         Args:
             origin: reference point to move [dbu]
@@ -8261,7 +8273,7 @@ class InstanceGroup(BaseModel, arbitrary_types_allowed=True):
     def rotate(
         self, angle: Literal[0, 1, 2, 3], center: kdb.Point | None = None
     ) -> InstanceGroup:
-        """Rotate instance in increments of 90°."""
+        """Rotate instance group in increments of 90°."""
         if center:
             t = kdb.Trans(center.to_v())
             self.transform(t.inverted())
@@ -8273,7 +8285,7 @@ class InstanceGroup(BaseModel, arbitrary_types_allowed=True):
     def mirror(
         self, p1: kdb.Point = kdb.Point(1, 0), p2: kdb.Point = kdb.Point(0, 0)
     ) -> InstanceGroup:
-        """Mirror the instance at a line."""
+        """Mirror the instance group at a line."""
         mirror_v = p2 - p1
         dedge = kdb.DEdge(self.insts[0].kcl.to_um(p1), self.insts[0].kcl.to_um(p2))
         angle = np.mod(np.rad2deg(np.arctan2(mirror_v.y, mirror_v.x)), 180) * 2
@@ -8290,12 +8302,12 @@ class InstanceGroup(BaseModel, arbitrary_types_allowed=True):
         return self
 
     def mirror_x(self, x: int = 0) -> InstanceGroup:
-        """Mirror the instance at an y-axis at position x."""
+        """Mirror the instance group at an y-axis at position x."""
         self.transform(kdb.Trans(2, True, 2 * x, 0))
         return self
 
     def mirror_y(self, y: int = 0) -> InstanceGroup:
-        """Mirror the instance at an x-axis at position y."""
+        """Mirror the instance group at an x-axis at position y."""
         self.transform(kdb.Trans(0, True, 0, 2 * y))
         return self
 
@@ -8306,7 +8318,7 @@ class InstanceGroup(BaseModel, arbitrary_types_allowed=True):
 
     @xmin.setter
     def xmin(self, __val: int) -> None:
-        """Moves the instance so that the bbox's left x-coordinate."""
+        """Moves the instance group so that the bbox's left x-coordinate."""
         self.transform(kdb.Trans(__val - self.bbox().left, 0))
 
     @property
@@ -8316,7 +8328,7 @@ class InstanceGroup(BaseModel, arbitrary_types_allowed=True):
 
     @ymin.setter
     def ymin(self, __val: int) -> None:
-        """Moves the instance so that the bbox's left x-coordinate."""
+        """Moves the instance group so that the bbox's left x-coordinate."""
         self.transform(kdb.Trans(0, __val - self.bbox().bottom))
 
     @property
@@ -8326,7 +8338,7 @@ class InstanceGroup(BaseModel, arbitrary_types_allowed=True):
 
     @xmax.setter
     def xmax(self, __val: int) -> None:
-        """Moves the instance so that the bbox's left x-coordinate."""
+        """Moves the instance group so that the bbox's left x-coordinate."""
         self.transform(kdb.Trans(__val - self.bbox().right, 0))
 
     @property
@@ -8336,7 +8348,7 @@ class InstanceGroup(BaseModel, arbitrary_types_allowed=True):
 
     @ymax.setter
     def ymax(self, __val: int) -> None:
-        """Moves the instance so that the bbox's left x-coordinate."""
+        """Moves the instance group so that the bbox's left x-coordinate."""
         self.transform(kdb.Trans(0, __val - self.bbox().top))
 
     @property
@@ -8356,7 +8368,7 @@ class InstanceGroup(BaseModel, arbitrary_types_allowed=True):
 
     @x.setter
     def x(self, __val: int) -> None:
-        """Moves the instance so that the bbox's center x-coordinate."""
+        """Moves the instance group so that the bbox's center x-coordinate."""
         self.transform(kdb.Trans(__val - self.bbox().center().x, 0))
 
     @property
@@ -8366,7 +8378,7 @@ class InstanceGroup(BaseModel, arbitrary_types_allowed=True):
 
     @y.setter
     def y(self, __val: int) -> None:
-        """Moves the instance so that the bbox's center x-coordinate."""
+        """Moves the instance group so that the bbox's center x-coordinate."""
         self.transform(kdb.Trans(__val - self.bbox().center().y, 0))
 
     @property
@@ -8376,7 +8388,7 @@ class InstanceGroup(BaseModel, arbitrary_types_allowed=True):
 
     @center.setter
     def center(self, val: tuple[int, int] | kdb.Vector) -> None:
-        """Moves the instance so that the bbox's center coordinate."""
+        """Moves the instance group so that the bbox's center coordinate."""
         if isinstance(val, kdb.Point | kdb.Vector):
             self.transform(kdb.Trans(val - self.bbox().center().to_v()))
         elif isinstance(val, tuple | list):
@@ -8396,7 +8408,7 @@ class InstanceGroup(BaseModel, arbitrary_types_allowed=True):
     def dmovex(self, origin: float, destination: float) -> InstanceGroup: ...
 
     def dmovex(self, origin: float, destination: float | None = None) -> InstanceGroup:
-        """Move the instance in x-direction in um.
+        """Move the instance group in x-direction in um.
 
         Args:
             origin: reference point to move
@@ -8415,7 +8427,7 @@ class InstanceGroup(BaseModel, arbitrary_types_allowed=True):
     def dmovey(self, origin: float, destination: float) -> InstanceGroup: ...
 
     def dmovey(self, origin: float, destination: float | None = None) -> InstanceGroup:
-        """Move the instance in y-direction in um.
+        """Move the instance group in y-direction in um.
 
         Args:
             origin: reference point to move
@@ -8432,7 +8444,7 @@ class InstanceGroup(BaseModel, arbitrary_types_allowed=True):
         angle: float,
         center: kdb.DPoint | kdb.DVector | tuple[float, float] | Port | None = None,
     ) -> InstanceGroup:
-        """Rotate instance in degrees.
+        """Rotate instance group in degrees.
 
         Args:
             angle: angle in degrees.
@@ -8468,7 +8480,7 @@ class InstanceGroup(BaseModel, arbitrary_types_allowed=True):
         origin: tuple[float, float],
         destination: tuple[float, float] | None = None,
     ) -> InstanceGroup:
-        """Move the instance in dbu.
+        """Move the instance group in dbu.
 
         Args:
             origin: reference point to move [dbu]
@@ -8487,7 +8499,7 @@ class InstanceGroup(BaseModel, arbitrary_types_allowed=True):
     def dmirror(
         self, p1: kdb.DPoint = kdb.DPoint(0, 1), p2: kdb.DPoint = kdb.DPoint(0, 0)
     ) -> InstanceGroup:
-        """Mirror the instance at a line."""
+        """Mirror the instance group at a line."""
         mirror_v = p2 - p1
         dedge = kdb.DEdge(p1, p2)
         angle = np.mod(np.rad2deg(np.arctan2(mirror_v.y, mirror_v.x)), 180) * 2
@@ -8504,12 +8516,12 @@ class InstanceGroup(BaseModel, arbitrary_types_allowed=True):
         return self
 
     def dmirror_x(self, x: float = 0) -> InstanceGroup:
-        """Mirror the instance at an x-axis."""
+        """Mirror the instance group at an x-axis."""
         self.transform(kdb.DTrans(2, True, 2 * x, 0))
         return self
 
     def dmirror_y(self, y: float = 0) -> InstanceGroup:
-        """Mirror the instance at an y-axis."""
+        """Mirror the instance group at an y-axis."""
         self.transform(kdb.DTrans(0, True, 0, 2 * y))
         return self
 
@@ -8520,7 +8532,7 @@ class InstanceGroup(BaseModel, arbitrary_types_allowed=True):
 
     @dxmin.setter
     def dxmin(self, __val: float) -> None:
-        """Moves the instance so that the bbox's left x-coordinate."""
+        """Moves the instance group so that the bbox's left x-coordinate."""
         self.transform(kdb.DTrans(__val - self.dbbox().left, 0.0))
 
     @property
@@ -8530,7 +8542,7 @@ class InstanceGroup(BaseModel, arbitrary_types_allowed=True):
 
     @dymin.setter
     def dymin(self, __val: float) -> None:
-        """Moves the instance so that the bbox's left x-coordinate."""
+        """Moves the instance group so that the bbox's left x-coordinate."""
         self.transform(kdb.DTrans(0.0, __val - self.dbbox().bottom))
 
     @property
@@ -8540,7 +8552,7 @@ class InstanceGroup(BaseModel, arbitrary_types_allowed=True):
 
     @dxmax.setter
     def dxmax(self, __val: float) -> None:
-        """Moves the instance so that the bbox's left x-coordinate."""
+        """Moves the instance group so that the bbox's left x-coordinate."""
         self.transform(kdb.DTrans(__val - self.dbbox().right, 0.0))
 
     @property
@@ -8560,7 +8572,7 @@ class InstanceGroup(BaseModel, arbitrary_types_allowed=True):
 
     @dymax.setter
     def dymax(self, __val: float) -> None:
-        """Moves the instance so that the bbox's left x-coordinate."""
+        """Moves the instance group so that the bbox's left x-coordinate."""
         self.transform(kdb.DTrans(0.0, __val - self.dbbox().top))
 
     @property
@@ -8570,7 +8582,7 @@ class InstanceGroup(BaseModel, arbitrary_types_allowed=True):
 
     @dx.setter
     def dx(self, __val: float) -> None:
-        """Moves the instance so that the bbox's center x-coordinate."""
+        """Moves the instance group so that the bbox's center x-coordinate."""
         self.transform(kdb.DTrans(__val - self.dbbox().center().x, 0.0))
 
     @property
@@ -8580,7 +8592,7 @@ class InstanceGroup(BaseModel, arbitrary_types_allowed=True):
 
     @dy.setter
     def dy(self, __val: float) -> None:
-        """Moves the instance so that the bbox's center x-coordinate."""
+        """Moves the instance group so that the bbox's center x-coordinate."""
         self.transform(kdb.DTrans(0.0, __val - self.dbbox().center().y))
 
     @property
@@ -8590,7 +8602,7 @@ class InstanceGroup(BaseModel, arbitrary_types_allowed=True):
 
     @dcenter.setter
     def dcenter(self, val: tuple[float, float] | kdb.DPoint) -> None:
-        """Moves the instance so that the bbox's center coordinate."""
+        """Moves the instance group so that the bbox's center coordinate."""
         if isinstance(val, kdb.DPoint | kdb.DVector):
             self.transform(kdb.DTrans(val - self.dbbox().center()))
         elif isinstance(val, tuple | list):
@@ -8607,6 +8619,7 @@ class InstanceGroup(BaseModel, arbitrary_types_allowed=True):
 __all__ = [
     "KCell",
     "Instance",
+    "InstanceGroup",
     "Port",
     "Ports",
     "cell",

--- a/src/kfactory/packing.py
+++ b/src/kfactory/packing.py
@@ -1,0 +1,79 @@
+"""Utilities for packing KCells and Instances."""
+
+from collections.abc import Sequence
+
+import rpack  # type: ignore[import-untyped,unused-ignore]
+
+from . import kdb
+from .kcell import Instance, InstanceGroup, KCell
+
+
+def pack_kcells(
+    target: KCell,
+    kcells: Sequence[KCell],
+    max_width: int | None = None,
+    max_height: int | None = None,
+    spacing: int = 0,
+) -> InstanceGroup:
+    """Pack KCells.
+
+    Args:
+        target: KCell to place the packed instances in.
+        kcells: Sequence of KCells from which to create instances.
+        max_width: Maximum width of the packed rectangle
+        max_height: Maximum height of the packed rectangle
+        spacing: Spacing between the instance bboxes
+    """
+    insts = [target << kc for kc in kcells]
+    bbs = [(inst, inst.bbox()) for inst in insts]
+
+    packed_bbs = rpack.pack(
+        ((bb[1].width() + spacing, bb[1].height() + spacing) for bb in bbs),
+        max_width=max_width,
+        max_height=max_height,
+    )
+
+    for inst_bb, bb in zip(bbs, packed_bbs):
+        inst, _bb = inst_bb
+        inst.transform(
+            kdb.Trans(
+                bb[0] + spacing // 2 - _bb.left, bb[1] + spacing // 2 - _bb.bottom
+            )
+        )
+
+    return InstanceGroup(insts=insts)
+
+
+def pack_instances(
+    target: KCell,
+    instances: Sequence[Instance],
+    max_width: int | None = None,
+    max_height: int | None = None,
+    spacing: int = 0,
+) -> InstanceGroup:
+    """Pack KCells.
+
+    Args:
+        target: KCell to place the packed instances in.
+        instances: Sequence of Instances to pack.
+        max_width: Maximum width of the packed rectangle
+        max_height: Maximum height of the packed rectangle
+        spacing: Spacing between the instance bboxes
+    """
+    bbs = [(inst, inst.bbox()) for inst in instances]
+
+    packed_bbs = rpack.pack(
+        ((bb[1].width() + spacing, bb[1].height() + spacing) for bb in bbs),
+        max_width=max_width,
+        max_height=max_height,
+    )
+
+    for inst_bb, bb in zip(bbs, packed_bbs):
+        inst, _bb = inst_bb
+        inst.transform(
+            kdb.Trans(
+                bb[0] + spacing // 2 - _bb.left, bb[1] + spacing // 2 - _bb.bottom
+            )
+        )
+
+    return InstanceGroup(insts=instances)


### PR DESCRIPTION
<details>

<summary>example.py</summary>

```python
import kfactory as kf
from kfactory.packing import pack_instances, pack_kcells


@kf.cell
def box(width: int, height: int) -> kf.KCell:
    c = kf.KCell()
    c.shapes(c.kcl.layer(1, 0)).insert(kf.kdb.Box(width, height))
    return c


c = kf.KCell("Box Packing")

ig1 = pack_kcells(
    c,
    [box(w, h) for w, h in [(500, 500) for _ in range(15)] + [(15_000, 1000)]],
    max_width=16000,
    spacing=1000,
)

small_boxes = [c << box(w, h) for w, h in ((500, 500) for _ in range(15))]
bigbox = c << box(15_000, 1000)
bigbox.transform(kf.kdb.Trans.R90)
ig2 = pack_instances(
    c,
    small_boxes + [bigbox],
    max_width=16000,
    spacing=1000,
)

ig2.movex(ig1.xmax + 5000 - ig2.xmin)
c.show()
```

</details>

gives:

![image](https://github.com/user-attachments/assets/e5197eb7-6461-47a6-aa7f-8849e0725af8)


Also clean up some of the instance group code.


@joamatab @akshat-ja @gdspaul 