### PR TITLE
fix add_ports in case port.kcl is not ports.kcl

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
         exclude: 'changelog\.d/.*|CHANGELOG\.md'
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.5.1
+    rev: v0.5.4
     hooks:
       # Run the linter.
       - id: ruff
@@ -48,7 +48,7 @@ repos:
         # ignore all tests, not just tests data
         exclude: ^tests/
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v1.10.1'  # Use the sha / tag you want to point at
+    rev: 'v1.11.0'  # Use the sha / tag you want to point at
     hooks:
       - id: mypy
         require_serial: true

--- a/src/kfactory/kcell.py
+++ b/src/kfactory/kcell.py
@@ -5441,7 +5441,6 @@ class Port:
     _dcplx_trans: kdb.DCplxTrans | None
     info: Info = Info()
     port_type: str
-    layer_info: kdb.LayerInfo
 
     @overload
     def __init__(

--- a/src/kfactory/kcell.py
+++ b/src/kfactory/kcell.py
@@ -3081,8 +3081,8 @@ class KCLayout(BaseModel, arbitrary_types_allowed=True, extra="allow"):
         """Convert Shapes or values in dbu to DShapes or floats in um."""
         return kdb.CplxTrans(self.layout.dbu).inverted() * other
 
+    @computed_field  # type: ignore[prop-decorator]
     @property
-    @computed_field
     def name(self) -> str:
         """Name of the KCLayout."""
         return self._name

--- a/src/kfactory/kcell.py
+++ b/src/kfactory/kcell.py
@@ -390,7 +390,7 @@ class LayerEnum(int, Enum):  # type: ignore[misc]
 def convert_metadata_type(value: Any) -> MetaData:
     """Recursively clean up a MetaData for KCellSettings."""
     if isinstance(value, int | float | bool | str | SerializableShape):
-        return value  # type: ignore[no-any-return]
+        return value
     elif value is None:
         return None
     elif isinstance(value, tuple):
@@ -3081,8 +3081,8 @@ class KCLayout(BaseModel, arbitrary_types_allowed=True, extra="allow"):
         """Convert Shapes or values in dbu to DShapes or floats in um."""
         return kdb.CplxTrans(self.layout.dbu).inverted() * other
 
-    @computed_field  # type: ignore[misc]
     @property
+    @computed_field
     def name(self) -> str:
         """Name of the KCLayout."""
         return self._name
@@ -5369,18 +5369,18 @@ class VShapes(BaseModel, arbitrary_types_allowed=True):
         new_shapes: list[DShapeLike] = []
 
         for shape in self._shapes:
-            if isinstance(shape, DShapeLike):  # type: ignore[misc, arg-type]
-                new_shapes.append(shape.transformed(trans))  # type: ignore[union-attr, call-overload]
-            elif isinstance(shape, IShapeLike):  # type: ignore[misc, arg-type]
-                new_shapes.append(
-                    shape.to_dtype(  # type: ignore[union-attr]
-                        self.cell.kcl.dbu
-                    ).transformed(trans)
-                )
+            if isinstance(shape, DShapeLike):
+                new_shapes.append(shape.transformed(trans))
+            elif isinstance(shape, IShapeLike):
+                if isinstance(shape, kdb.Region):
+                    for poly in shape.each():
+                        new_shapes.append(poly.to_dtype(self.cell.kcl.dbu))
+                else:
+                    new_shapes.append(
+                        shape.to_dtype(self.cell.kcl.dbu).transformed(trans)
+                    )
             else:
-                new_shapes.append(
-                    shape.transform(trans)  # type: ignore[union-attr, call-overload, arg-type]
-                )
+                new_shapes.append(shape.dpolygon.transform(trans))
 
         return VShapes(cell=self.cell, _shapes=new_shapes)  # type: ignore[arg-type]
 

--- a/src/kfactory/kcell.py
+++ b/src/kfactory/kcell.py
@@ -6897,15 +6897,29 @@ class Ports:
                 else set [Port.trans.mirror][kfactory.kcell.Port.trans] (or the complex
                 equivalent) to `False`.
         """
-        _port = port.copy()
-        if not keep_mirror:
-            if _port._trans:
-                _port._trans.mirror = False
-            elif _port._dcplx_trans:
-                _port._dcplx_trans.mirror = False
-        if name is not None:
-            _port.name = name
-        self._ports.append(_port)
+        if port.kcl == self.kcl:
+            _port = port.copy()
+            if not keep_mirror:
+                if _port._trans:
+                    _port._trans.mirror = False
+                elif _port._dcplx_trans:
+                    _port._dcplx_trans.mirror = False
+            if name is not None:
+                _port.name = name
+            self._ports.append(_port)
+        else:
+            dcplx_trans = port.dcplx_trans.dup()
+            if not keep_mirror:
+                dcplx_trans.mirror = False
+            _port = Port(
+                kcl=self.kcl,
+                name=name or port.name,
+                dcplx_trans=port.dcplx_trans,
+                info=_port.info.model_dump(),
+                dwidth=port.dwidth,
+                layer=port.layer,
+            )
+            self._ports.append(_port)
         return _port
 
     def add_ports(


### PR DESCRIPTION
Fixes `add_port(s)` if `port.kcl` is not the same as `c.ports.kcl`
Adds so that the following works

```python

class LAYER(kf.LayerEnum):
    WG = (1,0)

c.kcl.layer(LAYER.WG) # prints `0`
c.kcl.layer(LAYER.WG.name) # now also prints `0`
```