### PR TITLE
Adjust AttributeError text in optical routing for taper and bend

### DIFF
--- a/src/kfactory/routing/optical.py
+++ b/src/kfactory/routing/optical.py
@@ -857,7 +857,7 @@ def place90(
             taperp1, taperp2 = taper_ports
         else:
             raise AttributeError(
-                "At least one optical ports of the taper must be the same width as"
+                "At least one of the taper's optical ports must be the same width as"
                 " the bend's ports"
             )
         route = OpticalManhattanRoute(


### PR DESCRIPTION
The phrasing on this error seemed a bit odd to me. Does the change here seem clearer?
