### PR TITLE
bump klayout to 0.29.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
   "cachetools >= 5.2.0",
   "gitpython",
   "loguru",
-  "klayout >= 0.29.6",
+  "klayout >= 0.29.7",
   "pydantic >= 2.0.2, < 3",
   "pydantic-settings >= 2.0.1, < 3",
   "rectangle-packer",


### PR DESCRIPTION
This allows the usage of:

```python
c.shapes(c.kcl.infos.WG).insert(...)
```

Or in the more general form

```python
c.shapes(kf.kdb.LayerInfo(1,0) # or any other variation such as `kf.kdb.LayerInfo("WG")` as long as it can be mapped to a proper layer
```

Also fixes the long write time for big polygons as described in https://github.com/gdsfactory/gdsfactory/issues/3088