### PR TITLE
fix AREF __getitem__ for instance ports and generic route_bundle

### DIFF
--- a/src/kfactory/kcell.py
+++ b/src/kfactory/kcell.py
@@ -1285,13 +1285,13 @@ class InstancePorts:
             p = self.cell_ports[key]
             if not self.instance.is_complex():
                 return p.copy(
-                    self.instance.trans
-                    * kdb.Trans(self.instance.a * i_a + self.instance.b * i_b)
+                    kdb.Trans(self.instance.a * i_a + self.instance.b * i_b)
+                    * self.instance.trans
                 )
             else:
                 return p.copy(
-                    self.instance.dcplx_trans
-                    * kdb.DCplxTrans(self.instance.da * i_a + self.instance.db * i_b)
+                    kdb.DCplxTrans(self.instance.da * i_a + self.instance.db * i_b)
+                    * self.instance.dcplx_trans
                 )
 
     @property

--- a/src/kfactory/routing/generic.py
+++ b/src/kfactory/routing/generic.py
@@ -373,16 +373,6 @@ def route_bundle(
     for router in routers:
         sp = start_mapping[router.start_transformation]
         ep = end_mapping[router.end_transformation]
-        routes.append(
-            placer_function(
-                c,
-                sp,
-                ep,
-                router.start.pts,
-                route_width=router.width,
-                **placer_kwargs,
-            )
-        )
         start_ports.append(sp)
         end_ports.append(ep)
 


### PR DESCRIPTION
- single port retrieval in AREF applied wrong transformation order
- generic route_bundle used placer twice