### PR TITLE
fix: MetaData type alias and __all__ exports

### DIFF
--- a/src/kfactory/kcell.py
+++ b/src/kfactory/kcell.py
@@ -92,6 +92,7 @@ __all__ = [
     "save_layout_options",
     "LayerEnum",
     "KCellParams",
+    "MetaData",
 ]
 
 
@@ -153,8 +154,15 @@ DShapeLike: TypeAlias = (
 ShapeLike: TypeAlias = IShapeLike | DShapeLike | kdb.Shape
 
 MetaData: TypeAlias = (
-    "int | float | bool | str | SerializableShape | None |"
-    " list[MetaData] | tuple[MetaData, ...] | dict[str, MetaData]"
+    int
+    | float
+    | bool
+    | str
+    | SerializableShape
+    | None
+    | list["MetaData"]
+    | tuple["MetaData", ...]
+    | dict[str, "MetaData"]
 )
 
 


### PR DESCRIPTION
Fixes #515

## Summary by Sourcery

Fix the MetaData type alias to support recursive types and include MetaData in the module's __all__ exports.

Bug Fixes:
- Correct the MetaData type alias to properly handle recursive types.

Enhancements:
- Add MetaData to the __all__ exports in kcell.py.