### PR TITLE
Update metadata alias

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
         exclude: 'changelog\.d/.*|CHANGELOG\.md'
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.6.9
+    rev: v0.7.4
     hooks:
       # Run the linter.
       - id: ruff
@@ -30,7 +30,7 @@ repos:
       - id: ruff-format
         exclude: ^tests/
   - repo: https://github.com/kynan/nbstripout
-    rev: 0.7.1
+    rev: 0.8.0
     hooks:
       - id: nbstripout
         files: .ipynb
@@ -49,7 +49,7 @@ repos:
         # ignore all tests, not just tests data
         exclude: ^tests/
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v1.11.2'  # Use the sha / tag you want to point at
+    rev: 'v1.13.0'  # Use the sha / tag you want to point at
     hooks:
       - id: mypy
         require_serial: true

--- a/src/kfactory/kcell.py
+++ b/src/kfactory/kcell.py
@@ -153,8 +153,15 @@ DShapeLike: TypeAlias = (
 ShapeLike: TypeAlias = IShapeLike | DShapeLike | kdb.Shape
 
 MetaData: TypeAlias = (
-    "int | float | bool | str | SerializableShape | None |"
-    " list[MetaData] | tuple[MetaData, ...] | dict[str, MetaData]"
+    int
+    | float
+    | bool
+    | str
+    | SerializableShape
+    | None
+    | list["MetaData"]
+    | tuple["MetaData", ...]
+    | dict[str, "MetaData"]
 )
 
 
@@ -921,7 +928,6 @@ class Ports:
             if not keep_mirror:
                 dcplx_trans.mirror = False
             _li = self.kcl.get_info(port.layer)
-            _l = self.kcl.layer(_li)
             if _li is not None and _li.name is not None:
                 _port = Port(
                     kcl=self.kcl,


### PR DESCRIPTION
## Summary by Sourcery

Refactor the MetaData TypeAlias for improved readability and update pre-commit hooks to newer versions for enhanced code quality checks.

Enhancements:
- Refactor the MetaData TypeAlias to improve readability by using a more structured format.

CI:
- Update pre-commit hooks to use newer versions of ruff, nbstripout, and mypy.