### PR TITLE
at least partially fix the fill_tiled error

### DIFF
--- a/src/kfactory/utils/fill.py
+++ b/src/kfactory/utils/fill.py
@@ -118,7 +118,10 @@ def fill_tiled(
     if n_threads is None:
         n_threads = config.n_threads
     tp = kdb.TilingProcessor()
-    tp.frame = c.bbox().to_dtype(c.kcl.dbu)  # type: ignore
+    dbb = c.dbbox()
+    for r, ext in fill_regions:
+        dbb += r.bbox().to_dtype(c.kcl.dbu).enlarged(ext)
+    tp.frame = dbb  # type: ignore
     tp.dbu = c.kcl.dbu
     tp.threads = n_threads
 
@@ -186,29 +189,25 @@ def fill_tiled(
     if layer_names or region_names:
         exlayers = " + ".join(
             [
-                layer_name + f".sized({int(size / c.kcl.dbu)})" if size else layer_name
+                layer_name + f".sized({c.kcl.to_dbu(size)})" if size else layer_name
                 for layer_name, (_, size) in zip(exlayer_names, exclude_layers)
             ]
         )
         exregions = " + ".join(
             [
-                region_name + f".sized({int(size / c.kcl.dbu)})"
-                if size
-                else region_name
+                region_name + f".sized({c.kcl.to_dbu(size)})" if size else region_name
                 for region_name, (_, size) in zip(exregion_names, exclude_regions)
             ]
         )
         layers = " + ".join(
             [
-                layer_name + f".sized({int(size / c.kcl.dbu)})" if size else layer_name
+                layer_name + f".sized({c.kcl.to_dbu(size)})" if size else layer_name
                 for layer_name, (_, size) in zip(layer_names, fill_layers)
             ]
         )
         regions = " + ".join(
             [
-                region_name + f".sized({int(size / c.kcl.dbu)})"
-                if size
-                else region_name
+                region_name + f".sized({c.kcl.to_dbu(size)})" if size else region_name
                 for region_name, (_, size) in zip(region_names, fill_regions)
             ]
         )


### PR DESCRIPTION
test case:

```python
import kfactory as kf
from kfactory.utils.fill import fill_tiled

import gdsfactory as gf

c = kf.KCell("ToFill")
ellipse = kf.kdb.DPolygon.ellipse(kf.kdb.DBox(5000, 3000), 512)
triangle = kf.kdb.DPolygon(
    [kf.kdb.DPoint(0, 0), kf.kdb.DPoint(5000, 0), kf.kdb.DPoint(5000, 3000)]
)
# c.shapes(kf.kcl.layer(1, 0)).insert(ellipse)
# c.shapes(kf.kcl.layer(10, 0)).insert(triangle)

fc = kf.KCell()
fc.shapes(fc.kcl.layer(2, 0)).insert(kf.kdb.DBox(20, 40))
fc.shapes(fc.kcl.layer(3, 0)).insert(kf.kdb.DBox(30, 15))

r1 = gf.kdb.Region(triangle.to_itype(gf.kcl.dbu))

fill_tiled(
    c,
    fc,
    fill_regions=[(r1, 0)],
    x_space=5,
    y_space=5,
)

c.show()
```

The problem is that the algorithm uses `_frame` to restrict the filling area. But if filling area is outside of the bounding box, this will cause that area to be ignored of course