### PR TITLE
basic klayout pcell implementation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
         exclude: 'changelog\.d/.*|CHANGELOG\.md'
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.6.9
+    rev: v0.8.1
     hooks:
       # Run the linter.
       - id: ruff
@@ -30,7 +30,7 @@ repos:
       - id: ruff-format
         exclude: ^tests/
   - repo: https://github.com/kynan/nbstripout
-    rev: 0.7.1
+    rev: 0.8.1
     hooks:
       - id: nbstripout
         files: .ipynb
@@ -42,14 +42,14 @@ repos:
         additional_dependencies:
           - tomli
   - repo: https://github.com/PyCQA/bandit
-    rev: 1.7.10
+    rev: 1.8.0
     hooks:
       - id: bandit
         args: [--exit-zero]
         # ignore all tests, not just tests data
         exclude: ^tests/
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v1.11.2'  # Use the sha / tag you want to point at
+    rev: 'v1.13.0'  # Use the sha / tag you want to point at
     hooks:
       - id: mypy
         require_serial: true


### PR DESCRIPTION
## Summary by Sourcery

Implement a basic PCell decorator in the kcell module to enhance cell management with caching and auto-naming capabilities. Update pre-commit configuration to use the latest versions of several tools, improving code quality checks and consistency.

New Features:
- Introduce a new decorator function 'pcell' in the kcell module to cache and auto-name cells, with various configuration options for cell management.

Build:
- Update pre-commit hooks to use newer versions of ruff, nbstripout, bandit, and mypy.