### PR TITLE
fix writer using gdsii always

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
         exclude: 'changelog\.d/.*|CHANGELOG\.md'
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.6.9
+    rev: v0.8.2
     hooks:
       # Run the linter.
       - id: ruff
@@ -30,7 +30,7 @@ repos:
       - id: ruff-format
         exclude: ^tests/
   - repo: https://github.com/kynan/nbstripout
-    rev: 0.7.1
+    rev: 0.8.1
     hooks:
       - id: nbstripout
         files: .ipynb
@@ -42,14 +42,14 @@ repos:
         additional_dependencies:
           - tomli
   - repo: https://github.com/PyCQA/bandit
-    rev: 1.7.10
+    rev: 1.8.0
     hooks:
       - id: bandit
         args: [--exit-zero]
         # ignore all tests, not just tests data
         exclude: ^tests/
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v1.11.2'  # Use the sha / tag you want to point at
+    rev: 'v1.13.0'  # Use the sha / tag you want to point at
     hooks:
       - id: mypy
         require_serial: true

--- a/src/kfactory/factories/bezier.py
+++ b/src/kfactory/factories/bezier.py
@@ -42,7 +42,7 @@ class BezierKCell(Protocol):
 
 
 def bezier_curve(
-    t: nty.NDArray[np.float64],
+    t: nty.NDArray[np.floating[Any]],
     control_points: Sequence[tuple[np.float64 | float, np.float64 | float]],
 ) -> list[kdb.DPoint]:
     """Calculates the backbone of a bezier bend."""

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -139,7 +139,7 @@ def test_metainfo_read_cell(straight: kf.KCell) -> None:
 
 def test_nometainfo_read(straight: kf.KCell) -> None:
     """Test whether we can turn of metadata writing."""
-    with NamedTemporaryFile("a") as t:
+    with NamedTemporaryFile("a", suffix=".oas") as t:
         # save = kf.save_layout_options()
         # save.write_context_info = True
         straight.kcl.write(t.name, kf.save_layout_options(write_context_info=False))
@@ -173,7 +173,7 @@ def test_info_dump() -> None:
     assert c.info == c.info.model_copy()
     assert c.settings == c.settings.model_copy()
 
-    with NamedTemporaryFile("a") as t:
+    with NamedTemporaryFile("a", suffix=".oas") as t:
         # save = kf.save_layout_options()
         # save.write_context_info = True
         c.kcl.write(t.name)


### PR DESCRIPTION
## Summary by Sourcery

Fix the writer to automatically determine the file format from the file extension, defaulting to GDSII if unspecified, and update tests to reflect this change.

Bug Fixes:
- Fix the writer to automatically set the file format based on the file extension, defaulting to GDSII if not specified.

Tests:
- Update tests to include file suffixes, ensuring correct file format handling during metadata writing.