### PR TITLE
Fix ports setter for VKCell

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
         exclude: 'changelog\.d/.*|CHANGELOG\.md'
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.8.2
+    rev: v0.8.3
     hooks:
       # Run the linter.
       - id: ruff

--- a/src/kfactory/kcell.py
+++ b/src/kfactory/kcell.py
@@ -5570,7 +5570,7 @@ class VKCell(BaseModel, arbitrary_types_allowed=True):
 
     @ports.setter
     def ports(self, new_ports: InstancePorts | Ports) -> None:
-        if not self._locked:
+        if self._locked:
             raise LockedError(self)
         self._ports = new_ports.copy()
 


### PR DESCRIPTION
## Summary by Sourcery

Fix the ports setter logic in VKCell to ensure it raises a LockedError when the cell is locked and update the pre-commit configuration to use Ruff version 0.8.3.

Bug Fixes:
- Correct the logic in the ports setter for VKCell to raise a LockedError when the cell is locked.

Build:
- Update the pre-commit configuration to use Ruff version 0.8.3.