### PR TITLE
better LockedError message

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
         exclude: 'changelog\.d/.*|CHANGELOG\.md'
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.8.3
+    rev: v0.8.4
     hooks:
       # Run the linter.
       - id: ruff
@@ -49,7 +49,7 @@ repos:
         # ignore all tests, not just tests data
         exclude: ^tests/
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v1.13.0'  # Use the sha / tag you want to point at
+    rev: 'v1.14.0'  # Use the sha / tag you want to point at
     hooks:
       - id: mypy
         require_serial: true

--- a/src/kfactory/kcell.py
+++ b/src/kfactory/kcell.py
@@ -597,9 +597,10 @@ class LockedError(AttributeError):
     def __init__(self, kcell: KCell | VKCell):
         """Throw _locked error."""
         super().__init__(
-            f"{kcell.name!r} is locked and stored in cache. Modifications are disabled "
-            "as its associated function is decorated with `cell`. To modify, update"
-            "the code in the function or create a copy of the component."
+            f"{kcell.name!r} is locked and likely stored in cache. Modifications are "
+            "disabled as its associated function is decorated with `cell`. To modify, "
+            "update the code in the function or create a copy of "
+            f"the {kcell.__class__.__name__}."
         )
 
 
@@ -749,8 +750,8 @@ class PortCheck(IntFlag):
     width = auto()
     layer = auto()
     port_type = auto()
-    all_opposite = opposite + width + port_type + layer
-    all_overlap = width + port_type + layer
+    all_opposite = opposite + width + port_type + layer  # type: ignore[operator]
+    all_overlap = width + port_type + layer  # type: ignore[operator]
 
 
 def port_check(p1: Port, p2: Port, checks: PortCheck = PortCheck.all_opposite) -> None:

--- a/src/kfactory/kcell.py
+++ b/src/kfactory/kcell.py
@@ -597,9 +597,9 @@ class LockedError(AttributeError):
     def __init__(self, kcell: KCell | VKCell):
         """Throw _locked error."""
         super().__init__(
-            f"KCell {kcell.name} has been locked already."
-            " Modification has been disabled. "
-            "Modify the KCell in its autocell function or make a copy."
+            f"{kcell.name!r} is locked and stored in cache. Modifications are disabled "
+            "as its associated function is decorated with `cell`. To modify, update"
+            "the code in the function or create a copy of the component."
         )
 
 


### PR DESCRIPTION
Make it so that we can also use it in gdsfactory

## Summary by Sourcery

Bug Fixes:
- Clarify the error message when modifying a locked `KCell` to explain how to resolve the issue.