### PR TITLE
Easier mirror

### DIFF
--- a/src/kfactory/kcell.py
+++ b/src/kfactory/kcell.py
@@ -7834,9 +7834,11 @@ class Instance:
         )
 
     def mirror(
-        self, p1: kdb.Point = kdb.Point(1, 0), p2: kdb.Point = kdb.Point(0, 0)
+        self, p1: tuple[int, int] = (0, 1), p2: tuple[int, int] = (0, 0)
     ) -> Instance:
         """Mirror the instance at a line."""
+        p1 = kdb.DPoint(p1[0], p1[1])
+        p2 = kdb.DPoint(p2[0], p2[1])
         mirror_v = p2 - p1
         disp = self.dcplx_trans.disp
         angle = np.mod(np.rad2deg(np.arctan2(mirror_v.y, mirror_v.x)), 180) * 2
@@ -8057,9 +8059,12 @@ class Instance:
         return self
 
     def dmirror(
-        self, p1: kdb.DPoint = kdb.DPoint(0, 1), p2: kdb.DPoint = kdb.DPoint(0, 0)
+        self, p1: tuple[float, float] = (0, 1), p2: tuple[float, float] = (0, 0)
     ) -> Instance:
         """Mirror the instance at a line."""
+        p1 = kdb.DPoint(p1[0], p1[1])
+        p2 = kdb.DPoint(p2[0], p2[1])
+
         mirror_v = p2 - p1
         disp = self.dcplx_trans.disp
         angle = np.mod(np.rad2deg(np.arctan2(mirror_v.y, mirror_v.x)), 180) * 2

--- a/src/kfactory/kcell.py
+++ b/src/kfactory/kcell.py
@@ -7760,12 +7760,12 @@ class Instance:
         self, p1: tuple[int, int] = (0, 1), p2: tuple[int, int] = (0, 0)
     ) -> Instance:
         """Mirror the instance at a line."""
-        p1 = kdb.DPoint(p1[0], p1[1])
-        p2 = kdb.DPoint(p2[0], p2[1])
-        mirror_v = p2 - p1
+        _p1 = kdb.Point(p1[0], p1[1])
+        _p2 = kdb.Point(p2[0], p2[1])
+        mirror_v = _p2 - _p1
         disp = self.dcplx_trans.disp
         angle = np.mod(np.rad2deg(np.arctan2(mirror_v.y, mirror_v.x)), 180) * 2
-        dedge = kdb.DEdge(self.kcl.to_um(p1), self.kcl.to_um(p2))
+        dedge = kdb.DEdge(self.kcl.to_um(_p1), self.kcl.to_um(_p2))
 
         v = self.kcl.to_um(mirror_v)
         v = kdb.DVector(-v.y, v.x)
@@ -7985,13 +7985,13 @@ class Instance:
         self, p1: tuple[float, float] = (0, 1), p2: tuple[float, float] = (0, 0)
     ) -> Instance:
         """Mirror the instance at a line."""
-        p1 = kdb.DPoint(p1[0], p1[1])
-        p2 = kdb.DPoint(p2[0], p2[1])
+        _p1 = kdb.DPoint(p1[0], p1[1])
+        _p2 = kdb.DPoint(p2[0], p2[1])
 
-        mirror_v = p2 - p1
+        mirror_v = _p2 - _p1
         disp = self.dcplx_trans.disp
         angle = np.mod(np.rad2deg(np.arctan2(mirror_v.y, mirror_v.x)), 180) * 2
-        dedge = kdb.DEdge(p1, p2)
+        dedge = kdb.DEdge(_p1, _p2)
 
         v = mirror_v
         v = kdb.DVector(-v.y, v.x)

--- a/tests/test_instance.py
+++ b/tests/test_instance.py
@@ -53,7 +53,10 @@ def test_mirror(LAYER: Layers) -> None:
     mp1 = kf.kdb.Point(50000, 25000)
     mp2 = -mp1
 
-    b2.mirror(disp * mp1, disp * mp2)
+    p1 = disp * mp1
+    p2 = disp * mp2
+
+    b2.mirror((p1.x, p1.y), (p2.x, p2.y))
 
     c.shapes(c.kcl.find_layer(LAYER.WG)).insert(kf.kdb.Edge(mp1, mp2).transformed(disp))
 
@@ -70,7 +73,10 @@ def test_dmirror(LAYER: Layers) -> None:
     mp1 = c.kcl.to_um(kf.kdb.Point(50000, 25000))
     mp2 = -mp1
 
-    b2.dmirror(disp * mp1, disp * mp2)
+    p1 = disp * mp1
+    p2 = disp * mp2
+
+    b2.dmirror((p1.x, p1.y), (p2.x, p2.y))
 
     c.shapes(c.kcl.find_layer(LAYER.WG)).insert(
         kf.kdb.DEdge(mp1, mp2).transformed(disp)


### PR DESCRIPTION
allow using tuples for mirror points

## Summary by Sourcery

Enhancements:
- Change `center` and `dcenter` properties to return tuples instead of kdb.Point and kdb.DPoint objects.