### PR TITLE
Setup codecov

### DIFF
--- a/.github/workflows/test_code.yml
+++ b/.github/workflows/test_code.yml
@@ -52,6 +52,18 @@ jobs:
         env:
           KFACTORY_LOGFILTER_LEVEL: "ERROR"
         run: pytest
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - name: Test coverage
+        run: |
+          make cov
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
   test_docs:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/test_code.yml
+++ b/.github/workflows/test_code.yml
@@ -53,10 +53,28 @@ jobs:
           KFACTORY_LOGFILTER_LEVEL: "ERROR"
         run: pytest
   coverage:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      max-parallel: 12
+      matrix:
+        python-version:
+          - "3.13"
+        os: [macos-latest]
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: "pip"
+          cache-dependency-path: pyproject.toml
+      - name: Install dependencies
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python -m pip install wheel uv
+          uv pip install --system -e .[ci] pytest
+          make gds-download
       - name: Test coverage
         run: |
           make cov

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ docs-serve:
 test:
 	uv run pytest -s
 
-cov:
+cov: dev
 	uv run pytest --cov=kfactory
 
 venv:

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ install:
 dev:
 	uv sync --all-extras
 	uv pip install -e .
-	pre-commit install
+	uv run pre-commit install
 
 docs-clean:
 	rm -rf site

--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,8 @@ docs-serve:
 test:
 	uv run pytest -s
 
-cov: dev
-	uv run pytest --cov=kfactory
+cov:
+	uv run pytest --cov=kfactory --cov-branch --cov-report=xml
 
 venv:
 	uv venv -p 3.13

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # KFactory 1.0.0
 
+[![codecov](https://codecov.io/gh/gdsfactory/kfactory/graph/badge.svg?token=dArcfnQE4w)](https://codecov.io/gh/gdsfactory/kfactory)
+
 Kfactory is the backend for [gdsfactory](https://github.com/gdsfactory/gdsfactory). It is built upon [KLayout](https://klayout.de).
 It offers basic operations like gdsfactory, so it can be used on its own as as layout tool as well.
 


### PR DESCRIPTION
## Summary by Sourcery

Set up Codecov to collect and display test coverage reports.

Enhancements:
- Generate coverage reports during tests.

CI:
- Add a new CI job to upload coverage reports to Codecov after running tests.