### PR TITLE
Fix um grid

### DIFF
--- a/src/kfactory/grid.py
+++ b/src/kfactory/grid.py
@@ -6,7 +6,8 @@ from collections.abc import Sequence
 from typing import Literal, cast
 
 from . import kdb
-from .instance import Instance
+from .instance import DInstance, Instance
+from .instance_group import DInstanceGroup, InstanceGroup
 from .kcell import DKCell, KCell
 
 
@@ -20,7 +21,7 @@ def grid_dbu(
     align_y: Literal["origin", "ymin", "ymax", "center"] = "center",
     rotation: Literal[0, 1, 2, 3] = 0,
     mirror: bool = False,
-) -> list[list[Instance | None]]:
+) -> InstanceGroup:
     """Create a grid of instances.
 
     A grid uses the bounding box of the biggest width and biggest height of any bounding
@@ -144,7 +145,9 @@ def grid_dbu(
                 x0 += w // 2
             y0 += h // 2
             x0 = 0
-        return insts
+        return InstanceGroup(
+            [inst for array in insts for inst in array if inst is not None]
+        )
     else:
         _kcells: Sequence[KCell | None]
         if isinstance(kcells[0], KCell):
@@ -222,7 +225,9 @@ def grid_dbu(
                 x0 = 0
             else:
                 x0 += w // 2
-        return insts
+        return InstanceGroup(
+            [inst for array in insts for inst in array if inst is not None]
+        )
 
 
 def flexgrid_dbu(
@@ -235,7 +240,7 @@ def flexgrid_dbu(
     align_y: Literal["origin", "ymin", "ymax", "center"] = "center",
     rotation: Literal[0, 1, 2, 3] = 0,
     mirror: bool = False,
-) -> list[list[Instance | None]]:
+) -> InstanceGroup:
     """Create a grid of instances.
 
     A grid uses the bounding box of the biggest width per column and biggest height per
@@ -367,7 +372,9 @@ def flexgrid_dbu(
                 x0 += xmax.get(i_x, 0)
             y0 += ymax.get(i_y, 0)
             x0 = 0
-        return insts
+        return InstanceGroup(
+            [inst for array in insts for inst in array if inst is not None]
+        )
     else:
         _kcells: Sequence[KCell | None]
         if isinstance(kcells[0], KCell):
@@ -453,7 +460,9 @@ def flexgrid_dbu(
                 x0 = 0
             else:
                 x0 += xmax.get(i_x, 0)
-        return insts
+        return InstanceGroup(
+            [inst for array in insts for inst in array if inst is not None]
+        )
 
 
 def grid(
@@ -466,7 +475,7 @@ def grid(
     align_y: Literal["origin", "ymin", "ymax", "center"] = "center",
     rotation: Literal[0, 1, 2, 3] = 0,
     mirror: bool = False,
-) -> list[list[Instance | None]]:
+) -> DInstanceGroup:
     """Create a grid of instances.
 
     A grid uses the bounding box of the biggest width and biggest height of any bounding
@@ -531,7 +540,7 @@ def grid(
         spacing_x = spacing
         spacing_y = spacing
 
-    insts: list[list[Instance | None]]
+    insts: list[list[DInstance | None]]
     kcell_array: Sequence[Sequence[DKCell]]
 
     if shape is None:
@@ -591,7 +600,9 @@ def grid(
                 x0 += w / 2
             y0 += h / 2
             x0 = 0
-        return insts
+        return DInstanceGroup(
+            [inst for array in insts for inst in array if inst is not None]
+        )
     else:
         _kcells: Sequence[DKCell | None]
         if isinstance(kcells[0], DKCell):
@@ -669,7 +680,9 @@ def grid(
                 x0 = 0
             else:
                 x0 += w / 2
-        return insts
+        return DInstanceGroup(
+            [inst for array in insts for inst in array if inst is not None]
+        )
 
 
 def flexgrid(
@@ -682,7 +695,7 @@ def flexgrid(
     align_y: Literal["origin", "ymin", "ymax", "center"] = "center",
     rotation: Literal[0, 1, 2, 3] = 0,
     mirror: bool = False,
-) -> list[list[Instance | None]]:
+) -> DInstanceGroup:
     """Create a grid of instances.
 
     A grid uses the bounding box of the biggest width per column and biggest height per
@@ -742,7 +755,7 @@ def flexgrid(
         spacing_x = spacing
         spacing_y = spacing
 
-    insts: list[list[Instance | None]]
+    insts: list[list[DInstance | None]]
     kcell_array: Sequence[Sequence[DKCell]]
 
     if shape is None:
@@ -814,7 +827,9 @@ def flexgrid(
                 x0 += xmax.get(i_x, 0)
             y0 += ymax.get(i_y, 0)
             x0 = 0
-        return insts
+        return DInstanceGroup(
+            [inst for array in insts for inst in array if inst is not None]
+        )
     else:
         _kcells: Sequence[DKCell | None]
         if isinstance(kcells[0], DKCell):
@@ -900,4 +915,6 @@ def flexgrid(
                 x0 = 0
             else:
                 x0 += xmax.get(i_x, 0)
-        return insts
+        return DInstanceGroup(
+            [inst for array in insts for inst in array if inst is not None]
+        )

--- a/src/kfactory/grid.py
+++ b/src/kfactory/grid.py
@@ -7,7 +7,7 @@ from typing import Literal, cast
 
 from . import kdb
 from .instance import Instance
-from .kcell import KCell
+from .kcell import DKCell, KCell
 
 
 def grid_dbu(
@@ -457,8 +457,8 @@ def flexgrid_dbu(
 
 
 def grid(
-    target: KCell,
-    kcells: Sequence[KCell | None] | Sequence[Sequence[KCell | None]],
+    target: DKCell,
+    kcells: Sequence[DKCell | None] | Sequence[Sequence[DKCell | None]],
     spacing: float | tuple[float, float],
     target_trans: kdb.DCplxTrans = kdb.DCplxTrans(),
     shape: tuple[int, int] | None = None,
@@ -532,10 +532,10 @@ def grid(
         spacing_y = spacing
 
     insts: list[list[Instance | None]]
-    kcell_array: Sequence[Sequence[KCell]]
+    kcell_array: Sequence[Sequence[DKCell]]
 
     if shape is None:
-        if isinstance(kcells[0], KCell):
+        if isinstance(kcells[0], DKCell):
             kcell_array = [list(kcells)]  # type:ignore[arg-type]
         else:
             kcell_array = kcells  # type: ignore[assignment]
@@ -593,13 +593,13 @@ def grid(
             x0 = 0
         return insts
     else:
-        _kcells: Sequence[KCell | None]
-        if isinstance(kcells[0], KCell):
-            _kcells = cast(Sequence[KCell | None], kcells)
+        _kcells: Sequence[DKCell | None]
+        if isinstance(kcells[0], DKCell):
+            _kcells = cast(Sequence[DKCell | None], kcells)
         else:
             _kcells = [
                 kcell
-                for array in cast(Sequence[Sequence[KCell | None]], kcells)
+                for array in cast(Sequence[Sequence[DKCell | None]], kcells)
                 for kcell in array
             ]
 
@@ -673,8 +673,8 @@ def grid(
 
 
 def flexgrid(
-    target: KCell,
-    kcells: Sequence[KCell | None] | Sequence[Sequence[KCell | None]],
+    target: DKCell,
+    kcells: Sequence[DKCell | None] | Sequence[Sequence[DKCell | None]],
     spacing: float | tuple[float, float],
     target_trans: kdb.DCplxTrans = kdb.DCplxTrans(),
     shape: tuple[int, int] | None = None,
@@ -724,8 +724,8 @@ def flexgrid(
     ```
 
     Args:
-        target: Target KCell.
-        kcells: Sequence or sequence of sequence of KCells to add to the grid
+        target: Target DKCell.
+        kcells: Sequence or sequence of sequence of DKCells to add to the grid
         spacing: Value or tuple of value (different x/y) for spacing of the grid.
         target_trans: Apply a transformation to the whole grid before placing it.
         shape: Respace the input of kcells into an array and fill as many positions
@@ -743,13 +743,13 @@ def flexgrid(
         spacing_y = spacing
 
     insts: list[list[Instance | None]]
-    kcell_array: Sequence[Sequence[KCell]]
+    kcell_array: Sequence[Sequence[DKCell]]
 
     if shape is None:
-        if isinstance(kcells[0], KCell):
-            kcell_array = cast(Sequence[list[KCell]], [list(kcells)])
+        if isinstance(kcells[0], DKCell):
+            kcell_array = cast(Sequence[list[DKCell]], [list(kcells)])
         else:
-            kcell_array = cast(Sequence[Sequence[KCell]], kcells)
+            kcell_array = cast(Sequence[Sequence[DKCell]], kcells)
 
         x0: float = 0
         y0: float = 0
@@ -816,13 +816,13 @@ def flexgrid(
             x0 = 0
         return insts
     else:
-        _kcells: Sequence[KCell | None]
-        if isinstance(kcells[0], KCell):
-            _kcells = cast(Sequence[KCell | None], kcells)
+        _kcells: Sequence[DKCell | None]
+        if isinstance(kcells[0], DKCell):
+            _kcells = cast(Sequence[DKCell | None], kcells)
         else:
             _kcells = [
                 kcell
-                for array in cast(Sequence[Sequence[KCell | None]], kcells)
+                for array in cast(Sequence[Sequence[DKCell | None]], kcells)
                 for kcell in array
             ]
 

--- a/src/kfactory/grid.py
+++ b/src/kfactory/grid.py
@@ -513,8 +513,8 @@ def grid(
     ```
 
     Args:
-        target: Target KCell.
-        kcells: Sequence or sequence of sequence of KCells to add to the grid
+        target: Target DKCell.
+        kcells: Sequence or sequence of sequence of DKCells to add to the grid
         spacing: Value or tuple of value (different x/y) for spacing of the grid. [um]
         target_trans: Apply a transformation to the whole grid before placing it.
         shape: Respace the input of kcells into an array and fill as many positions

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -49,7 +49,7 @@ def test_grid_dbu_2d_uneven(straight_factory_dbu: Callable[..., kf.KCell]) -> No
                 straight_factory_dbu(
                     width=randint(500, 2500) * 2, length=randint(2000, 20_000)
                 )
-                for i in range(10 + j**2)
+                for _ in range(10 + j**2)
             ]
             for j in range(-3, 3)
         ],
@@ -399,7 +399,7 @@ def test_flexgrid_dbu_2d_shape_rotation(
 def test_flexgrid_2d_shape_rotation(
     straight_factory: Callable[..., kf.KCell],
 ) -> None:
-    c = kf.KCell()
+    c = kf.DKCell()
 
     kf.flexgrid(
         c,
@@ -407,7 +407,7 @@ def test_flexgrid_2d_shape_rotation(
             [
                 straight_factory(
                     width=round(uniform(0.5, 2.5)) * 2, length=round(uniform(2, 20))
-                )
+                ).to_dkcell()
                 for _ in range(10)
             ]
             for _ in range(2)

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -140,6 +140,145 @@ def test_grid_dbu_2d_shape_rotation(
     )
 
 
+def test_grid_1d(straight_factory_dbu: Callable[..., kf.KCell]) -> None:
+    c = kf.DKCell()
+
+    kf.grid(
+        c,
+        kcells=[
+            straight_factory_dbu(
+                width=randint(500, 2500) * 2, length=randint(2000, 20_000)
+            ).to_dkcell()
+            for _ in range(10)
+        ],
+        spacing=5000,
+        align_x="origin",
+    )
+
+
+def test_grid_2d(straight_factory_dbu: Callable[..., kf.KCell]) -> None:
+    c = kf.DKCell()
+
+    kf.grid(
+        c,
+        kcells=[
+            [
+                straight_factory_dbu(
+                    width=randint(500, 2500) * 2, length=randint(2000, 20_000)
+                ).to_dkcell()
+                for _ in range(10)
+            ]
+            for _ in range(2)
+        ],
+        spacing=5000,
+        align_x="origin",
+    )
+
+
+def test_grid_2d_uneven(straight_factory_dbu: Callable[..., kf.KCell]) -> None:
+    c = kf.DKCell()
+
+    kf.grid(
+        c,
+        kcells=[
+            [
+                straight_factory_dbu(
+                    width=randint(500, 2500) * 2, length=randint(2000, 20_000)
+                ).to_dkcell()
+                for _ in range(10 + j**2)
+            ]
+            for j in range(-3, 3)
+        ],
+        spacing=5000,
+        align_x="xmin",
+        align_y="ymax",
+    )
+
+
+def test_grid_2d_rotation(straight_factory_dbu: Callable[..., kf.KCell]) -> None:
+    c = kf.DKCell()
+
+    kf.grid(
+        c,
+        kcells=[
+            [
+                straight_factory_dbu(
+                    width=randint(500, 2500) * 2, length=randint(2000, 20_000)
+                ).to_dkcell()
+                for _ in range(10)
+            ]
+            for _ in range(2)
+        ],
+        rotation=1,
+        spacing=5000,
+        align_x="xmin",
+        align_y="ymin",
+    )
+
+
+def test_grid_1d_shape(straight_factory_dbu: Callable[..., kf.KCell]) -> None:
+    c = kf.DKCell()
+
+    kf.grid(
+        c,
+        kcells=[
+            [
+                straight_factory_dbu(
+                    width=randint(500, 2500) * 2, length=randint(2000, 20_000)
+                ).to_dkcell()
+                for _ in range(10)
+            ]
+            for _ in range(2)
+        ],
+        spacing=5000,
+        align_x="origin",
+        shape=(1, 10),
+    )
+
+
+def test_grid_2d_shape(straight_factory_dbu: Callable[..., kf.KCell]) -> None:
+    c = kf.DKCell()
+
+    kf.grid(
+        c,
+        kcells=[
+            [
+                straight_factory_dbu(
+                    width=randint(500, 2500) * 2, length=randint(2000, 20_000)
+                ).to_dkcell()
+                for _ in range(10)
+            ]
+            for _ in range(2)
+        ],
+        spacing=5000,
+        align_x="origin",
+        shape=(4, 5),
+    )
+
+
+def test_grid_2d_shape_rotation(
+    straight_factory_dbu: Callable[..., kf.KCell],
+) -> None:
+    c = kf.DKCell()
+
+    kf.grid(
+        c,
+        kcells=[
+            [
+                straight_factory_dbu(
+                    width=randint(500, 2500) * 2, length=randint(2000, 20_000)
+                ).to_dkcell()
+                for _ in range(10)
+            ]
+            for _ in range(2)
+        ],
+        rotation=1,
+        spacing=5000,
+        align_x="origin",
+        shape=(3, 7),
+    )
+
+
 def test_flexgrid_dbu_1d(straight_factory_dbu: Callable[..., kf.KCell]) -> None:
     c = kf.KCell()
 
@@ -254,30 +393,6 @@ def test_flexgrid_dbu_2d_shape_rotation(
         spacing=5000,
         align_x="origin",
         shape=(3, 7),
-    )
-
-
-def test_grid_2d_shape_rotation(
-    straight_factory: Callable[..., kf.KCell],
-) -> None:
-    c = kf.KCell()
-
-    kf.grid(
-        c,
-        kcells=[
-            [
-                straight_factory(
-                    width=round(uniform(0.5, 2.5)) * 2, length=round(uniform(2, 20))
-                )
-                for _ in range(10)
-            ]
-            for _ in range(2)
-        ],
-        rotation=1,
-        spacing=5,
-        align_x="origin",
-        shape=(3, 7),
-        target_trans=kf.kdb.DCplxTrans(1, 37, False, 0, 0),
     )
 
 

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -232,7 +232,7 @@ def test_grid_1d_shape(straight_factory_dbu: Callable[..., kf.KCell]) -> None:
         ],
         spacing=5000,
         align_x="origin",
-        shape=(1, 10),
+        shape=(2, 10),
     )
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -737,7 +737,7 @@ wheels = [
 
 [[package]]
 name = "kfactory"
-version = "1.0.2"
+version = "1.0.3"
 source = { editable = "." }
 dependencies = [
     { name = "aenum" },

--- a/uv.lock
+++ b/uv.lock
@@ -52,11 +52,11 @@ wheels = [
 
 [[package]]
 name = "attrs"
-version = "24.3.0"
+version = "25.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/48/c8/6260f8ccc11f0917360fc0da435c5c9c7504e3db174d5a12a1494887b045/attrs-24.3.0.tar.gz", hash = "sha256:8f5c07333d543103541ba7be0e2ce16eeee8130cb0b3f9238ab904ce1e85baff", size = 805984 }
+sdist = { url = "https://files.pythonhosted.org/packages/49/7c/fdf464bcc51d23881d110abd74b512a42b3d5d376a55a831b44c603ae17f/attrs-25.1.0.tar.gz", hash = "sha256:1c97078a80c814273a76b2a298a932eb681c87415c11dee0a6921de7f1b02c3e", size = 810562 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/89/aa/ab0f7891a01eeb2d2e338ae8fecbe57fcebea1a24dbb64d45801bfab481d/attrs-24.3.0-py3-none-any.whl", hash = "sha256:ac96cd038792094f438ad1f6ff80837353805ac950cd2aa0e0625ef19850c308", size = 63397 },
+    { url = "https://files.pythonhosted.org/packages/fc/30/d4986a882011f9df997a55e6becd864812ccfcd821d64aac8570ee39f719/attrs-25.1.0-py3-none-any.whl", hash = "sha256:c75a69e28a550a7e93789579c22aa26b0f5b83b75dc4e08fe092980051e1090a", size = 63152 },
 ]
 
 [[package]]
@@ -613,11 +613,11 @@ wheels = [
 
 [[package]]
 name = "isort"
-version = "5.13.2"
+version = "6.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/87/f9/c1eb8635a24e87ade2efce21e3ce8cd6b8630bb685ddc9cdaca1349b2eb5/isort-5.13.2.tar.gz", hash = "sha256:48fdfcb9face5d58a4f6dde2e72a1fb8dcaf8ab26f95ab49fab84c2ddefb0109", size = 175303 }
+sdist = { url = "https://files.pythonhosted.org/packages/1c/28/b382d1656ac0ee4cef4bf579b13f9c6c813bff8a5cb5996669592c8c75fa/isort-6.0.0.tar.gz", hash = "sha256:75d9d8a1438a9432a7d7b54f2d3b45cad9a4a0fdba43617d9873379704a8bdf1", size = 828356 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d1/b3/8def84f539e7d2289a02f0524b944b15d7c75dab7628bedf1c4f0992029c/isort-5.13.2-py3-none-any.whl", hash = "sha256:8ca5e72a8d85860d5a3fa69b8745237f2939afe12dbf656afbcb47fe72d947a6", size = 92310 },
+    { url = "https://files.pythonhosted.org/packages/76/c7/d6017f09ae5b1206fbe531f7af3b6dac1f67aedcbd2e79f3b386c27955d6/isort-6.0.0-py3-none-any.whl", hash = "sha256:567954102bb47bb12e0fae62606570faacddd441e45683968c8d1734fb1af892", size = 94053 },
 ]
 
 [[package]]
@@ -1075,11 +1075,11 @@ wheels = [
 
 [[package]]
 name = "mistune"
-version = "3.1.0"
+version = "3.1.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/79/6e/96fc7cb3288666c5de2c396eb0e338dc95f7a8e4920e43e38783a22d0084/mistune-3.1.0.tar.gz", hash = "sha256:dbcac2f78292b9dc066cd03b7a3a26b62d85f8159f2ea5fd28e55df79908d667", size = 94401 }
+sdist = { url = "https://files.pythonhosted.org/packages/c6/1d/6b2b634e43bacc3239006e61800676aa6c41ac1836b2c57497ed27a7310b/mistune-3.1.1.tar.gz", hash = "sha256:e0740d635f515119f7d1feb6f9b192ee60f0cc649f80a8f944f905706a21654c", size = 94645 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b4/b3/743ffc3f59da380da504d84ccd1faf9a857a1445991ff19bf2ec754163c2/mistune-3.1.0-py3-none-any.whl", hash = "sha256:b05198cf6d671b3deba6c87ec6cf0d4eb7b72c524636eddb6dbf13823b52cee1", size = 53694 },
+    { url = "https://files.pythonhosted.org/packages/c6/02/c66bdfdadbb021adb642ca4e8a5ed32ada0b4a3e4b39c5d076d19543452f/mistune-3.1.1-py3-none-any.whl", hash = "sha256:02106ac2aa4f66e769debbfa028509a275069dcffce0dfa578edd7b991ee700a", size = 53696 },
 ]
 
 [[package]]
@@ -1326,7 +1326,7 @@ wheels = [
 
 [[package]]
 name = "nbconvert"
-version = "7.16.5"
+version = "7.16.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beautifulsoup4" },
@@ -1344,9 +1344,9 @@ dependencies = [
     { name = "pygments" },
     { name = "traitlets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/46/2c/d026c0367f2be2463d4c2f5b538e28add2bc67bc13730abb7f364ae4eb8b/nbconvert-7.16.5.tar.gz", hash = "sha256:c83467bb5777fdfaac5ebbb8e864f300b277f68692ecc04d6dab72f2d8442344", size = 856367 }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/59/f28e15fc47ffb73af68a8d9b47367a8630d76e97ae85ad18271b9db96fdf/nbconvert-7.16.6.tar.gz", hash = "sha256:576a7e37c6480da7b8465eefa66c17844243816ce1ccc372633c6b71c3c0f582", size = 857715 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8f/9e/2dcc9fe00cf55d95a8deae69384e9cea61816126e345754f6c75494d32ec/nbconvert-7.16.5-py3-none-any.whl", hash = "sha256:e12eac052d6fd03040af4166c563d76e7aeead2e9aadf5356db552a1784bd547", size = 258061 },
+    { url = "https://files.pythonhosted.org/packages/cc/9a/cd673b2f773a12c992f41309ef81b99da1690426bd2f96957a7ade0d3ed7/nbconvert-7.16.6-py3-none-any.whl", hash = "sha256:1375a7b67e0c2883678c48e506dc320febb57685e5ee67faa51b18a90f3a712b", size = 258525 },
 ]
 
 [[package]]
@@ -1696,7 +1696,7 @@ wheels = [
 
 [[package]]
 name = "pylint"
-version = "3.3.3"
+version = "3.3.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "astroid" },
@@ -1707,22 +1707,22 @@ dependencies = [
     { name = "platformdirs" },
     { name = "tomlkit" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/17/fd/e9a739afac274a39596bbe562e9d966db6f3917fdb2bd7322ffc56da0ba2/pylint-3.3.3.tar.gz", hash = "sha256:07c607523b17e6d16e2ae0d7ef59602e332caa762af64203c24b41c27139f36a", size = 1516550 }
+sdist = { url = "https://files.pythonhosted.org/packages/ab/b9/50be49afc91469f832c4bf12318ab4abe56ee9aa3700a89aad5359ad195f/pylint-3.3.4.tar.gz", hash = "sha256:74ae7a38b177e69a9b525d0794bd8183820bfa7eb68cc1bee6e8ed22a42be4ce", size = 1518905 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/91/e1/26d55acea92b1ea4d33672e48f09ceeb274e84d7d542a4fb9a32a556db46/pylint-3.3.3-py3-none-any.whl", hash = "sha256:26e271a2bc8bce0fc23833805a9076dd9b4d5194e2a02164942cb3cdc37b4183", size = 521918 },
+    { url = "https://files.pythonhosted.org/packages/0d/8b/eef15df5f4e7aa393de31feb96ca9a3d6639669bd59d589d0685d5ef4e62/pylint-3.3.4-py3-none-any.whl", hash = "sha256:289e6a1eb27b453b08436478391a48cd53bb0efb824873f949e709350f3de018", size = 522280 },
 ]
 
 [[package]]
 name = "pylsp-mypy"
-version = "0.6.9"
+version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mypy" },
     { name = "python-lsp-server" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9e/5b/d0a6c54ae8863bec81911965047d92662a13bc38dfb6fee6388d8419a72b/pylsp_mypy-0.6.9.tar.gz", hash = "sha256:d28994a6ba123c3918ce3274a5cad768418650e575001002101c425ad6c7bbaa", size = 16908 }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/4d/9683a57f2e8b9263910ef497a99d88622f4fb1c158decb867fd40a41bfdd/pylsp_mypy-0.7.0.tar.gz", hash = "sha256:e94f531d4ce523222c2af7471abe396cfeb4cc3c4b181d54462fb6d553e1e0b3", size = 18529 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f3/41/6f7db581bcd31895b4e5acdfd25f49a278898babda3f01a6d224b611b119/pylsp_mypy-0.6.9-py3-none-any.whl", hash = "sha256:9b73ece2977b22b5fc75dfec1cc491bf2031955e3da4062d924a5cc22a278151", size = 11472 },
+    { url = "https://files.pythonhosted.org/packages/a6/7d/324859fa4af565db32ff8d924fd10dd49922756736be12d783be3813ffc8/pylsp_mypy-0.7.0-py3-none-any.whl", hash = "sha256:756377d05d251d2e31d1963397654149b9c1ea5b0ba1aedd74adef76decd32e9", size = 12232 },
 ]
 
 [[package]]
@@ -2055,16 +2055,16 @@ wheels = [
 
 [[package]]
 name = "referencing"
-version = "0.36.1"
+version = "0.36.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
     { name = "rpds-py" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/27/32/fd98246df7a0f309b58cae68b10b6b219ef2eb66747f00dfb34422687087/referencing-0.36.1.tar.gz", hash = "sha256:ca2e6492769e3602957e9b831b94211599d2aade9477f5d44110d2530cf9aade", size = 74661 }
+sdist = { url = "https://files.pythonhosted.org/packages/2f/db/98b5c277be99dd18bfd91dd04e1b759cad18d1a338188c936e92f921c7e2/referencing-0.36.2.tar.gz", hash = "sha256:df2e89862cd09deabbdba16944cc3f10feb6b3e6f18e902f7cc25609a34775aa", size = 74744 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cc/fa/9f193ef0c9074b659009f06d7cbacc6f25b072044815bcf799b76533dbb8/referencing-0.36.1-py3-none-any.whl", hash = "sha256:363d9c65f080d0d70bc41c721dce3c7f3e77fc09f269cd5c8813da18069a6794", size = 26777 },
+    { url = "https://files.pythonhosted.org/packages/c1/b1/3baf80dc6d2b7bc27a95a67752d0208e410351e3feb4eb78de5f77454d8d/referencing-0.36.2-py3-none-any.whl", hash = "sha256:e8699adbbf8b5c7de96d8ffa0eb5c158b3beafce084968e2ea8bb08c6794dcd0", size = 26775 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix an issue where the loop counter `i` was not used in `test_grid_dbu_2d_uneven` causing potential confusion. Replace `i` with `_` to indicate that the variable is intentionally unused.