### PR TITLE
Add to_itype, to_dtype to dbu, um classes

### DIFF
--- a/src/kfactory/instance.py
+++ b/src/kfactory/instance.py
@@ -96,6 +96,12 @@ class ProtoTInstance(ProtoInstance[TUnit], Generic[TUnit]):
     def cell_name(self) -> str:
         return self._instance.cell.name
 
+    def to_itype(self) -> Instance:
+        return Instance(kcl=self.kcl, instance=self._instance)
+
+    def to_dtype(self) -> DInstance:
+        return DInstance(kcl=self.kcl, instance=self._instance)
+
     @abstractmethod
     def __getitem__(
         self, key: int | str | None | tuple[int | str | None, int, int]

--- a/src/kfactory/instance_group.py
+++ b/src/kfactory/instance_group.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Generic, NoReturn
 
 from . import kdb
 from .geometry import DBUGeometricObject, GeometricObject, UMGeometricObject
-from .instance import DInstance, Instance, VInstance
+from .instance import ProtoTInstance, VInstance
 from .typings import TInstance, TUnit
 
 if TYPE_CHECKING:
@@ -55,7 +55,19 @@ class ProtoInstanceGroup(Generic[TUnit, TInstance], GeometricObject[TUnit]):
         return bb
 
 
-class InstanceGroup(ProtoInstanceGroup[int, Instance], DBUGeometricObject):
+class ProtoTInstanceGroup(
+    ProtoInstanceGroup[TUnit, ProtoTInstance[TUnit]],
+    Generic[TUnit],
+    GeometricObject[TUnit],
+):
+    def to_itype(self) -> InstanceGroup:
+        return InstanceGroup(insts=[inst.to_itype() for inst in self.insts])
+
+    def to_dtype(self) -> DInstanceGroup:
+        return DInstanceGroup(insts=[inst.to_dtype() for inst in self.insts])
+
+
+class InstanceGroup(ProtoTInstanceGroup[int], DBUGeometricObject):
     """Group of Instances.
 
     The instance group can be treated similar to a single instance
@@ -68,7 +80,7 @@ class InstanceGroup(ProtoInstanceGroup[int, Instance], DBUGeometricObject):
     ...
 
 
-class DInstanceGroup(ProtoInstanceGroup[float, DInstance], UMGeometricObject):
+class DInstanceGroup(ProtoTInstanceGroup[float], UMGeometricObject):
     """Group of DInstances.
 
     The instance group can be treated similar to a single instance

--- a/src/kfactory/instances.py
+++ b/src/kfactory/instances.py
@@ -103,6 +103,12 @@ class ProtoTInstances(ProtoInstances[TUnit, ProtoTInstance[TUnit]], ABC):
     def remove(self, inst: ProtoTInstance[Any]) -> None:
         inst.instance.delete()
 
+    def to_itype(self) -> Instances:
+        return Instances(cell=self._tkcell)
+
+    def to_dtype(self) -> DInstances:
+        return DInstances(cell=self._tkcell)
+
 
 class Instances(ProtoTInstances[int]):
     """Holder for instances.

--- a/src/kfactory/kcell.py
+++ b/src/kfactory/kcell.py
@@ -525,15 +525,12 @@ class ProtoTKCell(ProtoKCell[TUnit], ABC):
     def boundary(self, boundary: kdb.DPolygon | None) -> None:
         self._base_kcell.boundary = boundary
 
-    @classmethod
-    def from_kcell(cls, kcell: ProtoTKCell[Any]) -> Self:
-        """Create a KCell from a KLayout Cell."""
-        return cls(base_kcell=kcell._base_kcell)
-
-    def to_kcell(self) -> KCell:
+    def to_itype(self) -> KCell:
+        """Convert the kcell to a dbu kcell."""
         return KCell(base_kcell=self._base_kcell)
 
-    def to_dkcell(self) -> DKCell:
+    def to_dtype(self) -> DKCell:
+        """Convert the kcell to a um kcell."""
         return DKCell(base_kcell=self._base_kcell)
 
     def show(
@@ -1817,13 +1814,13 @@ class ProtoTKCell(ProtoKCell[TUnit], ABC):
                 ):
                     xy = (port.x, port.y)
                     if port.layer not in inst_ports:
-                        inst_ports[port.layer] = {xy: [(port, inst.cell.to_kcell())]}
+                        inst_ports[port.layer] = {xy: [(port, inst.cell.to_itype())]}
                     else:
                         if xy not in inst_ports[port.layer]:
-                            inst_ports[port.layer][xy] = [(port, inst.cell.to_kcell())]
+                            inst_ports[port.layer][xy] = [(port, inst.cell.to_itype())]
                         else:
                             inst_ports[port.layer][xy].append(
-                                (port, inst.cell.to_kcell())
+                                (port, inst.cell.to_itype())
                             )
 
         for layer, port_coord_mapping in inst_ports.items():

--- a/src/kfactory/layout.py
+++ b/src/kfactory/layout.py
@@ -793,7 +793,7 @@ class KCLayout(
                             pass
                     cell.insert_vinsts(recursive=False)
                     if snap_ports:
-                        for port in cell.to_kcell().ports:
+                        for port in cell.to_itype().ports:
                             if port.base.dcplx_trans:
                                 dup = port.base.dcplx_trans.dup()
                                 dup.disp = self.to_um(
@@ -801,7 +801,7 @@ class KCLayout(
                                 )
                                 port.dcplx_trans = dup
                     if add_port_layers:
-                        for port in cell.to_kcell().ports:
+                        for port in cell.to_itype().ports:
                             if port.layer in cell.kcl.netlist_layer_mapping:
                                 if port.base.trans:
                                     edge = kdb.Edge(

--- a/src/kfactory/port.py
+++ b/src/kfactory/port.py
@@ -273,7 +273,7 @@ class ProtoPort(Generic[TUnit], ABC):
 
     def __eq__(self, other: object) -> bool:
         """Support for `port1 == port2` comparisons."""
-        if isinstance(other, Port):
+        if isinstance(other, ProtoPort):
             return self._base == other._base
         return False
 
@@ -325,9 +325,13 @@ class ProtoPort(Generic[TUnit], ABC):
         else:
             self._base.trans = kdb.ICplxTrans(value.dup(), self.kcl.dbu).s_trans()
 
-    def to_port(self) -> Port:
-        """Convert the port to a regular port."""
+    def to_itype(self) -> Port:
+        """Convert the port to a dbu port."""
         return Port(base=self._base)
+
+    def to_dtype(self) -> DPort:
+        """Convert the port to a um port."""
+        return DPort(base=self._base)
 
     @property
     @abstractmethod
@@ -883,7 +887,7 @@ class DPort(ProtoPort[float]):
                     "If a cross_section is not given a width must be defined."
                 )
             cross_section = kcl_.get_cross_section(
-                CrossSectionSpec(main_layer=layer_info, width=width)
+                CrossSectionSpec(main_layer=layer_info, width=kcl_.to_dbu(width))
             )
         cross_section_ = cross_section
         if trans is not None:

--- a/src/kfactory/ports.py
+++ b/src/kfactory/ports.py
@@ -101,6 +101,12 @@ class ProtoPorts(ABC, Generic[TUnit]):
             rename_funciton([Port(base=b) for b in bases])
         return self.__class__(bases=bases, kcl=self.kcl)
 
+    def to_itype(self) -> Ports:
+        return Ports(kcl=self.kcl, bases=self._bases)
+
+    def to_dtype(self) -> DPorts:
+        return DPorts(kcl=self.kcl, bases=self._bases)
+
     @abstractmethod
     def __iter__(self) -> Iterator[ProtoPort[TUnit]]: ...
 

--- a/src/kfactory/routing/electrical.py
+++ b/src/kfactory/routing/electrical.py
@@ -59,9 +59,9 @@ def route_elec(
         layer: Layer to place the wire on. Calculated from the start port if `None`.
         minimum_straight: require a minimum straight
     """
-    c_ = c.to_kcell()
-    p1_ = p1.to_port()
-    p2_ = p2.to_port()
+    c_ = c.to_itype()
+    p1_ = p1.to_itype()
+    p2_ = p2.to_itype()
     if width is None:
         width = p1_.width
     if layer is None:
@@ -108,8 +108,8 @@ def route_L(
     The function will produce a L-shape routing to connect input ports to output ports
     without any crossings.
     """
-    input_ports_ = [p.to_port() for p in input_ports]
-    c_ = c.to_kcell()
+    input_ports_ = [p.to_itype() for p in input_ports]
+    c_ = c.to_itype()
     input_ports_.sort(key=lambda p: p.y)
 
     y_max = input_ports_[-1].y

--- a/src/kfactory/routing/generic.py
+++ b/src/kfactory/routing/generic.py
@@ -262,7 +262,7 @@ def get_radius(
 
     This can be used to determine the radius of two bend ports.
     """
-    ports_ = tuple(p.to_port() for p in ports)
+    ports_ = tuple(p.to_itype() for p in ports)
     if len(ports_) != 2:
         raise ValueError(
             "Cannot determine the maximal radius of a bend with more than two ports."

--- a/tests/test_cell.py
+++ b/tests/test_cell.py
@@ -274,7 +274,7 @@ def test_check_ports(LAYER: Layers) -> None:
 
 def test_ports_in_cells() -> None:
     kcell = kf.KCell(name="test")
-    dkcell = kf.DKCell.from_kcell(kcell)
+    dkcell = kcell.to_dtype()
 
     port = kf.Port(name="test", layer=1, width=2, center=(0, 0), angle=90)
     new_port = kcell.add_port(port=port, name="o1")

--- a/tests/test_cell.py
+++ b/tests/test_cell.py
@@ -427,5 +427,19 @@ def test_cell_in_threads(LAYER: Layers, wg_enc: kf.LayerEnclosure) -> None:
     )
 
 
+def test_to_dtype(kcl: kf.KCLayout) -> None:
+    kcell = kcl.kcell()
+    kcell.shapes(0).insert(kf.kdb.Box(0, 0, 1000, 1000))
+    dkcell = kcell.to_dtype()
+    assert dkcell.bbox() == kf.kdb.DBox(0, 0, 1, 1)
+
+
+def test_to_itype(kcl: kf.KCLayout) -> None:
+    dkcell = kcl.dkcell()
+    dkcell.shapes(0).insert(kf.kdb.DBox(0, 0, 1, 1))
+    itype = dkcell.to_itype()
+    assert itype.bbox() == kf.kdb.Box(0, 0, 1000, 1000)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -148,7 +148,7 @@ def test_grid_1d(straight_factory_dbu: Callable[..., kf.KCell]) -> None:
         kcells=[
             straight_factory_dbu(
                 width=randint(500, 2500) * 2, length=randint(2000, 20_000)
-            ).to_dkcell()
+            ).to_dtype()
             for _ in range(10)
         ],
         spacing=5000,
@@ -165,7 +165,7 @@ def test_grid_2d(straight_factory_dbu: Callable[..., kf.KCell]) -> None:
             [
                 straight_factory_dbu(
                     width=randint(500, 2500) * 2, length=randint(2000, 20_000)
-                ).to_dkcell()
+                ).to_dtype()
                 for _ in range(10)
             ]
             for _ in range(2)
@@ -184,7 +184,7 @@ def test_grid_2d_uneven(straight_factory_dbu: Callable[..., kf.KCell]) -> None:
             [
                 straight_factory_dbu(
                     width=randint(500, 2500) * 2, length=randint(2000, 20_000)
-                ).to_dkcell()
+                ).to_dtype()
                 for _ in range(10 + j**2)
             ]
             for j in range(-3, 3)
@@ -204,7 +204,7 @@ def test_grid_2d_rotation(straight_factory_dbu: Callable[..., kf.KCell]) -> None
             [
                 straight_factory_dbu(
                     width=randint(500, 2500) * 2, length=randint(2000, 20_000)
-                ).to_dkcell()
+                ).to_dtype()
                 for _ in range(10)
             ]
             for _ in range(2)
@@ -225,7 +225,7 @@ def test_grid_1d_shape(straight_factory_dbu: Callable[..., kf.KCell]) -> None:
             [
                 straight_factory_dbu(
                     width=randint(500, 2500) * 2, length=randint(2000, 20_000)
-                ).to_dkcell()
+                ).to_dtype()
                 for _ in range(10)
             ]
             for _ in range(2)
@@ -245,7 +245,7 @@ def test_grid_2d_shape(straight_factory_dbu: Callable[..., kf.KCell]) -> None:
             [
                 straight_factory_dbu(
                     width=randint(500, 2500) * 2, length=randint(2000, 20_000)
-                ).to_dkcell()
+                ).to_dtype()
                 for _ in range(10)
             ]
             for _ in range(2)
@@ -267,7 +267,7 @@ def test_grid_2d_shape_rotation(
             [
                 straight_factory_dbu(
                     width=randint(500, 2500) * 2, length=randint(2000, 20_000)
-                ).to_dkcell()
+                ).to_dtype()
                 for _ in range(10)
             ]
             for _ in range(2)
@@ -407,7 +407,7 @@ def test_flexgrid_2d_shape_rotation(
             [
                 straight_factory(
                     width=round(uniform(0.5, 2.5)) * 2, length=round(uniform(2, 20))
-                ).to_dkcell()
+                ).to_dtype()
                 for _ in range(10)
             ]
             for _ in range(2)

--- a/tests/test_instance.py
+++ b/tests/test_instance.py
@@ -451,7 +451,7 @@ def test_center(dbu_instance_tuple: _DBUInstanceTuple) -> None:
 
 def test_vinstance_connect_by_port(kcl: kf.KCLayout, LAYER: Layers) -> None:
     c = kcl.vkcell()
-    straight_factory = kf.cells.straight.straight_dbu_factory(kcl)
+    straight_factory = kf.factories.straight.straight_dbu_factory(kcl)
     straight = straight_factory(
         width=kcl.to_dbu(5), length=kcl.to_dbu(10), layer=LAYER.WG
     )
@@ -469,7 +469,7 @@ def test_vinstance_connect_by_port_use_angle_false(
     kcl: kf.KCLayout, LAYER: Layers
 ) -> None:
     c = kcl.vkcell()
-    straight_factory = kf.cells.straight.straight_dbu_factory(kcl)
+    straight_factory = kf.factories.straight.straight_dbu_factory(kcl)
     straight = straight_factory(
         width=kcl.to_dbu(5), length=kcl.to_dbu(10), layer=LAYER.WG
     )
@@ -487,7 +487,7 @@ def test_vinstance_connect_by_port_use_mirror_false(
     kcl: kf.KCLayout, LAYER: Layers
 ) -> None:
     c = kcl.vkcell()
-    straight_factory = kf.cells.straight.straight_dbu_factory(kcl)
+    straight_factory = kf.factories.straight.straight_dbu_factory(kcl)
     straight = straight_factory(
         width=kcl.to_dbu(5), length=kcl.to_dbu(10), layer=LAYER.WG
     )
@@ -505,7 +505,7 @@ def test_vinstance_connect_by_port_use_mirror_Use_angle_false(
     kcl: kf.KCLayout, LAYER: Layers
 ) -> None:
     c = kcl.vkcell()
-    straight_factory = kf.cells.straight.straight_dbu_factory(kcl)
+    straight_factory = kf.factories.straight.straight_dbu_factory(kcl)
     straight = straight_factory(
         width=kcl.to_dbu(5), length=kcl.to_dbu(10), layer=LAYER.WG
     )
@@ -516,13 +516,12 @@ def test_vinstance_connect_by_port_use_mirror_Use_angle_false(
     ref2 = c << straight2
     ref2.move((10, 10)).rotate(270)
     ref.connect("o1", ref2.ports["o2"], use_mirror=False, use_angle=False)
-    c.show()
     assert c.bbox() == kdb.DBox(7.5, -22.5, 20, -10)
 
 
 def test_vinstance_connect_by_str(kcl: kf.KCLayout, LAYER: Layers) -> None:
     c = kcl.vkcell()
-    straight_factory = kf.cells.straight.straight_dbu_factory(kcl)
+    straight_factory = kf.factories.straight.straight_dbu_factory(kcl)
     straight = straight_factory(
         width=kcl.to_dbu(5), length=kcl.to_dbu(10), layer=LAYER.WG
     )
@@ -538,7 +537,7 @@ def test_vinstance_connect_by_str(kcl: kf.KCLayout, LAYER: Layers) -> None:
 
 def test_vinstance_errors(kcl: kf.KCLayout, LAYER: Layers) -> None:
     c = kcl.vkcell()
-    straight_factory = kf.cells.straight.straight_dbu_factory(kcl)
+    straight_factory = kf.factories.straight.straight_dbu_factory(kcl)
     straight = straight_factory(
         width=kcl.to_dbu(5), length=kcl.to_dbu(10), layer=LAYER.WG
     )
@@ -628,6 +627,30 @@ def test_mirror_y_equal() -> None:
     ref3.imirror_y()
 
     assert parent_cell.bbox() == kf.kdb.DBox(-5, -5, 5, 5)
+
+
+def test_to_itype(kcl: kf.KCLayout) -> None:
+    cell = kcl.kcell()
+    dkcell = kcl.dkcell()
+    dkcell.shapes(0).insert(kf.kdb.DBox(-5, -5, 5, 5))
+    ref = cell << dkcell
+    assert isinstance(ref, kf.Instance)
+    assert ref.bbox() == kf.kdb.Box(-5000, -5000, 5000, 5000)
+    dref = ref.to_dtype()
+    assert isinstance(dref, kf.DInstance)
+    assert dref.bbox() == kf.kdb.DBox(-5, -5, 5, 5)
+
+
+def test_to_dtype(kcl: kf.KCLayout) -> None:
+    cell = kcl.dkcell()
+    dkcell = kcl.kcell()
+    dkcell.shapes(0).insert(kf.kdb.DBox(-5, -5, 5, 5))
+    dref = cell << dkcell
+    assert isinstance(dref, kf.DInstance)
+    assert dref.bbox() == kf.kdb.DBox(-5, -5, 5, 5)
+    ref = dref.to_itype()
+    assert ref.bbox() == kf.kdb.Box(-5000, -5000, 5000, 5000)
+    assert isinstance(ref, kf.Instance)
 
 
 if __name__ == "__main__":

--- a/tests/test_instance_group.py
+++ b/tests/test_instance_group.py
@@ -178,5 +178,33 @@ def test_instance_group_attributes(
     assert instance1.center == instance2.center
 
 
+def test_to_itype(kcl: kf.KCLayout) -> None:
+    cell = kcl.kcell()
+    dkcell = kcl.dkcell()
+    dkcell.shapes(0).insert(kf.kdb.DBox(-5, -5, 5, 5))
+    ref = cell << dkcell
+    ref2 = cell << dkcell
+    ref2.move((0, 0), (1000, 1000))
+    instance_group = kf.InstanceGroup(insts=[ref, ref2])
+    assert instance_group.bbox() == kf.kdb.Box(-5000, -5000, 6000, 6000)
+    dinstance_group = instance_group.to_dtype()
+    assert dinstance_group.bbox() == kf.kdb.DBox(-5, -5, 6, 6)
+    assert isinstance(dinstance_group, kf.DInstanceGroup)
+
+
+def test_to_dtype(kcl: kf.KCLayout) -> None:
+    cell = kcl.kcell()
+    dkcell = kcl.dkcell()
+    cell.shapes(0).insert(kf.kdb.DBox(-5, -5, 5, 5))
+    ref = dkcell << cell
+    ref2 = dkcell << cell
+    ref2.move((0, 0), (1, 1))
+    instance_group = kf.DInstanceGroup(insts=[ref, ref2])
+    assert instance_group.bbox() == kf.kdb.DBox(-5, -5, 6, 6)
+    dinstance_group = instance_group.to_itype()
+    assert dinstance_group.bbox() == kf.kdb.Box(-5000, -5000, 6000, 6000)
+    assert isinstance(dinstance_group, kf.InstanceGroup)
+
+
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/tests/test_instances.py
+++ b/tests/test_instances.py
@@ -70,5 +70,31 @@ def test_dinstances_contains_str(kcl: kf.KCLayout, LAYER: Layers) -> None:
     assert ref.name in c.insts
 
 
+def test_to_itype(kcl: kf.KCLayout) -> None:
+    cell = kcl.kcell()
+    dkcell = kcl.dkcell()
+    dkcell.shapes(0).insert(kf.kdb.DBox(-5, -5, 5, 5))
+    _ = cell << dkcell
+    ref = cell.insts[0]
+    assert isinstance(ref, kf.Instance)
+    assert ref.bbox() == kf.kdb.Box(-5000, -5000, 5000, 5000)
+    dref = ref.to_dtype()
+    assert isinstance(dref, kf.DInstance)
+    assert dref.bbox() == kf.kdb.DBox(-5, -5, 5, 5)
+
+
+def test_to_dtype(kcl: kf.KCLayout) -> None:
+    cell = kcl.dkcell()
+    dkcell = kcl.kcell()
+    dkcell.shapes(0).insert(kf.kdb.DBox(-5, -5, 5, 5))
+    _ = cell << dkcell
+    dref = cell.insts[0]
+    assert isinstance(dref, kf.DInstance)
+    assert dref.bbox() == kf.kdb.DBox(-5, -5, 5, 5)
+    ref = dref.to_itype()
+    assert ref.bbox() == kf.kdb.Box(-5000, -5000, 5000, 5000)
+    assert isinstance(ref, kf.Instance)
+
+
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/tests/test_ports.py
+++ b/tests/test_ports.py
@@ -259,12 +259,52 @@ def test_dplx_port_dbu_port_conversion(LAYER: Layers, kcl: kf.KCLayout) -> None:
 
 def test_ports_eq() -> None:
     kcell = kf.KCell(name="test_ports_eq")
-    dkcell = kf.DKCell.from_kcell(kcell)
+    dkcell = kcell.to_dtype()
 
     port = kf.Port(name="test", layer=1, width=2, center=(0, 0), angle=90)
 
     dkcell.ports = [port]  # type: ignore[assignment]
     assert kcell.ports == [port]
+
+
+def test_to_dtype(kcl: kf.KCLayout) -> None:
+    port = kf.Port(name="o1", width=10, layer=1, center=(1000, 1000), angle=1)
+    dtype = port.to_dtype()
+    assert dtype.name == "o1"
+    assert dtype.width == 0.01
+    assert dtype.layer == 1
+    assert dtype.center == (1, 1)
+    assert dtype.angle == 90
+
+
+def test_to_itype(kcl: kf.KCLayout) -> None:
+    port = kf.DPort(name="o1", width=0.01, layer=1, center=(1, 1), angle=90)
+    itype = port.to_itype()
+    assert itype.name == "o1"
+    assert itype.width == 10
+    assert itype.layer == 1
+    assert itype.center == (1000, 1000)
+    assert itype.angle == 1
+
+
+def test_ports_to_dtype() -> None:
+    port = kf.Port(name="o1", width=10, layer=1, center=(1000, 1000), angle=1)
+    ports = kf.Ports(
+        kcl=kf.kcl,
+        ports=[port],
+    )
+    dtype = ports.to_dtype()
+    assert dtype[0] == port
+
+
+def test_ports_to_itype() -> None:
+    port = kf.DPort(name="o1", width=0.01, layer=1, center=(1, 1), angle=90)
+    ports = kf.DPorts(
+        kcl=kf.kcl,
+        ports=[port],
+    )
+    itype = ports.to_itype()
+    assert itype[0] == port
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary by Sourcery

New Features:
- Added `to_itype` and `to_dtype` functions to `Port`, `Instance`, `InstanceGroup`, `Instances`, `Ports`, `KCell`, and `KCLayout` to allow easy conversion between integer and float representations.