### PR TITLE
Add more ruff rules and performed ruff check fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,6 +133,11 @@ ignore = [
     "TRY003",
     "PLR0913",
     "PLR0912",
+    "PLR0915",
+    "N802",
+    "BLE001",
+    "TC001",
+    "T201",
 ]
 
 [tool.ruff.lint.per-file-ignores]
@@ -149,6 +154,7 @@ ignore = [
     "FBT002",
     "ARG001",
 ]
+"src/kfactory/cli/**/*.py" = ["FBT002"]
 
 [tool.ruff.format]
 # Like Black, use double quotes for strings.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,17 +114,41 @@ target-version = "py311"
 
 [tool.ruff.lint]
 select = [
-    "E",  # pycodestyle
-    "F",  # pyflakes
-    "UP", # pyupgrade
-    # "D",   # pydocstyle
-    "I",   # isort
-    "W",   # pycodestyle
-    "ANN", # annotations
-    "RUF", # ruff
+    "ALL",
+    # "E",   # pycodestyle
+    # "F",   # pyflakes
+    # "UP",  # pyupgrade
+    # "I",   # isort
+    # "W",   # pycodestyle
+    # "ANN", # annotations
+    # "RUF", # ruff
 ]
-ignore = ["ANN401"]
-per-file-ignores = { "tests/*.py" = ["D"] }
+ignore = [
+    "ANN401",
+    "D",
+    "S101",
+    "EM102",
+    "C901",
+    "PLR0911",
+    "TRY003",
+    "PLR0913",
+    "PLR0912",
+]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/*.py" = [
+    "D",
+    "PLR2004",
+    "PLR0915",
+    "N803",
+    "FBT003",
+    "INP001",
+    "FBT001",
+    "EM101",
+    "PT012",
+    "FBT002",
+    "ARG001",
+]
 
 [tool.ruff.format]
 # Like Black, use double quotes for strings.

--- a/src/kfactory/__init__.py
+++ b/src/kfactory/__init__.py
@@ -9,8 +9,8 @@ Uses the klayout package as a backend.
 __version__ = "1.0.3"
 
 import klayout.db as kdb
-import klayout.lay as lay
-import klayout.rdb as rdb
+from klayout import lay
+from klayout import rdb
 
 
 from .conf import config, logger

--- a/src/kfactory/cells/bezier.py
+++ b/src/kfactory/cells/bezier.py
@@ -1,7 +1,7 @@
 """Bezier curve based bends and functions."""
 
-from ..factories.bezier import bend_s_bezier_factory
-from ..layout import kcl
+from kfactory.factories.bezier import bend_s_bezier_factory
+from kfactory.layout import kcl
 
 __all__ = ["bend_s"]
 

--- a/src/kfactory/cells/circular.py
+++ b/src/kfactory/cells/circular.py
@@ -3,8 +3,8 @@
 A circular bend has a constant radius.
 """
 
-from ..factories.circular import bend_circular_factory
-from ..layout import kcl
+from kfactory.factories.circular import bend_circular_factory
+from kfactory.layout import kcl
 
 __all__ = ["bend_circular"]
 

--- a/src/kfactory/cells/euler.py
+++ b/src/kfactory/cells/euler.py
@@ -9,8 +9,8 @@ All the default bends use snapping. To use no snapping make an instance of
 BendEulerCustom(KCell.kcl) and use that one.
 """
 
-from ..factories.euler import bend_euler_factory, bend_s_euler_factory
-from ..layout import kcl
+from kfactory.factories.euler import bend_euler_factory, bend_s_euler_factory
+from kfactory.layout import kcl
 
 __all__ = [
     "bend_euler",

--- a/src/kfactory/cells/straight.py
+++ b/src/kfactory/cells/straight.py
@@ -16,10 +16,10 @@ The slabs and excludes can be given in the form of an
 [Enclosure][kfactory.enclosure.LayerEncolosure].
 """
 
-from .. import KCell, kcl, kdb
-from ..enclosure import LayerEnclosure
-from ..factories.straight import straight_dbu_factory
-from ..typings import um
+from kfactory import KCell, kcl, kdb
+from kfactory.enclosure import LayerEnclosure
+from kfactory.factories.straight import straight_dbu_factory
+from kfactory.typings import um
 
 __all__ = ["straight", "straight_dbu"]
 

--- a/src/kfactory/cells/taper.py
+++ b/src/kfactory/cells/taper.py
@@ -4,10 +4,10 @@ TODO: Non-linear tapers.
 
 """
 
-from .. import KCell, kcl, kdb
-from ..enclosure import LayerEnclosure
-from ..factories.taper import taper_factory
-from ..typings import um
+from kfactory import KCell, kcl, kdb
+from kfactory.enclosure import LayerEnclosure
+from kfactory.factories.taper import taper_factory
+from kfactory.typings import um
 
 __all__ = ["taper", "taper_dbu"]
 

--- a/src/kfactory/cells/virtual/circular.py
+++ b/src/kfactory/cells/virtual/circular.py
@@ -1,7 +1,7 @@
 """Virtual circular cells."""
 
-from ...factories.virtual.circular import virtual_bend_circular_factory
-from ...layout import kcl
+from kfactory.factories.virtual.circular import virtual_bend_circular_factory
+from kfactory.layout import kcl
 
 __all__ = ["virtual_bend_circular"]
 

--- a/src/kfactory/cells/virtual/euler.py
+++ b/src/kfactory/cells/virtual/euler.py
@@ -1,7 +1,7 @@
 """Virtual euler cells."""
 
-from ...factories.virtual.euler import virtual_bend_euler_factory
-from ...layout import kcl
+from kfactory.factories.virtual.euler import virtual_bend_euler_factory
+from kfactory.layout import kcl
 
 __all__ = ["virtual_bend_euler"]
 

--- a/src/kfactory/cells/virtual/straight.py
+++ b/src/kfactory/cells/virtual/straight.py
@@ -1,7 +1,7 @@
 """Straight virtual waveguide cells."""
 
-from ...factories.virtual.straight import virtual_straight_factory
-from ...layout import kcl
+from kfactory.factories.virtual.straight import virtual_straight_factory
+from kfactory.layout import kcl
 
 virtual_straight = virtual_straight_factory(kcl)
 """Default straight on the "default" kcl."""

--- a/src/kfactory/cli/__init__.py
+++ b/src/kfactory/cli/__init__.py
@@ -20,7 +20,8 @@ app.command()(show)
 @app.callback(invoke_without_command=True)
 def version_callback(
     version: Annotated[
-        bool, typer.Option("--version", "-V", help="Show version of the CLI")
+        bool,
+        typer.Option("--version", "-V", help="Show version of the CLI"),
     ] = False,
 ) -> None:
     """Show the version of the cli."""

--- a/src/kfactory/cli/__init__.py
+++ b/src/kfactory/cli/__init__.py
@@ -7,7 +7,8 @@ from typing import Annotated
 
 import typer
 
-from .. import __version__
+from kfactory import __version__
+
 from .build import build, show
 
 app = typer.Typer(name="kf")
@@ -27,4 +28,3 @@ def version_callback(
     """Show the version of the cli."""
     if version:
         print(f"KFactory CLI Version: {__version__}")
-        raise typer.Exit()

--- a/src/kfactory/cli/build.py
+++ b/src/kfactory/cli/build.py
@@ -15,11 +15,11 @@ from typing import Annotated, Optional
 import git
 import typer
 
-from ..conf import logger
-from ..kcell import KCell
-from ..kcell import show as kfshow
-from ..layout import kcls
-from ..utilities import save_layout_options
+from kfactory.conf import logger
+from kfactory.kcell import KCell
+from kfactory.kcell import show as kfshow
+from kfactory.layout import kcls
+from kfactory.utilities import save_layout_options
 
 __all__ = ["build", "show"]
 

--- a/src/kfactory/cli/build.py
+++ b/src/kfactory/cli/build.py
@@ -64,48 +64,52 @@ def build(
         Optional[list[str]],
         typer.Argument(
             help="Arguments used for --type function."
-            " Doesn't have any influence for other types"
+            " Doesn't have any influence for other types",
         ),
     ] = None,
     show: Annotated[
-        bool, typer.Option(help="Show the file through klive in KLayout")
+        bool,
+        typer.Option(help="Show the file through klive in KLayout"),
     ] = True,
     library: Annotated[
         Optional[list[str]],
         typer.Option(
             help="Library(s) used by the main layout file. Only works for functions,"
-            " not for '__main__' modules"
+            " not for '__main__' modules",
         ),
     ] = None,
     suffix: Annotated[
-        LayoutSuffix, typer.Option(help="Format of the layout files")
+        LayoutSuffix,
+        typer.Option(help="Format of the layout files"),
     ] = LayoutSuffix.oas,
     write_full: Annotated[
         bool,
         typer.Option(
             help="Write the gds with full library support. Uses libraries passed with"
-            " --library. Only works in function mode not on modules"
+            " --library. Only works in function mode not on modules",
         ),
     ] = True,
     write_static: Annotated[
         bool,
         typer.Option(
             help="Write a layout where all cells are converted to static (non-library)"
-            " cells."
+            " cells.",
         ),
     ] = False,
     write_nocontext: Annotated[
         bool,
         typer.Option(
             help="Write the layout without any meta infos. This is useful for "
-            "submitting the GDS to fabs."
+            "submitting the GDS to fabs.",
         ),
     ] = False,
     max_vertex_count: Annotated[
-        int, typer.Option(help="Maximum number of vertices per polygon.")
+        int,
+        typer.Option(help="Maximum number of vertices per polygon."),
     ] = 4000,
     max_cellname_length: Annotated[
-        int, typer.Option(help="Maximum number of characters in a cell name.")
+        int,
+        typer.Option(help="Maximum number of characters in a cell name."),
     ] = 99,
 ) -> None:
     """Run a python modules __main__ or a function if specified."""
@@ -195,7 +199,7 @@ def build(
                 logger.critical(
                     f"Couldn't import function '{func}' from module '"
                     f"{file.with_suffix('')}"
-                    "'"
+                    "'",
                 )
         else:
             runpy.run_path(mod_file, run_name="__main__")
@@ -262,7 +266,7 @@ def build(
                         )
             except ImportError:
                 logger.critical(
-                    f"Couldn't import function '{func}' from module '{mod_file}'"
+                    f"Couldn't import function '{func}' from module '{mod_file}'",
                 )
         else:
             runpy.run_module(mod_file, run_name="__main__")

--- a/src/kfactory/conf.py
+++ b/src/kfactory/conf.py
@@ -59,9 +59,9 @@ class ShowFunction(Protocol):
         lyrdb: rdb.ReportDatabase | Path | str | None,
         l2n: kdb.LayoutToNetlist | Path | str | None,
         keep_position: bool,
-        save_options: kdb.SaveLayoutOptions,
+        save_options: kdb.SaveLayoutOptions | None,
         use_libraries: bool,
-        library_save_options: kdb.SaveLayoutOptions,
+        library_save_options: kdb.SaveLayoutOptions | None,
     ) -> None: ...
 
 

--- a/src/kfactory/cross_section.py
+++ b/src/kfactory/cross_section.py
@@ -7,10 +7,10 @@ from typing import TYPE_CHECKING, NotRequired, Self, TypedDict, cast
 
 from pydantic import BaseModel, Field, model_validator
 
-from . import kdb
 from .enclosure import DLayerEnclosure, LayerEnclosure, LayerEnclosureSpec
 
 if TYPE_CHECKING:
+    from . import kdb
     from .layout import KCLayout
 
 
@@ -37,12 +37,16 @@ class SymmetricalCrossSection(BaseModel, frozen=True):
     @model_validator(mode="after")
     def _validate_enclosure_main_layer(self) -> Self:
         if self.enclosure.main_layer is None:
-            raise ValueError("Enclosures of cross sections must have a main layer.")
+            msg = "Enclosures of cross sections must have a main layer."
+            raise ValueError(msg)
         if (self.width // 2) * 2 != self.width:
-            raise ValueError(
+            msg = (
                 "Width of symmetrical cross sections must have be a multiple of 2. "
                 "This could cause cross sections and extrusions to become unsymmetrical"
-                " otherwise.",
+                " otherwise."
+            )
+            raise ValueError(
+                msg,
             )
         return self
 
@@ -135,8 +139,9 @@ class CrossSectionModel(BaseModel):
             else:
                 w = cross_section["width"]
                 if not isinstance(w, int) and not w.is_integer():
+                    msg = "A CrossSectionSpec with 'sections' must have a width in dbu."
                     raise ValueError(
-                        "A CrossSectionSpec with 'sections' must have a width in dbu.",
+                        msg,
                     )
                 cross_section = SymmetricalCrossSection(
                     width=int(w),

--- a/src/kfactory/cross_section.py
+++ b/src/kfactory/cross_section.py
@@ -22,11 +22,16 @@ class SymmetricalCrossSection(BaseModel, frozen=True):
     name: str
 
     def __init__(
-        self, width: int, enclosure: LayerEnclosure, name: str | None = None
+        self,
+        width: int,
+        enclosure: LayerEnclosure,
+        name: str | None = None,
     ) -> None:
         """Initialized the CrossSection."""
         super().__init__(
-            width=width, enclosure=enclosure, name=name or f"{enclosure.name}_{width}"
+            width=width,
+            enclosure=enclosure,
+            name=name or f"{enclosure.name}_{width}",
         )
 
     @model_validator(mode="after")
@@ -37,7 +42,7 @@ class SymmetricalCrossSection(BaseModel, frozen=True):
             raise ValueError(
                 "Width of symmetrical cross sections must have be a multiple of 2. "
                 "This could cause cross sections and extrusions to become unsymmetrical"
-                " otherwise."
+                " otherwise.",
             )
         return self
 
@@ -95,9 +100,10 @@ class CrossSectionModel(BaseModel):
         | DSymmetricalCrossSection,
     ) -> SymmetricalCrossSection:
         if isinstance(
-            cross_section, SymmetricalCrossSection
+            cross_section,
+            SymmetricalCrossSection,
         ) and cross_section.enclosure != self.kcl.get_enclosure(
-            cross_section.enclosure
+            cross_section.enclosure,
         ):
             return self.get_cross_section(
                 CrossSectionSpec(
@@ -105,12 +111,12 @@ class CrossSectionModel(BaseModel):
                     main_layer=cross_section.main_layer,
                     name=cross_section.name,
                     width=cross_section.width,
-                )
+                ),
             )
 
         if isinstance(cross_section, str):
             return self.cross_sections[cross_section]
-        elif isinstance(cross_section, DSymmetricalCrossSection):
+        if isinstance(cross_section, DSymmetricalCrossSection):
             cross_section = cross_section.to_itype(self.kcl)
         elif isinstance(cross_section, dict):
             cast(CrossSectionSpec, cross_section)
@@ -130,7 +136,7 @@ class CrossSectionModel(BaseModel):
                 w = cross_section["width"]
                 if not isinstance(w, int) and not w.is_integer():
                     raise ValueError(
-                        "A CrossSectionSpec with 'sections' must have a width in dbu."
+                        "A CrossSectionSpec with 'sections' must have a width in dbu.",
                     )
                 cross_section = SymmetricalCrossSection(
                     width=int(w),

--- a/src/kfactory/decorators.py
+++ b/src/kfactory/decorators.py
@@ -60,7 +60,8 @@ class KCellDecorator(Protocol):
     """Signature of the `@cell` decorator."""
 
     def __call__(
-        self, **kwargs: Unpack[KCellDecoratorKWargs]
+        self,
+        **kwargs: Unpack[KCellDecoratorKWargs],
     ) -> Callable[[KCellFunc[KCellParams, KC]], KCellFunc[KCellParams, KC]]:
         """__call__ implementation."""
         ...
@@ -70,7 +71,9 @@ class ModuleDecorator(Protocol):
     """Signature of the `@module_cell` decorator."""
 
     def __call__(
-        self, /, **kwargs: Unpack[ModuleCellKWargs]
+        self,
+        /,
+        **kwargs: Unpack[ModuleCellKWargs],
     ) -> Callable[[KCellFunc[KCellParams, KC]], KCellFunc[KCellParams, KC]]:
         """__call__ implementation."""
         ...
@@ -112,7 +115,9 @@ class Decorators:
 
     @overload
     def module_cell(
-        self, /, **kwargs: Unpack[ModuleCellKWargs]
+        self,
+        /,
+        **kwargs: Unpack[ModuleCellKWargs],
     ) -> Callable[[KCellFunc[KCellParams, KC]], KCellFunc[KCellParams, KC]]: ...
 
     def module_cell(  # type: ignore[misc]

--- a/src/kfactory/decorators.py
+++ b/src/kfactory/decorators.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Iterable
 from typing import TYPE_CHECKING, Any, Protocol, TypedDict, overload
 
 from typing_extensions import Unpack
 
 if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable
+
     from cachetools import Cache
 
     from .conf import CHECK_INSTANCES

--- a/src/kfactory/exceptions.py
+++ b/src/kfactory/exceptions.py
@@ -18,7 +18,7 @@ class LockedError(AttributeError):
             f"{kcell.name!r} is locked and likely stored in cache. Modifications are "
             "disabled as its associated function is decorated with `cell`. To modify, "
             "update the code in the function or create a copy of "
-            f"the {kcell.__class__.__name__}."
+            f"the {kcell.__class__.__name__}.",
         )
 
 
@@ -26,7 +26,7 @@ class MergeError(ValueError):
     """Raised if two layout's have conflicting cell definitions."""
 
 
-class PortWidthMismatch(ValueError):
+class PortWidthMismatchError(ValueError):
     """Error thrown when two ports don't have a matching `width`."""
 
     def __init__(
@@ -55,7 +55,7 @@ class PortWidthMismatch(ValueError):
             )
 
 
-class PortLayerMismatch(ValueError):
+class PortLayerMismatchError(ValueError):
     """Error thrown when two ports don't have a matching `layer`."""
 
     def __init__(
@@ -95,7 +95,7 @@ class PortLayerMismatch(ValueError):
             )
 
 
-class PortTypeMismatch(ValueError):
+class PortTypeMismatchError(ValueError):
     """Error thrown when two ports don't have a matching `port_type`."""
 
     def __init__(
@@ -126,3 +126,21 @@ class PortTypeMismatch(ValueError):
 
 class CellNameError(ValueError):
     """Raised if a KCell is created and the automatic assigned name is taken."""
+
+
+class InvalidMetaDataError(ValueError):
+    """Raised if a metadata value is not valid."""
+
+    def __init__(self, value: Any, value_type: type[Any]) -> None:
+        """Throw error for the invalid metadata value `value` of type `type`."""
+        super().__init__(
+            f"{value=} is not a valid metadata type. {value_type=}",
+        )
+
+
+class NonSerializableError(ValueError):
+    """Raised if a value is not serializable."""
+
+    def __init__(self, value: Any, extra_message: str = "") -> None:
+        """Throw error for the non-serializable value `value`."""
+        super().__init__(f"{value=} is not serializable. {extra_message}")

--- a/src/kfactory/exceptions.py
+++ b/src/kfactory/exceptions.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -144,3 +145,11 @@ class NonSerializableError(ValueError):
     def __init__(self, value: Any, extra_message: str = "") -> None:
         """Throw error for the non-serializable value `value`."""
         super().__init__(f"{value=} is not serializable. {extra_message}")
+
+
+class NonInferableReturnAnnotationError(ValueError):
+    """Raised if a function's return annotation cannot be inferred."""
+
+    def __init__(self, func: Callable[..., Any]) -> None:
+        """Throw error for the function `func`."""
+        super().__init__(f"Return annotation cannot be inferred for {func.__name__}")

--- a/src/kfactory/factories/__init__.py
+++ b/src/kfactory/factories/__init__.py
@@ -2,7 +2,8 @@
 
 from typing import Protocol
 
-from .. import DKCell, KCell
+from kfactory import DKCell, KCell
+
 from . import bezier, circular, euler, straight, taper, virtual
 
 

--- a/src/kfactory/factories/bezier.py
+++ b/src/kfactory/factories/bezier.py
@@ -7,12 +7,12 @@ import numpy as np
 import numpy.typing as nty
 from scipy.special import binom  # type:ignore[import-untyped,unused-ignore]
 
-from .. import kdb
-from ..enclosure import LayerEnclosure
-from ..kcell import KCell
-from ..layout import KCLayout
-from ..settings import Info
-from ..typings import MetaData, um
+from kfactory import kdb
+from kfactory.enclosure import LayerEnclosure
+from kfactory.kcell import KCell
+from kfactory.layout import KCLayout
+from kfactory.settings import Info
+from kfactory.typings import MetaData, um
 
 __all__ = ["bend_s_bezier_factory"]
 

--- a/src/kfactory/factories/bezier.py
+++ b/src/kfactory/factories/bezier.py
@@ -57,7 +57,7 @@ def bezier_curve(
         xs += ank * control_points[k][0]
         ys += ank * control_points[k][1]
 
-    return [kdb.DPoint(float(x), float(y)) for x, y in zip(xs, ys)]
+    return [kdb.DPoint(float(x), float(y)) for x, y in zip(xs, ys, strict=False)]
 
 
 def bend_s_bezier_factory(
@@ -138,7 +138,12 @@ def bend_s_bezier_factory(
             enclosure = LayerEnclosure()
 
         enclosure.extrude_path(
-            c, path=pts, main_layer=layer, width=width, start_angle=0, end_angle=0
+            c,
+            path=pts,
+            main_layer=layer,
+            width=width,
+            start_angle=0,
+            end_angle=0,
         )
 
         c.create_port(
@@ -150,7 +155,10 @@ def bend_s_bezier_factory(
         c.create_port(
             width=int(width / c.kcl.dbu),
             trans=kdb.Trans(
-                0, False, c.bbox().right, c.bbox().top - int(width / c.kcl.dbu) // 2
+                0,
+                False,
+                c.bbox().right,
+                c.bbox().top - int(width / c.kcl.dbu) // 2,
             ),
             layer=c.kcl.find_layer(layer),
             port_type="optical",
@@ -166,7 +174,7 @@ def bend_s_bezier_factory(
                 t_start=t_start,
                 t_stop=t_stop,
                 enclosure=enclosure,
-            )
+            ),
         )
         _info.update(_additional_info)
         c.info = Info(**_info)

--- a/src/kfactory/factories/circular.py
+++ b/src/kfactory/factories/circular.py
@@ -8,13 +8,13 @@ from typing import Any, Protocol
 
 import numpy as np
 
-from .. import kdb
-from ..conf import logger
-from ..enclosure import LayerEnclosure, extrude_path
-from ..kcell import KCell
-from ..layout import KCLayout
-from ..settings import Info
-from ..typings import MetaData, deg, um
+from kfactory import kdb
+from kfactory.conf import logger
+from kfactory.enclosure import LayerEnclosure, extrude_path
+from kfactory.kcell import KCell
+from kfactory.layout import KCLayout
+from kfactory.settings import Info
+from kfactory.typings import MetaData, deg, um
 
 __all__ = ["bend_circular_factory"]
 

--- a/src/kfactory/factories/circular.py
+++ b/src/kfactory/factories/circular.py
@@ -114,14 +114,14 @@ def bend_circular_factory(
             logger.critical(
                 f"Negative angles are not allowed {angle} as ports"
                 " will be inverted. Please use a positive number. Forcing positive"
-                " lengths."
+                " lengths.",
             )
             angle = -angle
         if width < 0:
             logger.critical(
                 f"Negative widths are not allowed {width} as ports"
                 " will be inverted. Please use a positive number. Forcing positive"
-                " lengths."
+                " lengths.",
             )
             width = -width
 
@@ -133,7 +133,10 @@ def bend_circular_factory(
                     (-np.cos(_angle / 180 * np.pi) + 1) * r,
                 ]
                 for _angle in np.linspace(
-                    0, angle, int(angle // angle_step + 0.5), endpoint=True
+                    0,
+                    angle,
+                    int(angle // angle_step + 0.5),
+                    endpoint=True,
                 )
             ]
         ]
@@ -169,7 +172,7 @@ def bend_circular_factory(
                 enclosure=enclosure,
                 angle=angle,
                 angle_step=angle_step,
-            )
+            ),
         )
         _info.update(_additional_info)
         c.info = Info(**_info)

--- a/src/kfactory/factories/euler.py
+++ b/src/kfactory/factories/euler.py
@@ -16,13 +16,13 @@ import numpy as np
 from scipy.optimize import brentq  # type:ignore[import-untyped,unused-ignore]
 from scipy.special import fresnel  # type:ignore[import-untyped,unused-ignore]
 
-from .. import kdb
-from ..conf import logger
-from ..enclosure import LayerEnclosure, extrude_path
-from ..kcell import KCell
-from ..layout import KCLayout
-from ..settings import Info
-from ..typings import MetaData, deg, um
+from kfactory import kdb
+from kfactory.conf import logger
+from kfactory.enclosure import LayerEnclosure, extrude_path
+from kfactory.kcell import KCell
+from kfactory.layout import KCLayout
+from kfactory.settings import Info
+from kfactory.typings import MetaData, deg, um
 
 __all__ = [
     "bend_euler_factory",
@@ -142,9 +142,8 @@ def euler_bend_points(
     step = Ltot / max(int(th * resolution), 1)
 
     # Generate points
-    points = [_xy(i * step) for i in range(int(round(Ltot / step)) + 1)]
+    return [_xy(i * step) for i in range(int(round(Ltot / step)) + 1)]
 
-    return points
 
 
 def euler_endpoint(

--- a/src/kfactory/factories/euler.py
+++ b/src/kfactory/factories/euler.py
@@ -79,7 +79,9 @@ class BendSEulerFactory(Protocol):
 
 
 def euler_bend_points(
-    angle_amount: deg = 90, radius: um = 100, resolution: float = 150
+    angle_amount: deg = 90,
+    radius: um = 100,
+    resolution: float = 150,
 ) -> list[kdb.DPoint]:
     """Base euler bend, no transformation, emerging from the origin."""
     if angle_amount < 0:
@@ -110,7 +112,7 @@ def euler_bend_points(
     def _xy(s: float) -> kdb.DPoint:
         if th == 0:
             return kdb.DPoint(0, 0)
-        elif s <= Ltot / 2:
+        if s <= Ltot / 2:
             (fsin, fcos) = fresnel(s / (sq2pi * a))
             X = sq2pi * a * fcos
             Y = sq2pi * a * fsin
@@ -170,7 +172,9 @@ def euler_endpoint(
 
 
 def euler_sbend_points(
-    offset: um = 5.0, radius: um = 10.0e-6, resolution: float = 150
+    offset: um = 5.0,
+    radius: um = 10.0e-6,
+    resolution: float = 150,
 ) -> list[kdb.DPoint]:
     """An Euler s-bend with parallel input and output, separated by an offset."""
 
@@ -285,14 +289,14 @@ def bend_euler_factory(
             logger.critical(
                 f"Negative lengths are not allowed {angle} as ports"
                 " will be inverted. Please use a positive number. Forcing positive"
-                " lengths."
+                " lengths.",
             )
             angle = -angle
         if width < 0:
             logger.critical(
                 f"Negative widths are not allowed {width} as ports"
                 " will be inverted. Please use a positive number. Forcing positive"
-                " lengths."
+                " lengths.",
             )
             width = -width
         backbone = euler_bend_points(angle, radius=radius, resolution=resolution)
@@ -335,7 +339,7 @@ def bend_euler_factory(
                 enclosure=enclosure,
                 angle=angle,
                 resolution=resolution,
-            )
+            ),
         )
         _info.update(_additional_info)
         c.info = Info(**_info)
@@ -411,7 +415,7 @@ def bend_s_euler_factory(
             logger.critical(
                 f"Negative widths are not allowed {width} as ports"
                 " will be inverted. Please use a positive number. Forcing positive"
-                " lengths."
+                " lengths.",
             )
             width = -width
         backbone = euler_sbend_points(
@@ -459,7 +463,7 @@ def bend_s_euler_factory(
                 layer=layer,
                 enclosure=enclosure,
                 resolution=resolution,
-            )
+            ),
         )
         _info.update(_additional_info)
         c.info = Info(**_info)

--- a/src/kfactory/factories/straight.py
+++ b/src/kfactory/factories/straight.py
@@ -19,13 +19,13 @@ The slabs and excludes can be given in the form of an
 from collections.abc import Callable
 from typing import Any, Protocol
 
-from .. import kdb
-from ..conf import logger
-from ..enclosure import LayerEnclosure
-from ..kcell import KCell
-from ..layout import KCLayout
-from ..settings import Info
-from ..typings import MetaData, dbu
+from kfactory import kdb
+from kfactory.conf import logger
+from kfactory.enclosure import LayerEnclosure
+from kfactory.kcell import KCell
+from kfactory.layout import KCLayout
+from kfactory.settings import Info
+from kfactory.typings import MetaData, dbu
 
 __all__ = ["straight_dbu_factory"]
 
@@ -145,7 +145,8 @@ def straight_dbu_factory(
             width = -width
 
         if width // 2 * 2 != width:
-            raise ValueError("The width (w) must be a multiple of 2 database units")
+            msg = "The width (w) must be a multiple of 2 database units"
+            raise ValueError(msg)
 
         li = c.kcl.find_layer(layer)
         c.shapes(li).insert(kdb.Box(0, -width // 2, length, width // 2))

--- a/src/kfactory/factories/straight.py
+++ b/src/kfactory/factories/straight.py
@@ -133,14 +133,14 @@ def straight_dbu_factory(
             logger.critical(
                 f"Negative lengths are not allowed {length} as ports"
                 " will be inverted. Please use a positive number. Forcing positive"
-                " lengths."
+                " lengths.",
             )
             length = -length
         if width < 0:
             logger.critical(
                 f"Negative widths are not allowed {width} as ports"
                 " will be inverted. Please use a positive number. Forcing positive"
-                " lengths."
+                " lengths.",
             )
             width = -width
 
@@ -162,8 +162,11 @@ def straight_dbu_factory(
         }
         _info.update(
             _additional_info_func(
-                width=width, length=length, layer=layer, enclosure=enclosure
-            )
+                width=width,
+                length=length,
+                layer=layer,
+                enclosure=enclosure,
+            ),
         )
         _info.update(_additional_info)
         c.info = Info(**_info)

--- a/src/kfactory/factories/taper.py
+++ b/src/kfactory/factories/taper.py
@@ -6,13 +6,13 @@ TODO: Non-linear tapers
 from collections.abc import Callable
 from typing import Any, Protocol
 
-from .. import kdb
-from ..conf import logger
-from ..enclosure import LayerEnclosure
-from ..kcell import KCell
-from ..layout import KCLayout, kcl
-from ..settings import Info
-from ..typings import MetaData, dbu
+from kfactory import kdb
+from kfactory.conf import logger
+from kfactory.enclosure import LayerEnclosure
+from kfactory.kcell import KCell
+from kfactory.layout import KCLayout, kcl
+from kfactory.settings import Info
+from kfactory.typings import MetaData, dbu
 
 __all__ = ["taper"]
 

--- a/src/kfactory/factories/taper.py
+++ b/src/kfactory/factories/taper.py
@@ -138,14 +138,14 @@ def taper_factory(
             logger.critical(
                 f"Negative lengths are not allowed {length} as ports"
                 " will be inverted. Please use a positive number. Forcing positive"
-                " lengths."
+                " lengths.",
             )
             length = -length
         if width1 < 0:
             logger.critical(
                 f"Negative widths are not allowed {width1} as ports"
                 " will be inverted. Please use a positive number. Forcing positive"
-                " lengths."
+                " lengths.",
             )
             width1 = -width1
 
@@ -153,7 +153,7 @@ def taper_factory(
             logger.critical(
                 f"Negative widths are not allowed {width2} as ports"
                 " will be inverted. Please use a positive number. Forcing positive"
-                " lengths."
+                " lengths.",
             )
             width2 = -width2
 
@@ -165,8 +165,8 @@ def taper_factory(
                     kdb.Point(0, width1 // 2),
                     kdb.Point(length, width2 // 2),
                     kdb.Point(length, int(-width2 / 2)),
-                ]
-            )
+                ],
+            ),
         )
 
         c.create_port(trans=kdb.Trans(2, False, 0, 0), width=width1, layer=li)
@@ -189,7 +189,7 @@ def taper_factory(
                 length=length,
                 layer=layer,
                 enclosure=enclosure,
-            )
+            ),
         )
         _info.update(_additional_info)
         c.info = Info(**_info)

--- a/src/kfactory/factories/virtual/circular.py
+++ b/src/kfactory/factories/virtual/circular.py
@@ -5,13 +5,14 @@ from typing import Any, Protocol
 
 import numpy as np
 
-from ... import kdb
-from ...conf import logger
-from ...enclosure import LayerEnclosure
-from ...kcell import VKCell
-from ...layout import KCLayout
-from ...settings import Info
-from ...typings import MetaData
+from kfactory import kdb
+from kfactory.conf import logger
+from kfactory.enclosure import LayerEnclosure
+from kfactory.kcell import VKCell
+from kfactory.layout import KCLayout
+from kfactory.settings import Info
+from kfactory.typings import MetaData
+
 from .utils import extrude_backbone
 
 __all__ = ["virtual_bend_circular_factory"]

--- a/src/kfactory/factories/virtual/circular.py
+++ b/src/kfactory/factories/virtual/circular.py
@@ -108,14 +108,14 @@ def virtual_bend_circular_factory(
             logger.critical(
                 f"Negative lengths are not allowed {angle} as ports"
                 " will be inverted. Please use a positive number. Forcing positive"
-                " lengths."
+                " lengths.",
             )
             angle = -angle
         if width < 0:
             logger.critical(
                 f"Negative widths are not allowed {width} as ports"
                 " will be inverted. Please use a positive number. Forcing positive"
-                " lengths."
+                " lengths.",
             )
             width = -width
         dbu = c.kcl.dbu
@@ -127,7 +127,10 @@ def virtual_bend_circular_factory(
                     (-np.cos(_angle / 180 * np.pi) + 1) * radius,
                 ]
                 for _angle in np.linspace(
-                    0, angle, int(angle // angle_step + 0.5), endpoint=True
+                    0,
+                    angle,
+                    int(angle // angle_step + 0.5),
+                    endpoint=True,
                 )
             ]
         ]
@@ -151,7 +154,7 @@ def virtual_bend_circular_factory(
                 enclosure=enclosure,
                 angle=angle,
                 angle_step=angle_step,
-            )
+            ),
         )
         _info.update(_additional_info)
         c.info = Info(**_info)

--- a/src/kfactory/factories/virtual/euler.py
+++ b/src/kfactory/factories/virtual/euler.py
@@ -3,14 +3,15 @@
 from collections.abc import Callable
 from typing import Any, Protocol
 
-from ... import kdb
-from ...conf import logger
-from ...enclosure import LayerEnclosure
-from ...factories.euler import euler_bend_points
-from ...kcell import VKCell
-from ...layout import KCLayout
-from ...settings import Info
-from ...typings import MetaData
+from kfactory import kdb
+from kfactory.conf import logger
+from kfactory.enclosure import LayerEnclosure
+from kfactory.factories.euler import euler_bend_points
+from kfactory.kcell import VKCell
+from kfactory.layout import KCLayout
+from kfactory.settings import Info
+from kfactory.typings import MetaData
+
 from .utils import extrude_backbone
 
 

--- a/src/kfactory/factories/virtual/euler.py
+++ b/src/kfactory/factories/virtual/euler.py
@@ -105,14 +105,14 @@ def virtual_bend_euler_factory(
             logger.critical(
                 f"Negative lengths are not allowed {angle} as ports"
                 " will be inverted. Please use a positive number. Forcing positive"
-                " lengths."
+                " lengths.",
             )
             angle = -angle
         if width < 0:
             logger.critical(
                 f"Negative widths are not allowed {width} as ports"
                 " will be inverted. Please use a positive number. Forcing positive"
-                " lengths."
+                " lengths.",
             )
             width = -width
         dbu = c.kcl.dbu
@@ -136,7 +136,7 @@ def virtual_bend_euler_factory(
                 layer=layer,
                 enclosure=enclosure,
                 angle=angle,
-            )
+            ),
         )
         _info.update(_additional_info)
         c.info = Info(**_info)

--- a/src/kfactory/factories/virtual/straight.py
+++ b/src/kfactory/factories/virtual/straight.py
@@ -111,14 +111,14 @@ def virtual_straight_factory(
             logger.critical(
                 f"Negative lengths are not allowed {length} as ports"
                 " will be inverted. Please use a positive number. Forcing positive"
-                " lengths."
+                " lengths.",
             )
             length = -length
         if width < 0:
             logger.critical(
                 f"Negative widths are not allowed {width} as ports"
                 " will be inverted. Please use a positive number. Forcing positive"
-                " lengths."
+                " lengths.",
             )
             width = -width
 
@@ -140,7 +140,7 @@ def virtual_straight_factory(
                 length=length,
                 layer=layer,
                 enclosure=enclosure,
-            )
+            ),
         )
         _info.update(_additional_info)
         c.info = Info(**_info)

--- a/src/kfactory/factories/virtual/straight.py
+++ b/src/kfactory/factories/virtual/straight.py
@@ -3,13 +3,14 @@
 from collections.abc import Callable
 from typing import Any, Protocol
 
-from ... import kdb
-from ...conf import logger
-from ...enclosure import LayerEnclosure
-from ...kcell import VKCell
-from ...layout import KCLayout, vcell
-from ...settings import Info
-from ...typings import MetaData
+from kfactory import kdb
+from kfactory.conf import logger
+from kfactory.enclosure import LayerEnclosure
+from kfactory.kcell import VKCell
+from kfactory.layout import KCLayout, vcell
+from kfactory.settings import Info
+from kfactory.typings import MetaData
+
 from .utils import extrude_backbone
 
 __all__ = ["virtual_straight_factory"]

--- a/src/kfactory/factories/virtual/utils.py
+++ b/src/kfactory/factories/virtual/utils.py
@@ -2,9 +2,9 @@
 
 from collections.abc import Sequence
 
-from ... import kdb
-from ...enclosure import LayerEnclosure, extrude_path_points
-from ...kcell import VKCell
+from kfactory import kdb
+from kfactory.enclosure import LayerEnclosure, extrude_path_points
+from kfactory.kcell import VKCell
 
 
 def extrude_backbone(

--- a/src/kfactory/factories/virtual/utils.py
+++ b/src/kfactory/factories/virtual/utils.py
@@ -30,11 +30,14 @@ def extrude_backbone(
         dbu: database unit to use as a reference
     """
     center_path_l, center_path_r = extrude_path_points(
-        backbone, width=width, start_angle=start_angle, end_angle=end_angle
+        backbone,
+        width=width,
+        start_angle=start_angle,
+        end_angle=end_angle,
     )
     center_path_r.reverse()
     c.shapes(c.kcl.find_layer(layer)).insert(
-        kdb.DPolygon(center_path_l + center_path_r)
+        kdb.DPolygon(center_path_l + center_path_r),
     )
 
     if enclosure:

--- a/src/kfactory/geometry.py
+++ b/src/kfactory/geometry.py
@@ -128,7 +128,7 @@ class GeometricObject(Generic[TUnit], ABC):
     @abstractmethod
     def _standard_trans(self: GeometricObject[float]) -> type[kdb.DCplxTrans]: ...
     @abstractmethod
-    def _standard_trans(self) -> type[kdb.Trans] | type[kdb.DCplxTrans]: ...
+    def _standard_trans(self) -> type[kdb.Trans | kdb.DCplxTrans]: ...
 
     @abstractmethod
     def transform(
@@ -228,8 +228,9 @@ class GeometricObject(Generic[TUnit], ABC):
         """Moves self so that the bbox's center coordinate."""
         self.transform(
             self._standard_trans()(
-                __val[0] - self.bbox().center().x, __val[1] - self.bbox().center().y
-            )
+                __val[0] - self.bbox().center().x,
+                __val[1] - self.bbox().center().y,
+            ),
         )
 
     @overload
@@ -237,7 +238,9 @@ class GeometricObject(Generic[TUnit], ABC):
 
     @overload
     def move(
-        self, origin: tuple[TUnit, TUnit], destination: tuple[TUnit, TUnit]
+        self,
+        origin: tuple[TUnit, TUnit],
+        destination: tuple[TUnit, TUnit],
     ) -> Self: ...
 
     def move(
@@ -256,8 +259,9 @@ class GeometricObject(Generic[TUnit], ABC):
         else:
             self.transform(
                 self._standard_trans()(
-                    destination[0] - origin[0], destination[1] - origin[1]
-                )
+                    destination[0] - origin[0],
+                    destination[1] - origin[1],
+                ),
             )
         return self
 
@@ -306,7 +310,9 @@ class GeometricObject(Generic[TUnit], ABC):
 
     @abstractmethod
     def mirror(
-        self, p1: tuple[TUnit, TUnit] = ..., p2: tuple[TUnit, TUnit] = ...
+        self,
+        p1: tuple[TUnit, TUnit] = ...,
+        p2: tuple[TUnit, TUnit] = ...,
     ) -> Self:
         """Mirror self at a line."""
         ...
@@ -412,8 +418,9 @@ class GeometricObject(Generic[TUnit], ABC):
         """Moves self so that the bbox's center coordinate."""
         self.transform(
             kdb.Trans(
-                val[0] - self.ibbox().center().x, val[1] - self.ibbox().center().y
-            )
+                val[0] - self.ibbox().center().x,
+                val[1] - self.ibbox().center().y,
+            ),
         )
 
     @overload
@@ -421,11 +428,15 @@ class GeometricObject(Generic[TUnit], ABC):
 
     @overload
     def imove(
-        self, origin: tuple[int, int], destination: tuple[int, int] | None = None
+        self,
+        origin: tuple[int, int],
+        destination: tuple[int, int] | None = None,
     ) -> Self: ...
 
     def imove(
-        self, origin: tuple[int, int], destination: tuple[int, int] | None = None
+        self,
+        origin: tuple[int, int],
+        destination: tuple[int, int] | None = None,
     ) -> Self:
         """Move self in dbu.
 
@@ -437,7 +448,7 @@ class GeometricObject(Generic[TUnit], ABC):
             self.transform(kdb.Trans(*origin))
         else:
             self.transform(
-                kdb.Trans(destination[0] - origin[0], destination[1] - origin[1])
+                kdb.Trans(destination[0] - origin[0], destination[1] - origin[1]),
             )
         return self
 
@@ -491,7 +502,9 @@ class GeometricObject(Generic[TUnit], ABC):
         return self
 
     def imirror(
-        self, p1: tuple[int, int] = (1000, 0), p2: tuple[int, int] = (0, 0)
+        self,
+        p1: tuple[int, int] = (1000, 0),
+        p2: tuple[int, int] = (0, 0),
     ) -> Self:
         """Mirror self at a line."""
         p1_ = kdb.Point(p1[0], p1[1]).to_dtype(self.kcl.dbu)
@@ -508,7 +521,7 @@ class GeometricObject(Generic[TUnit], ABC):
         cross_point = dedge.cut_point(dedge_disp)
 
         self.transform(
-            kdb.DCplxTrans(1.0, angle, True, (cross_point.to_v() - disp) * 2)
+            kdb.DCplxTrans(1.0, angle, True, (cross_point.to_v() - disp) * 2),
         )
 
         return self
@@ -614,8 +627,9 @@ class GeometricObject(Generic[TUnit], ABC):
         """Moves self so that the bbox's center coordinate in um."""
         self.transform(
             kdb.DTrans(
-                val[0] - self.dbbox().center().x, val[1] - self.dbbox().center().y
-            )
+                val[0] - self.dbbox().center().x,
+                val[1] - self.dbbox().center().y,
+            ),
         )
 
     @overload
@@ -643,7 +657,7 @@ class GeometricObject(Generic[TUnit], ABC):
             self.transform(kdb.DCplxTrans(*origin))
         else:
             self.transform(
-                kdb.DCplxTrans(destination[0] - origin[0], destination[1] - origin[1])
+                kdb.DCplxTrans(destination[0] - origin[0], destination[1] - origin[1]),
             )
         return self
 
@@ -702,7 +716,9 @@ class GeometricObject(Generic[TUnit], ABC):
         return self
 
     def dmirror(
-        self, p1: tuple[float, float] = (1, 0), p2: tuple[float, float] = (0, 0)
+        self,
+        p1: tuple[float, float] = (1, 0),
+        p2: tuple[float, float] = (0, 0),
     ) -> Self:
         """Mirror self at a line."""
         p1_ = kdb.DPoint(p1[0], p1[1])
@@ -720,7 +736,7 @@ class GeometricObject(Generic[TUnit], ABC):
         cross_point = dedge.cut_point(dedge_disp)
 
         self.transform(
-            kdb.DCplxTrans(1.0, angle, True, (cross_point.to_v() - disp) * 2)
+            kdb.DCplxTrans(1.0, angle, True, (cross_point.to_v() - disp) * 2),
         )
 
         return self
@@ -765,7 +781,9 @@ class DBUGeometricObject(GeometricObject[int], ABC):
         return self.imirror_y(y)
 
     def mirror(
-        self, p1: tuple[int, int] = (1000, 0), p2: tuple[int, int] = (0, 0)
+        self,
+        p1: tuple[int, int] = (1000, 0),
+        p2: tuple[int, int] = (0, 0),
     ) -> Self:
         return self.imirror(p1, p2)
 
@@ -787,6 +805,8 @@ class UMGeometricObject(GeometricObject[float], ABC):
         return self.dmirror_y(y)
 
     def mirror(
-        self, p1: tuple[float, float] = (1, 0), p2: tuple[float, float] = (0, 0)
+        self,
+        p1: tuple[float, float] = (1, 0),
+        p2: tuple[float, float] = (0, 0),
     ) -> Self:
         return self.dmirror(p1, p2)

--- a/src/kfactory/geometry.py
+++ b/src/kfactory/geometry.py
@@ -6,12 +6,12 @@ from typing import TYPE_CHECKING, Generic, Self, overload
 import numpy as np
 
 from . import kdb
-from .protocols import BoxFunction, BoxLike
 from .typings import TUnit
 
 if TYPE_CHECKING:
     from .layer import LayerEnum
     from .layout import KCLayout
+    from .protocols import BoxFunction, BoxLike
 
 
 class SizeInfo(Generic[TUnit]):

--- a/src/kfactory/instance_group.py
+++ b/src/kfactory/instance_group.py
@@ -26,7 +26,7 @@ class ProtoInstanceGroup(Generic[TUnit, TInstance], GeometricObject[TUnit]):
         except IndexError as e:
             raise ValueError(
                 "Cannot transform or retrieve the KCLayout "
-                "of an instance group if it's empty"
+                "of an instance group if it's empty",
             ) from e
 
     @kcl.setter
@@ -34,7 +34,8 @@ class ProtoInstanceGroup(Generic[TUnit, TInstance], GeometricObject[TUnit]):
         raise ValueError("KCLayout cannot be set on an instance group.")
 
     def transform(
-        self, trans: kdb.Trans | kdb.DTrans | kdb.ICplxTrans | kdb.DCplxTrans
+        self,
+        trans: kdb.Trans | kdb.DTrans | kdb.ICplxTrans | kdb.DCplxTrans,
     ) -> None:
         """Transform the instance group."""
         for inst in self.insts:
@@ -76,8 +77,6 @@ class InstanceGroup(ProtoTInstanceGroup[int], DBUGeometricObject):
     Args:
         insts: List of the instances of the group.
     """
-
-    ...
 
 
 class DInstanceGroup(ProtoTInstanceGroup[float], UMGeometricObject):

--- a/src/kfactory/instance_group.py
+++ b/src/kfactory/instance_group.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
 from typing import TYPE_CHECKING, Generic, NoReturn
 
 from . import kdb
@@ -9,6 +8,8 @@ from .instance import ProtoTInstance, VInstance
 from .typings import TInstance, TUnit
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from .layout import KCLayout
 
 
@@ -24,14 +25,18 @@ class ProtoInstanceGroup(Generic[TUnit, TInstance], GeometricObject[TUnit]):
         try:
             return self.insts[0].kcl
         except IndexError as e:
-            raise ValueError(
+            msg = (
                 "Cannot transform or retrieve the KCLayout "
-                "of an instance group if it's empty",
+                "of an instance group if it's empty"
+            )
+            raise ValueError(
+                msg,
             ) from e
 
     @kcl.setter
-    def kcl(self, val: KCLayout) -> NoReturn:
-        raise ValueError("KCLayout cannot be set on an instance group.")
+    def kcl(self, _val: KCLayout) -> NoReturn:
+        msg = "KCLayout cannot be set on an instance group."
+        raise ValueError(msg)
 
     def transform(
         self,

--- a/src/kfactory/instance_ports.py
+++ b/src/kfactory/instance_ports.py
@@ -1,12 +1,10 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from collections.abc import Callable, Iterable, Iterator, Sequence
 from typing import TYPE_CHECKING, Any, Generic, cast
 
 from . import kdb
 from .conf import config
-from .layer import LayerEnum
 from .port import (
     BasePort,
     DPort,
@@ -23,7 +21,10 @@ from .typings import TUnit
 from .utilities import pprint_ports
 
 if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable, Iterator, Sequence
+
     from .instance import DInstance, Instance, ProtoTInstance, VInstance
+    from .layer import LayerEnum
 
 
 class HasCellPorts(Generic[TUnit], ABC):
@@ -61,10 +62,7 @@ class ProtoTInstancePorts(ProtoInstancePorts[TUnit], ABC):
         """Check whether a port is in this port collection."""
         if isinstance(port, ProtoPort):
             return port.base in [p.base for p in self.instance.ports]
-        for _port in self.instance.ports:
-            if _port.name == port:
-                return True
-        return False
+        return any(_port.name == port for _port in self.instance.ports)
 
     @property
     def ports(self) -> ProtoTInstancePorts[TUnit]:

--- a/src/kfactory/instances.py
+++ b/src/kfactory/instances.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from collections.abc import Iterator
 from typing import TYPE_CHECKING, Any, Generic
 
 import klayout.db as kdb
@@ -17,6 +16,8 @@ from .instance import (
 from .typings import TInstance, TUnit
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from .kcell import TKCell
 
 

--- a/src/kfactory/instances.py
+++ b/src/kfactory/instances.py
@@ -62,10 +62,9 @@ class ProtoTInstances(ProtoInstances[TUnit, ProtoTInstance[TUnit]], ABC):
         try:
             if isinstance(item, kdb.Instance):
                 return next(filter(lambda inst: inst == item, self._insts))
-            else:
-                return next(
-                    filter(lambda inst: inst.property(PROPID.NAME) == item, self._insts)
-                )
+            return next(
+                filter(lambda inst: inst.property(PROPID.NAME) == item, self._insts),
+            )
         except StopIteration as e:
             raise ValueError(f"Instance {item} not found in {self._tkcell}") from e
 
@@ -80,11 +79,10 @@ class ProtoTInstances(ProtoInstances[TUnit, ProtoTInstance[TUnit]], ABC):
             if isinstance(key, ProtoTInstance):
                 self._get_inst(key.instance)
                 return True
-            elif isinstance(key, str):
+            if isinstance(key, str):
                 self._get_inst(key)
                 return True
-            else:
-                return key < len(self)
+            return key < len(self)
             return False
         except ValueError:
             return False
@@ -126,8 +124,7 @@ class Instances(ProtoTInstances[int]):
         """Retrieve instance by index or by name."""
         if isinstance(key, int):
             return Instance(kcl=self._tkcell.kcl, instance=list(self._insts)[key])
-        else:
-            return Instance(kcl=self._tkcell.kcl, instance=self._get_inst(key))
+        return Instance(kcl=self._tkcell.kcl, instance=self._get_inst(key))
 
 
 class DInstances(ProtoTInstances[float]):
@@ -146,8 +143,7 @@ class DInstances(ProtoTInstances[float]):
         """Retrieve instance by index or by name."""
         if isinstance(key, int):
             return DInstance(kcl=self._tkcell.kcl, instance=list(self._insts)[key])
-        else:
-            return DInstance(kcl=self._tkcell.kcl, instance=self._get_inst(key))
+        return DInstance(kcl=self._tkcell.kcl, instance=self._get_inst(key))
 
 
 class VInstances(ProtoInstances[float, VInstance]):

--- a/src/kfactory/kcell.py
+++ b/src/kfactory/kcell.py
@@ -3017,7 +3017,7 @@ class VKCell(ProtoKCell[float], UMGeometricObject):
                 polys[w] = poly
             self.shapes(port.layer).insert(poly.transformed(port.dcplx_trans))
             self.shapes(port.layer).insert(
-                kdb.Text(port.name if port.name else "", port.trans),
+                kdb.Text(port.name or "", port.trans),
             )
 
     def write(

--- a/src/kfactory/kcell.py
+++ b/src/kfactory/kcell.py
@@ -937,7 +937,7 @@ class ProtoTKCell(ProtoKCell[TUnit], ABC):
             else:
                 self.shapes(port.layer).insert(poly, port.dcplx_trans)
                 self.shapes(port.layer).insert(
-                    kdb.Text(port.name if port.name else "", port.trans),
+                    kdb.Text(port.name or "", port.trans),
                 )
         self._base_kcell.kdb_cell.locked = locked
 

--- a/src/kfactory/layer.py
+++ b/src/kfactory/layer.py
@@ -46,14 +46,14 @@ class LayerInfos(BaseModel):
             if not isinstance(f, kdb.LayerInfo):
                 raise InvalidLayerError(
                     "All fields in LayerInfos must be of type kdb.LayerInfo. "
-                    f"Field {field_name} is of type {type(f)}"
+                    f"Field {field_name} is of type {type(f)}",
                 )
             if not f.is_named():
                 f.name = field_name
             if f.layer == -1 or f.datatype == -1:
                 raise InvalidLayerError(
                     "Layers must specify layer number and datatype."
-                    f" {field_name} didn't specify them"
+                    f" {field_name} didn't specify them",
                 )
         return self
 
@@ -103,14 +103,13 @@ class LayerEnum(int, Enum):  # type: ignore[misc]
         """Retrieve layer number[0] / datatype[1] of a layer."""
         if key == 0:
             return self.layer
-        elif key == 1:
+        if key == 1:
             return self.datatype
 
-        else:
-            raise ValueError(
-                "LayerMap only has two values accessible like"
-                " a list, layer == [0] and datatype == [1]"
-            )
+        raise ValueError(
+            "LayerMap only has two values accessible like"
+            " a list, layer == [0] and datatype == [1]",
+        )
 
     def __len__(self) -> int:
         """A layer has length 2, layer number and datatype."""
@@ -259,7 +258,7 @@ def layerenum_from_dict(
     from .layout import get_default_kcl
 
     members: dict[str, constant[KCLayout] | tuple[int, int]] = {
-        "layout": constant(layout or get_default_kcl().layout)
+        "layout": constant(layout or get_default_kcl().layout),
     }
     for li in layers.model_dump().values():
         members[li.name] = li.layer, li.datatype

--- a/src/kfactory/layer.py
+++ b/src/kfactory/layer.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Iterator
 from typing import TYPE_CHECKING, Any, Self
 
 import klayout.db as kdb
@@ -10,6 +9,8 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 from .settings import Info
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from .layout import KCLayout
 
 
@@ -79,10 +80,10 @@ class LayerEnum(int, Enum):  # type: ignore[misc]
         self.layout.set_info(self, kdb.LayerInfo(self.layer, self.datatype, self.name))
 
     def __new__(  # type: ignore[misc]
-        cls: LayerEnum,
+        cls,
         layer: int,
         datatype: int,
-    ) -> LayerEnum:
+    ) -> Self:
         """Create a new Enum.
 
         Because it needs to act like an integer an enum is created and expanded.
@@ -106,9 +107,12 @@ class LayerEnum(int, Enum):  # type: ignore[misc]
         if key == 1:
             return self.datatype
 
-        raise ValueError(
+        msg = (
             "LayerMap only has two values accessible like"
-            " a list, layer == [0] and datatype == [1]",
+            " a list, layer == [0] and datatype == [1]"
+        )
+        raise ValueError(
+            msg,
         )
 
     def __len__(self) -> int:

--- a/src/kfactory/merge.py
+++ b/src/kfactory/merge.py
@@ -2,12 +2,15 @@ from __future__ import annotations
 
 from collections import defaultdict
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
 
 from pydantic import ConfigDict
 
 from . import kdb
 from .conf import LogLevel, logger
-from .typings import MetaData
+
+if TYPE_CHECKING:
+    from .typings import MetaData
 
 
 @dataclass
@@ -84,8 +87,8 @@ class MergeDiff:
         cell = self.layout_a.cell(instance.cell_index)
 
         regions: list[kdb.Region] = []
-        layers = [layer for layer in cell.layout().layer_indexes()]
-        layer_infos = [li for li in cell.layout().layer_infos()]
+        layers = list(cell.layout().layer_indexes())
+        layer_infos = list(cell.layout().layer_infos())
 
         for layer in layers:
             r = kdb.Region()
@@ -102,8 +105,8 @@ class MergeDiff:
         cell = self.layout_b.cell(instance.cell_index)
 
         regions: list[kdb.Region] = []
-        layers = [layer for layer in cell.layout().layer_indexes()]
-        layer_infos = [li for li in cell.layout().layer_infos()]
+        layers = list(cell.layout().layer_indexes())
+        layer_infos = list(cell.layout().layer_infos())
 
         for layer in layers:
             r = kdb.Region()

--- a/src/kfactory/merge.py
+++ b/src/kfactory/merge.py
@@ -93,7 +93,7 @@ class MergeDiff:
             regions.append(r)
 
         for trans in instance.each_cplx_trans():
-            for li, r in zip(layer_infos, regions):
+            for li, r in zip(layer_infos, regions, strict=False):
                 self.cell_a.shapes(self.diff_a.layer(li)).insert(r.transformed(trans))
 
     def on_instance_in_b_only(self, instance: kdb.CellInstArray, propid: int) -> None:
@@ -111,7 +111,7 @@ class MergeDiff:
             regions.append(r)
 
         for trans in instance.each_cplx_trans():
-            for li, r in zip(layer_infos, regions):
+            for li, r in zip(layer_infos, regions, strict=False):
                 self.cell_b.shapes(self.diff_b.layer(li)).insert(r.transformed(trans))
 
     def on_polygon_in_b_only(self, poly: kdb.Polygon, propid: int) -> None:
@@ -129,7 +129,7 @@ class MergeDiff:
 
             c.shapes(self.diff_xor.layer(self.layer)).insert(
                 kdb.Region(self.cell_a.shapes(self.layer_a))
-                ^ kdb.Region(self.cell_b.shapes(self.layer_b))
+                ^ kdb.Region(self.cell_b.shapes(self.layer_b)),
             )
 
     def on_cell_meta_info_differs(
@@ -154,17 +154,17 @@ class MergeDiff:
         else:
             logger.error(
                 f"'{name}' MetaInfo differs between existing '{meta_a!s}' and"
-                f" loaded '{meta_b!s}'"
+                f" loaded '{meta_b!s}'",
             )
             self.cells_meta_diff[self.cell_a.name][name] = {
                 "existing": str(meta_a),
                 "loaded": str(meta_b),
             }
         dc = self.diff_xor.cell(self.cell_a.name) or self.diff_xor.create_cell(
-            self.cell_a.name
+            self.cell_a.name,
         )
         dc.add_meta_info(
-            kdb.LayoutMetaInfo(name, {"a": meta_a, "b": meta_b}, persisted=True)
+            kdb.LayoutMetaInfo(name, {"a": meta_a, "b": meta_b}, persisted=True),
         )
 
     def compare(self) -> bool:

--- a/src/kfactory/packing.py
+++ b/src/kfactory/packing.py
@@ -35,12 +35,13 @@ def pack_kcells(
         max_height=max_height,
     )
 
-    for inst_bb, bb in zip(bbs, packed_bbs):
+    for inst_bb, bb in zip(bbs, packed_bbs, strict=False):
         inst, _bb = inst_bb
         inst.transform(
             kdb.Trans(
-                bb[0] + spacing // 2 - _bb.left, bb[1] + spacing // 2 - _bb.bottom
-            )
+                bb[0] + spacing // 2 - _bb.left,
+                bb[1] + spacing // 2 - _bb.bottom,
+            ),
         )
 
     return InstanceGroup(insts=insts)
@@ -70,12 +71,13 @@ def pack_instances(
         max_height=max_height,
     )
 
-    for inst_bb, bb in zip(bbs, packed_bbs):
+    for inst_bb, bb in zip(bbs, packed_bbs, strict=False):
         inst, _bb = inst_bb
         inst.transform(
             kdb.Trans(
-                bb[0] + spacing // 2 - _bb.left, bb[1] + spacing // 2 - _bb.bottom
-            )
+                bb[0] + spacing // 2 - _bb.left,
+                bb[1] + spacing // 2 - _bb.bottom,
+            ),
         )
 
     return InstanceGroup(insts=instances)

--- a/src/kfactory/placer.py
+++ b/src/kfactory/placer.py
@@ -101,7 +101,7 @@ def cells_from_yaml(
     """
     yaml = get_yaml_obj()
     yaml.register_class(
-        include_from_loader(inp.parent, kcl, additional_classes, verbose)
+        include_from_loader(inp.parent, kcl, additional_classes, verbose),
     )
 
     register_classes(
@@ -127,13 +127,18 @@ def exploded_yaml(
 
     class ModKCell(KCell):
         def __init__(
-            self, name: str | None = None, library: KCLayout = library
+            self,
+            name: str | None = None,
+            library: KCLayout = library,
         ) -> None:
             KCell.__init__(self, name=name, kcl=library)
 
         @classmethod
         def from_yaml(
-            cls, constructor: SafeConstructor, node: Any, verbose: bool = False
+            cls,
+            constructor: SafeConstructor,
+            node: Any,
+            verbose: bool = False,
         ) -> Self:
             return super().from_yaml(constructor, node, verbose=verbose)
 
@@ -162,7 +167,10 @@ def include_from_loader(
                 cells_from_yaml(f, library, additional_classes, verbose)
             else:
                 cells_from_yaml(
-                    (folder / f).resolve(), library, additional_classes, verbose
+                    (folder / f).resolve(),
+                    library,
+                    additional_classes,
+                    verbose,
                 )
 
     return Include

--- a/src/kfactory/port.py
+++ b/src/kfactory/port.py
@@ -22,7 +22,7 @@ from typing import (
 )
 
 import klayout.db as kdb
-import klayout.rdb as rdb
+from klayout import rdb
 from pydantic import (
     BaseModel,
     model_serializer,
@@ -56,10 +56,10 @@ def create_port_error(
     if p1.name and p2.name:
         it.add_value(f"Port Names: {c1.name}.{p1.name}/{c2.name}.{p2.name}")
     it.add_value(
-        port_polygon(p1.cross_section.width).transformed(p1.trans).to_dtype(dbu)
+        port_polygon(p1.cross_section.width).transformed(p1.trans).to_dtype(dbu),
     )
     it.add_value(
-        port_polygon(p2.cross_section.width).transformed(p2.trans).to_dtype(dbu)
+        port_polygon(p2.cross_section.width).transformed(p2.trans).to_dtype(dbu),
     )
 
 
@@ -138,7 +138,7 @@ class BasePort(BaseModel, arbitrary_types_allowed=True):
         if isinstance(post_trans, kdb.Trans):
             post_trans = kdb.DCplxTrans(post_trans.to_dtype(self.kcl.dbu))
         dcplx_trans = self.dcplx_trans or kdb.DCplxTrans(
-            t=self.trans.to_dtype(self.kcl.dbu)  # type: ignore[union-attr]
+            t=self.trans.to_dtype(self.kcl.dbu),  # type: ignore[union-attr]
         )
 
         base.trans = None
@@ -173,7 +173,7 @@ class BasePort(BaseModel, arbitrary_types_allowed=True):
 
     def get_dcplx_trans(self) -> kdb.DCplxTrans:
         return self.dcplx_trans or kdb.DCplxTrans(
-            self.trans.to_dtype(self.kcl.dbu)  # type: ignore[union-attr]
+            self.trans.to_dtype(self.kcl.dbu),  # type: ignore[union-attr]
         )
 
 
@@ -260,7 +260,8 @@ class ProtoPort(Generic[TUnit], ABC):
         index.
         """
         return self.kcl.find_layer(
-            self.cross_section.main_layer, allow_undefined_layers=True
+            self.cross_section.main_layer,
+            allow_undefined_layers=True,
         )
 
     @property
@@ -313,13 +314,13 @@ class ProtoPort(Generic[TUnit], ABC):
         transformation (set simple to `None` and the complex to the provided value.
         """
         return self._base.dcplx_trans or kdb.DCplxTrans(
-            self.trans.to_dtype(self.kcl.layout.dbu)
+            self.trans.to_dtype(self.kcl.layout.dbu),
         )
 
     @dcplx_trans.setter
     def dcplx_trans(self, value: kdb.DCplxTrans) -> None:
         if value.is_complex() or value.disp != self.kcl.to_um(
-            self.kcl.to_dbu(value.disp)
+            self.kcl.to_dbu(value.disp),
         ):
             self._base.dcplx_trans = value.dup()
         else:
@@ -669,12 +670,11 @@ class Port(ProtoPort[int]):
             if width is None:
                 raise ValueError(
                     "any width and layer, or a cross_section must be given if the"
-                    " 'port is None'"
+                    " 'port is None'",
                 )
-            else:
-                cross_section = kcl_.get_cross_section(
-                    CrossSectionSpec(main_layer=layer_info, width=width)
-                )
+            cross_section = kcl_.get_cross_section(
+                CrossSectionSpec(main_layer=layer_info, width=width),
+            )
         cross_section_ = cross_section
         if trans is not None:
             if isinstance(trans, str):
@@ -742,7 +742,11 @@ class Port(ProtoPort[int]):
         return Port(base=self._base.transformed(trans=trans, post_trans=post_trans))
 
     def copy_polar(
-        self, d: int = 0, d_orth: int = 0, angle: int = 2, mirror: bool = False
+        self,
+        d: int = 0,
+        d_orth: int = 0,
+        angle: int = 2,
+        mirror: bool = False,
     ) -> Port:
         """Get a polar copy of the port.
 
@@ -884,10 +888,10 @@ class DPort(ProtoPort[float]):
                 layer_info = kcl_.layout.get_info(layer)
             if width is None:
                 raise ValueError(
-                    "If a cross_section is not given a width must be defined."
+                    "If a cross_section is not given a width must be defined.",
                 )
             cross_section = kcl_.get_cross_section(
-                CrossSectionSpec(main_layer=layer_info, width=kcl_.to_dbu(width))
+                CrossSectionSpec(main_layer=layer_info, width=kcl_.to_dbu(width)),
             )
         cross_section_ = cross_section
         if trans is not None:
@@ -961,7 +965,11 @@ class DPort(ProtoPort[float]):
         return DPort(base=self._base.transformed(trans=trans, post_trans=post_trans))
 
     def copy_polar(
-        self, d: float = 0, d_orth: float = 0, angle: float = 2, mirror: bool = False
+        self,
+        d: float = 0,
+        d_orth: float = 0,
+        angle: float = 2,
+        mirror: bool = False,
     ) -> DPort:
         """Get a polar copy of the port.
 
@@ -976,7 +984,7 @@ class DPort(ProtoPort[float]):
             mirror: Whether to mirror the port relative to the original port.
         """
         return self.copy(
-            post_trans=kdb.DCplxTrans(rot=angle, mirrx=mirror, x=d, y=d_orth)
+            post_trans=kdb.DCplxTrans(rot=angle, mirrx=mirror, x=d, y=d_orth),
         )
 
     @property
@@ -1288,8 +1296,7 @@ def filter_regex(ports: Iterable[TPort], regex: str) -> filter[TPort]:
     def regex_filter(p: TPort) -> bool:
         if p.name is not None:
             return bool(pattern.match(p.name))
-        else:
-            return False
+        return False
 
     return filter(regex_filter, ports)
 
@@ -1301,18 +1308,17 @@ def port_polygon(width: int) -> kdb.Polygon:
     """Gets a polygon representation for a given port width."""
     if width in polygon_dict:
         return polygon_dict[width]
-    else:
-        poly = kdb.Polygon(
-            [
-                kdb.Point(0, width // 2),
-                kdb.Point(0, -width // 2),
-                kdb.Point(width // 2, 0),
-            ]
-        )
+    poly = kdb.Polygon(
+        [
+            kdb.Point(0, width // 2),
+            kdb.Point(0, -width // 2),
+            kdb.Point(width // 2, 0),
+        ],
+    )
 
-        hole = kdb.Region(poly).sized(-int(width * 0.05) or -1)
-        hole -= kdb.Region(kdb.Box(0, 0, width // 2, -width // 2))
+    hole = kdb.Region(poly).sized(-int(width * 0.05) or -1)
+    hole -= kdb.Region(kdb.Box(0, 0, width // 2, -width // 2))
 
-        poly.insert_hole(list(next(iter(hole.each())).each_point_hull()))
-        polygon_dict[width] = poly
-        return poly
+    poly.insert_hole(list(next(iter(hole.each())).each_point_hull()))
+    polygon_dict[width] = poly
+    return poly

--- a/src/kfactory/ports.py
+++ b/src/kfactory/ports.py
@@ -151,13 +151,12 @@ class ProtoPorts(ABC, Generic[TUnit]):
         """Check whether a port is in this port collection."""
         if isinstance(port, ProtoPort):
             return port.base in self._bases
-        elif isinstance(port, BasePort):
+        if isinstance(port, BasePort):
             return port in self._bases
-        else:
-            for _port in self._bases:
-                if _port.name == port:
-                    return True
-            return False
+        for _port in self._bases:
+            if _port.name == port:
+                return True
+        return False
 
     def clear(self) -> None:
         """Deletes all ports."""
@@ -171,7 +170,7 @@ class ProtoPorts(ABC, Generic[TUnit]):
             other_list = cast(list[ProtoPort[Any]], list(other))
             if len(self._bases) != len(other_list):
                 return False
-            for b1, b2 in zip(self._bases, other_list):
+            for b1, b2 in zip(self._bases, other_list, strict=False):
                 if b1 != b2.base:
                     return False
             return True
@@ -261,7 +260,7 @@ class Ports(ProtoPorts[int]):
             base.dcplx_trans = None
             base.kcl = self.kcl
             base.cross_section = self.kcl.get_cross_section(
-                port.cross_section.to_dtype(port.kcl)
+                port.cross_section.to_dtype(port.kcl),
             )
             port_ = Port(base=base)
             port_.dcplx_trans = dcplx_trans
@@ -374,17 +373,17 @@ class Ports(ProtoPorts[int]):
             if width is None:
                 raise ValueError(
                     "Either width or dwidth must be set. It can be set through"
-                    " a cross section as well."
+                    " a cross section as well.",
                 )
             if layer_info is None:
                 if layer is None:
                     raise ValueError(
-                        "layer or layer_info must be defined to create a port."
+                        "layer or layer_info must be defined to create a port.",
                     )
                 layer_info = self.kcl.get_info(layer)
             assert layer_info is not None
             cross_section = self.kcl.get_cross_section(
-                CrossSectionSpec(main_layer=layer_info, width=width)
+                CrossSectionSpec(main_layer=layer_info, width=width),
             )
         if trans is not None:
             port = Port(
@@ -415,7 +414,7 @@ class Ports(ProtoPorts[int]):
         else:
             raise ValueError(
                 f"You need to define width {width} and trans {trans} or angle {angle}"
-                f" and center {center} or dcplx_trans {dcplx_trans}"
+                f" and center {center} or dcplx_trans {dcplx_trans}",
             )
 
         self._bases.append(port.base)
@@ -434,7 +433,7 @@ class Ports(ProtoPorts[int]):
         except StopIteration:
             raise KeyError(
                 f"{key=} is not a valid port name or index. "
-                f"Available ports: {[v.name for v in self._bases]}"
+                f"Available ports: {[v.name for v in self._bases]}",
             )
 
     def filter(
@@ -574,7 +573,7 @@ class DPorts(ProtoPorts[float]):
             base.dcplx_trans = None
             base.kcl = self.kcl
             base.cross_section = self.kcl.get_cross_section(
-                port.cross_section.to_dtype(port.kcl)
+                port.cross_section.to_dtype(port.kcl),
             )
             port_ = DPort(base=base)
             port_.dcplx_trans = dcplx_trans
@@ -698,12 +697,12 @@ class DPorts(ProtoPorts[float]):
             if width is None:
                 raise ValueError(
                     "Either width must be set. It can be set through"
-                    " a cross section as well."
+                    " a cross section as well.",
                 )
             if layer_info is None:
                 if layer is None:
                     raise ValueError(
-                        "layer or layer_info must be defined to create a port."
+                        "layer or layer_info must be defined to create a port.",
                     )
                 layer_info = self.kcl.get_info(layer)
             assert layer_info is not None
@@ -714,13 +713,13 @@ class DPorts(ProtoPorts[float]):
             if width_ % 2:
                 raise ValueError(
                     f"dwidth needs to be even to snap to grid. Got {dwidth}."
-                    "Ports must have a grid width of multiples of 2."
+                    "Ports must have a grid width of multiples of 2.",
                 )
             cross_section = self.kcl.get_cross_section(
                 CrossSectionSpec(
                     main_layer=layer_info,
                     width=width_,
-                )
+                ),
             )
         if trans is not None:
             port = DPort(
@@ -751,7 +750,7 @@ class DPorts(ProtoPorts[float]):
         else:
             raise ValueError(
                 f"You need to define width {width} and trans {trans} or angle {angle}"
-                f" and center {center} or dcplx_trans {dcplx_trans}"
+                f" and center {center} or dcplx_trans {dcplx_trans}",
             )
 
         self._bases.append(port.base)
@@ -770,7 +769,7 @@ class DPorts(ProtoPorts[float]):
         except StopIteration:
             raise KeyError(
                 f"{key=} is not a valid port name or index. "
-                f"Available ports: {[v.name for v in self._bases]}"
+                f"Available ports: {[v.name for v in self._bases]}",
             )
 
     def filter(

--- a/src/kfactory/ports.py
+++ b/src/kfactory/ports.py
@@ -19,13 +19,9 @@ from typing import (
     overload,
 )
 
-from ruamel.yaml.constructor import BaseConstructor
-from ruamel.yaml.representer import BaseRepresenter, SequenceNode
-
 from . import kdb
 from .conf import config
 from .cross_section import CrossSectionSpec, SymmetricalCrossSection
-from .layer import LayerEnum
 from .port import (
     BasePort,
     DPort,
@@ -41,6 +37,10 @@ from .typings import TUnit
 from .utilities import pprint_ports
 
 if TYPE_CHECKING:
+    from ruamel.yaml.constructor import BaseConstructor
+    from ruamel.yaml.representer import BaseRepresenter, SequenceNode
+
+    from .layer import LayerEnum
     from .layout import KCLayout
 
 
@@ -153,10 +153,7 @@ class ProtoPorts(ABC, Generic[TUnit]):
             return port.base in self._bases
         if isinstance(port, BasePort):
             return port in self._bases
-        for _port in self._bases:
-            if _port.name == port:
-                return True
-        return False
+        return any(_port.name == port for _port in self._bases)
 
     def clear(self) -> None:
         """Deletes all ports."""
@@ -371,14 +368,18 @@ class Ports(ProtoPorts[int]):
         """
         if cross_section is None:
             if width is None:
-                raise ValueError(
+                msg = (
                     "Either width or dwidth must be set. It can be set through"
-                    " a cross section as well.",
+                    " a cross section as well."
+                )
+                raise ValueError(
+                    msg,
                 )
             if layer_info is None:
                 if layer is None:
+                    msg = "layer or layer_info must be defined to create a port."
                     raise ValueError(
-                        "layer or layer_info must be defined to create a port.",
+                        msg,
                     )
                 layer_info = self.kcl.get_info(layer)
             assert layer_info is not None
@@ -695,20 +696,25 @@ class DPorts(ProtoPorts[float]):
         """
         if cross_section is None:
             if width is None:
-                raise ValueError(
+                msg = (
                     "Either width must be set. It can be set through"
-                    " a cross section as well.",
+                    " a cross section as well."
+                )
+                raise ValueError(
+                    msg,
                 )
             if layer_info is None:
                 if layer is None:
+                    msg = "layer or layer_info must be defined to create a port."
                     raise ValueError(
-                        "layer or layer_info must be defined to create a port.",
+                        msg,
                     )
                 layer_info = self.kcl.get_info(layer)
             assert layer_info is not None
             dwidth = width
             if dwidth <= 0:
-                raise ValueError("dwidth needs to be set and be >0")
+                msg = "dwidth needs to be set and be >0"
+                raise ValueError(msg)
             width_ = self.kcl.to_dbu(dwidth)
             if width_ % 2:
                 raise ValueError(

--- a/src/kfactory/routing/__init__.py
+++ b/src/kfactory/routing/__init__.py
@@ -2,9 +2,10 @@
 
 from pydantic import BaseModel
 
-from .. import kdb
-from ..instance import Instance
-from ..port import Port
+from kfactory import kdb
+from kfactory.instance import Instance
+from kfactory.port import Port
+
 from . import aa, electrical, generic, manhattan, optical
 
 

--- a/src/kfactory/routing/aa/optical.py
+++ b/src/kfactory/routing/aa/optical.py
@@ -9,10 +9,10 @@ import numpy as np
 from pydantic import BaseModel
 from scipy.optimize import minimize_scalar  # type: ignore[import-untyped,unused-ignore]
 
-from ... import kdb
-from ...instance import VInstance
-from ...kcell import DKCell, KCell, VKCell
-from ...port import DPort, Port, ProtoPort
+from kfactory import kdb
+from kfactory.instance import VInstance
+from kfactory.kcell import DKCell, KCell, VKCell
+from kfactory.port import DPort, Port, ProtoPort
 
 __all__ = ["OpticalAllAngleRoute", "route"]
 
@@ -72,7 +72,8 @@ def route(
             the point before and the following will be created.
     """
     if len(backbone) < 3:
-        raise ValueError("All angle routes with less than 3 points are not supported.")
+        msg = "All angle routes with less than 3 points are not supported."
+        raise ValueError(msg)
 
     bends: dict[float, VKCell] = {90: bend_factory(width=width, angle=90)}
     layer = bends[90].ports[bend_ports[0]].layer
@@ -233,9 +234,12 @@ def route_bundle(
 
     if backbone:
         if len(backbone) < 2:
-            raise NotImplementedError(
+            msg = (
                 "A bundle with less than two points has no orientation. "
-                "Cannot automatically determine orientation.",
+                "Cannot automatically determine orientation."
+            )
+            raise NotImplementedError(
+                msg,
             )
 
         if isinstance(separation, int | float):

--- a/src/kfactory/routing/electrical.py
+++ b/src/kfactory/routing/electrical.py
@@ -121,7 +121,10 @@ def route_L(
         for i, p in enumerate(input_ports_[::-1]):
             temp_port = p.copy()
             temp_port.trans = kdb.Trans(
-                3, False, x_max - wire_spacing * (i + 1), y_max + wire_spacing
+                3,
+                False,
+                x_max - wire_spacing * (i + 1),
+                y_max + wire_spacing,
             )
 
             route_elec(c_, p, temp_port)
@@ -131,14 +134,17 @@ def route_L(
         for i, p in enumerate(input_ports_):
             temp_port = p.copy()
             temp_port.trans = kdb.Trans(
-                1, False, x_max - wire_spacing * (i + 1), y_min - wire_spacing
+                1,
+                False,
+                x_max - wire_spacing * (i + 1),
+                y_min - wire_spacing,
             )
             route_elec(c_, p, temp_port)
             temp_port.trans.angle = 3
             output_ports.append(temp_port)
     else:
         raise ValueError(
-            "Invalid L-shape routing. Please change output_orientaion to 1 or 3."
+            "Invalid L-shape routing. Please change output_orientaion to 1 or 3.",
         )
     return output_ports
 
@@ -497,7 +503,7 @@ def place_single_wire(
         route_width = p1.width
     if kwargs:
         raise ValueError(
-            f"Additional kwargs aren't supported in route_single_wire {kwargs=}"
+            f"Additional kwargs aren't supported in route_single_wire {kwargs=}",
         )
 
     shape = (
@@ -551,7 +557,7 @@ def place_dual_rails(
     """
     if kwargs:
         raise ValueError(
-            f"Additional kwargs aren't supported in route_dual_rails {kwargs=}"
+            f"Additional kwargs aren't supported in route_dual_rails {kwargs=}",
         )
     if layer_info is None:
         layer_info = p1.layer_info
@@ -563,7 +569,7 @@ def place_dual_rails(
         raise ValueError(f"{separation_rails=} must be smaller than the {route_width}")
 
     region = kdb.Region(kdb.Path(pts, route_width)) - kdb.Region(
-        kdb.Path(pts, separation_rails)
+        kdb.Path(pts, separation_rails),
     )
 
     shapes = [

--- a/src/kfactory/routing/manhattan.py
+++ b/src/kfactory/routing/manhattan.py
@@ -164,7 +164,7 @@ def route_manhattan_180(
             pts[1:1] = [pts[1] + (t2 * kdb.Vector(0, tv.y))]
             raise NotImplementedError(
                 "`case (x, y, 0) if x > 0 and abs(y) == bend180_radius`"
-                " not supported yet"
+                " not supported yet",
             )
         case (x, 0, 2):
             if start_straight > 0:
@@ -195,7 +195,7 @@ def route_manhattan_180(
             )
     raise NotImplementedError(
         "Case not supportedt yet. Please open an issue if you believe this is an error"
-        " and needs to be implemented ;)"
+        " and needs to be implemented ;)",
     )
 
 
@@ -278,18 +278,24 @@ class ManhattanRouterSide:
 
     def right(self) -> None:
         self.pts.append(
-            (self.t * kdb.Trans(0, False, self.router.bend90_radius, 0)) * _p
+            (self.t * kdb.Trans(0, False, self.router.bend90_radius, 0)) * _p,
         )
         self.t *= kdb.Trans(
-            3, False, self.router.bend90_radius, -self.router.bend90_radius
+            3,
+            False,
+            self.router.bend90_radius,
+            -self.router.bend90_radius,
         )
 
     def left(self) -> None:
         self.pts.append(
-            (self.t * kdb.Trans(0, False, self.router.bend90_radius, 0)) * _p
+            (self.t * kdb.Trans(0, False, self.router.bend90_radius, 0)) * _p,
         )
         self.t *= kdb.Trans(
-            1, False, self.router.bend90_radius, self.router.bend90_radius
+            1,
+            False,
+            self.router.bend90_radius,
+            self.router.bend90_radius,
         )
 
     def straight(self, d: int) -> None:
@@ -368,7 +374,7 @@ class ManhattanRouter:
     def path_length(self) -> int:
         if not self.finished:
             raise ValueError(
-                "Router is not finished yet, path_length will be inaccurate."
+                "Router is not finished yet, path_length will be inaccurate.",
             )
         return self.start.path_length
 
@@ -464,7 +470,7 @@ class ManhattanRouter:
                 if x < self.bend90_radius and y_abs < self.bend90_radius:
                     logger.warning(
                         "route is too small, potential collisions: "
-                        f"{self.start=}; {self.end=}; {self.start.pts=}"
+                        f"{self.start=}; {self.end=}; {self.start.pts=}",
                     )
                     right()
                     self.start.straight(self.bend90_radius - _y)
@@ -477,11 +483,12 @@ class ManhattanRouter:
             "Route couldn't find a possible route, please open an issue on Github."
             f"{self.start=!r}, {self.end=!r}, {self.bend90_radius=}\n"
             f"{self.ta=}, {self.tv=!r}\n"
-            f"{self.pts=}"
+            f"{self.pts=}",
         )
 
     def collisions(
-        self, log_errors: None | Literal["warn", "error"] = "error"
+        self,
+        log_errors: None | Literal["warn", "error"] = "error",
     ) -> tuple[kdb.Edges, kdb.Edges]:
         """Finds collisions.
 
@@ -520,13 +527,13 @@ class ManhattanRouter:
                     logger.error(
                         f"Router {self.start.t=}, {self.end.t=}, {self.start.pts=},"
                         f" {self.end.pts=} has collisions in the manhattan route.\n"
-                        f"{collisions=}"
+                        f"{collisions=}",
                     )
                 case "warn":
                     logger.warning(
                         f"Router {self.start.t=}, {self.end.t=}, {self.start.pts=},"
                         f" {self.end.pts=} has collisions in the manhattan route.\n"
-                        f"{collisions=}"
+                        f"{collisions=}",
                     )
         return collisions, edges
 
@@ -540,12 +547,12 @@ class ManhattanRouter:
         tv = self.start.tv
         if self.start.ta != 2:
             raise ValueError(
-                "Route is not finished. The transformations must be facing each other"
+                "Route is not finished. The transformations must be facing each other",
             )
         if tv.y != 0:
             raise ValueError(
                 "Route  is not finished. The transformations are not properly aligned: "
-                f"Vector (as seen from t1): {tv.x=}, {tv.y=}"
+                f"Vector (as seen from t1): {tv.x=}, {tv.y=}",
             )
         if self.end.pts[-1] != self.start.pts[-1]:
             self.start.pts.extend(reversed(self.end.pts))
@@ -642,26 +649,27 @@ def path_length_match_manhattan_route(
     """
     if kwargs:
         raise ValueError(
-            f"Additional kwargs aren't supported in route_dual_rails {kwargs=}"
+            f"Additional kwargs aren't supported in route_dual_rails {kwargs=}",
         )
     if bend90_radius is None:
         raise ValueError(
             "bend90_radius must be passed to the function, please pass it"
             " through the router_post_process_kwargs if using the "
-            "generic route_bunle"
+            "generic route_bunle",
         )
     if separation is None:
         raise ValueError(
             "separation must be passed to the function, please pass it"
             " through the router_post_process_kwargs if using the "
-            "generic route_bunle"
+            "generic route_bunle",
         )
     position = -1
     path_loops = 1
 
     path_length = path_length or max(r.path_length for r in routers)
     match_dict: dict[
-        Literal[0, 1, 2, 3], list[tuple[ManhattanRouter, PathMatchDict]]
+        Literal[0, 1, 2, 3],
+        list[tuple[ManhattanRouter, PathMatchDict]],
     ] = {
         0: [],
         1: [],
@@ -687,9 +695,11 @@ def path_length_match_manhattan_route(
             (
                 router,
                 PathMatchDict(
-                    angle=angle, pts=modify_pts, dl=path_length - router.path_length
+                    angle=angle,
+                    pts=modify_pts,
+                    dl=path_length - router.path_length,
                 ),
-            )
+            ),
         )
 
     match_dict[0].sort(key=lambda t: t[1]["pts"][0].y)
@@ -776,11 +786,13 @@ def _place_dl_path_length(
         if vl < (2 + path_loops * 4) * bend90_radius:
             raise ValueError(
                 f"Not enough space to place {path_loops} path length matching segments"
-                f" on {pts[0]} to {pts[1]}"
+                f" on {pts[0]} to {pts[1]}",
             )
 
         t = kdb.Trans(
-            angle, False, (_t * kdb.Point(pmin, (_tinv * pts[0]).y)).to_v()
+            angle,
+            False,
+            (_t * kdb.Point(pmin, (_tinv * pts[0]).y)).to_v(),
         ) * kdb.Trans(kdb.Vector(bend90_radius, 0))
         if direction == 1:
             _r = kdb.Trans(3, False, bend90_radius, -bend90_radius)
@@ -854,7 +866,7 @@ def route_smart(
     length = len(start_ports)
     if len(kwargs) > 0:
         raise ValueError(
-            f"Additional args and kwargs are not allowed for route_smart.{kwargs=}"
+            f"Additional args and kwargs are not allowed for route_smart.{kwargs=}",
         )
 
     if bend90_radius is None or separation is None:
@@ -862,7 +874,7 @@ def route_smart(
             "route_smart needs to have 'bend90_radius' and 'separation' "
             "defined as kwargs. Please pass them or if using a "
             "'route_bundle' function using this, make sure the bundle router"
-            " has the kwargs."
+            " has the kwargs.",
         )
 
     assert len(end_ports) == length, (
@@ -900,13 +912,13 @@ def route_smart(
                 "whether ports belong to specific bundles or they should build one "
                 "bounding box. Therefore, all ports will be assigned to one bounding"
                 " box. If this is the intended behavior, pass `[]` to the bboxes "
-                "parameter to disable this warning."
+                "parameter to disable this warning.",
             )
             bboxes = []
         _w0 = widths[0]
         if not all(w == _w0 for w in widths):
             raise NotImplementedError(
-                f"'sort_ports=True' with variable widths is not supported: {widths=}"
+                f"'sort_ports=True' with variable widths is not supported: {widths=}",
             )
         if waypoints is not None:
             return _route_waypoints(
@@ -925,7 +937,7 @@ def route_smart(
         default_start_bundle: list[kdb.Trans] = []
         start_bundles: dict[kdb.Box, list[kdb.Trans]] = defaultdict(list)
         mh_routers: list[ManhattanRouter] = []
-        for s, s_t, e, e_t in zip(starts, start_ts, ends, end_ts):
+        for s, s_t, e, e_t in zip(starts, start_ts, ends, end_ts, strict=False):
             mh_routers.append(
                 ManhattanRouter(
                     bend90_radius=bend90_radius,
@@ -933,7 +945,7 @@ def route_smart(
                     end_transformation=e_t,
                     start_steps=s,
                     end_steps=e,
-                )
+                ),
             )
         start_ts = [r.start.t for r in mh_routers]
         end_ts = [r.end.t for r in mh_routers]
@@ -988,7 +1000,8 @@ def route_smart(
         ]
 
         for box, s_bundle in sorted(
-            start_bundles.items(), key=lambda item: (item[0].left, item[0].bottom)
+            start_bundles.items(),
+            key=lambda item: (item[0].left, item[0].bottom),
         ):
             bl = len(s_bundle)
             bc = box.center()
@@ -1006,7 +1019,7 @@ def route_smart(
                     "The sorting algorithm currently doesn't support if multiple "
                     "bundles are conflicting with each other. Offending bundle at"
                     " starting port positions "
-                    f"{box.left=},{box.bottom=},{box.right=},{box.top=}[dbu]"
+                    f"{box.left=},{box.bottom=},{box.right=},{box.top=}[dbu]",
                 )
             start_ts = []
             end_ts = []
@@ -1025,7 +1038,7 @@ def route_smart(
                                     box=end_box,
                                     split=1,
                                     clockwise=False,
-                                )
+                                ),
                             )
                             start_ts.extend(
                                 _sort_transformations(
@@ -1034,7 +1047,7 @@ def route_smart(
                                     box=start_box,
                                     split=1,
                                     clockwise=True,
-                                )
+                                ),
                             )
                         else:
                             end_ts.extend(
@@ -1044,7 +1057,7 @@ def route_smart(
                                     box=end_box,
                                     split=1,
                                     clockwise=False,
-                                )
+                                ),
                             )
                             start_ts.extend(
                                 _sort_transformations(
@@ -1053,7 +1066,7 @@ def route_smart(
                                     box=start_box,
                                     split=1,
                                     clockwise=True,
-                                )
+                                ),
                             )
                     case 1:
                         if v.y < 0:
@@ -1064,7 +1077,7 @@ def route_smart(
                                     box=end_box,
                                     split=1,
                                     clockwise=False,
-                                )
+                                ),
                             )
                             start_ts.extend(
                                 _sort_transformations(
@@ -1073,7 +1086,7 @@ def route_smart(
                                     box=start_box,
                                     split=1,
                                     clockwise=True,
-                                )
+                                ),
                             )
                         else:
                             end_ts.extend(
@@ -1083,7 +1096,7 @@ def route_smart(
                                     box=end_box,
                                     split=1,
                                     clockwise=False,
-                                )
+                                ),
                             )
                             start_ts.extend(
                                 _sort_transformations(
@@ -1092,7 +1105,7 @@ def route_smart(
                                     box=start_box,
                                     split=1,
                                     clockwise=True,
-                                )
+                                ),
                             )
                     case 2:
                         if v.x > 0:
@@ -1103,7 +1116,7 @@ def route_smart(
                                     box=end_box,
                                     split=1,
                                     clockwise=False,
-                                )
+                                ),
                             )
                             start_ts.extend(
                                 _sort_transformations(
@@ -1112,7 +1125,7 @@ def route_smart(
                                     box=start_box,
                                     split=1,
                                     clockwise=True,
-                                )
+                                ),
                             )
                         else:
                             end_ts.extend(
@@ -1122,7 +1135,7 @@ def route_smart(
                                     box=end_box,
                                     split=1,
                                     clockwise=False,
-                                )
+                                ),
                             )
                             start_ts.extend(
                                 _sort_transformations(
@@ -1131,7 +1144,7 @@ def route_smart(
                                     box=start_box,
                                     split=1,
                                     clockwise=True,
-                                )
+                                ),
                             )
                     case 3:
                         if v.y > 0:
@@ -1142,7 +1155,7 @@ def route_smart(
                                     box=end_box,
                                     split=1,
                                     clockwise=False,
-                                )
+                                ),
                             )
                             start_ts.extend(
                                 _sort_transformations(
@@ -1151,7 +1164,7 @@ def route_smart(
                                     box=start_box,
                                     split=1,
                                     clockwise=True,
-                                )
+                                ),
                             )
                         else:
                             end_ts.extend(
@@ -1161,7 +1174,7 @@ def route_smart(
                                     box=end_box,
                                     split=1,
                                     clockwise=False,
-                                )
+                                ),
                             )
                             start_ts.extend(
                                 _sort_transformations(
@@ -1170,13 +1183,20 @@ def route_smart(
                                     box=start_box,
                                     split=1,
                                     clockwise=True,
-                                )
+                                ),
                             )
                     case _:
                         ...
 
         all_routers: list[ManhattanRouter] = []
-        for ts, te, w, ss, es in zip(start_ts, end_ts, widths, starts, ends):
+        for ts, te, w, ss, es in zip(
+            start_ts,
+            end_ts,
+            widths,
+            starts,
+            ends,
+            strict=False,
+        ):
             start_t = start_mapping[ts]
             end_t = end_mapping[te]
             all_routers.append(
@@ -1187,7 +1207,7 @@ def route_smart(
                     start_steps=ss,
                     end_steps=es,
                     width=w,
-                )
+                ),
             )
 
     else:
@@ -1207,7 +1227,14 @@ def route_smart(
             )
 
         all_routers = []
-        for ts, te, w, ss, es in zip(start_ts, end_ts, widths, starts, ends):
+        for ts, te, w, ss, es in zip(
+            start_ts,
+            end_ts,
+            widths,
+            starts,
+            ends,
+            strict=False,
+        ):
             all_routers.append(
                 ManhattanRouter(
                     bend90_radius=bend90_radius,
@@ -1216,12 +1243,12 @@ def route_smart(
                     start_steps=ss,
                     end_steps=es,
                     width=w,
-                )
+                ),
             )
 
     router_bboxes: list[kdb.Box] = [
         kdb.Box(router.start.t.disp.to_p(), router.end.t.disp.to_p()).enlarged(
-            router.width // 2
+            router.width // 2,
         )
         for router in all_routers
     ]
@@ -1231,7 +1258,7 @@ def route_smart(
     bundle = bundled_routers[0]
     bundle_bbox = complete_bbox.dup()
 
-    for router, bbox in zip(all_routers[1:], router_bboxes[1:]):
+    for router, bbox in zip(all_routers[1:], router_bboxes[1:], strict=False):
         dbrbox = bbox.enlarged(separation + router.width // 2)
         overlap_box = dbrbox & bundle_bbox
 
@@ -1272,7 +1299,7 @@ def route_smart(
 
     merge_bboxes: list[tuple[int, int]] = []
     for i in range(len(bundled_bboxes)):
-        for j in range(0, i):
+        for j in range(i):
             if not (bundled_bboxes[j] & bundled_bboxes[i]).empty():
                 merge_bboxes.append((i, j))
                 break
@@ -1297,15 +1324,21 @@ def route_smart(
         end_bbox += re.end.t * kdb.Point(-1, 0)
         for r in router_bundle:
             start_bbox += kdb.Box(r.start.pts[0], r.start.t.disp.to_p()) + kdb.Box(
-                0, -r.width // 2, 0, r.width // 2
+                0,
+                -r.width // 2,
+                0,
+                r.width // 2,
             ).transformed(r.start.t)
             end_bbox += kdb.Box(r.end.pts[0], r.end.t.disp.to_p()) + kdb.Box(
-                0, -r.width // 2, 0, r.width // 2
+                0,
+                -r.width // 2,
+                0,
+                r.width // 2,
             ).transformed(r.end.t)
             if r.end.t.angle != end_angle:
                 raise ValueError(
                     "All ports at the target (end) must have the same angle. "
-                    f"{r.start.t=}/{r.end.t=}"
+                    f"{r.start.t=}/{r.end.t=}",
                 )
         if bbox_routing == "minimal":
             route_to_bbox(
@@ -1350,7 +1383,10 @@ def route_smart(
             for rs in end_routers:
                 avg += rs.tv
             route_to_bbox(
-                end_routers, end_bbox, separation=separation, bbox_routing=bbox_routing
+                end_routers,
+                end_bbox,
+                separation=separation,
+                bbox_routing=bbox_routing,
             )
             _route_to_side(
                 end_routers,
@@ -1374,14 +1410,13 @@ def route_smart(
             if _ang != group_angle:
                 if group_angle is not None:
                     router_groups.append(
-                        ((group_angle - target_angle) % 4, current_group)
+                        ((group_angle - target_angle) % 4, current_group),
                     )
                 group_angle = _ang
                 current_group = []
             current_group.append(router)
-        else:
-            if group_angle is not None:
-                router_groups.append(((group_angle - target_angle) % 4, current_group))
+        if group_angle is not None:
+            router_groups.append(((group_angle - target_angle) % 4, current_group))
 
         total_bbox = start_bbox
 
@@ -1596,7 +1631,7 @@ def route_to_bbox(
         else:
             raise ValueError(
                 f"routing mode {bbox_routing=} is not supported, available modes"
-                " 'minimal', 'full'"
+                " 'minimal', 'full'",
             )
 
 
@@ -1647,7 +1682,8 @@ def route_loosely(
                 delta += router.width // 2
                 router.start.straight(s + tv.x)
                 router_start_box += router.start.t * kdb.Point(
-                    router.width + separation, 0
+                    router.width + separation,
+                    0,
                 )
                 router.start.left()
                 route_to_bbox(
@@ -1657,7 +1693,8 @@ def route_loosely(
                     bbox_routing=bbox_routing,
                 )
                 router_start_box += router.start.t * kdb.Point(
-                    router.bend90_radius + router.width + separation, 0
+                    router.bend90_radius + router.width + separation,
+                    0,
                 )
                 delta += router.width - router.width // 2 + separation
 
@@ -1679,7 +1716,8 @@ def route_loosely(
                 delta += router.width // 2
                 router.start.straight(s + tv.x)
                 router_start_box += router.start.t * kdb.Point(
-                    router.width + separation, 0
+                    router.width + separation,
+                    0,
                 )
                 router.start.right()
                 route_to_bbox(
@@ -1689,7 +1727,8 @@ def route_loosely(
                     bbox_routing=bbox_routing,
                 )
                 router_start_box += router.start.t * kdb.Point(
-                    router.bend90_radius + router.width + separation, 0
+                    router.bend90_radius + router.width + separation,
+                    0,
                 )
                 delta += router.width - router.width // 2 + separation
 
@@ -1714,7 +1753,8 @@ def route_loosely(
                 s = 0
             elif tv.y > 0:
                 r_bbox = kdb.Box(
-                    router.start.t.disp.to_p(), router.end.t.disp.to_p()
+                    router.start.t.disp.to_p(),
+                    router.end.t.disp.to_p(),
                 ).enlarged(router.width)
                 if s == -1:
                     if group:
@@ -1736,14 +1776,10 @@ def route_loosely(
                 s = 1
             else:
                 r_bbox = kdb.Box(
-                    router.start.t.disp.to_p(), router.end.t.disp.to_p()
+                    router.start.t.disp.to_p(),
+                    router.end.t.disp.to_p(),
                 ).enlarged(router.width)
-                if s == 1:
-                    if group:
-                        forward_groups.append(group)
-                    group = [router]
-                    group_bbox = r_bbox
-                elif s == 0:
+                if s == 1 or s == 0:
                     if group:
                         forward_groups.append(group)
                     group = [router]
@@ -1832,31 +1868,31 @@ def _sort_transformations(
                 match back_angle:
                     case 0:
                         start_transformations = _sort_trans_bank(
-                            [t for t in back if t.disp.y < box.center().y]
+                            [t for t in back if t.disp.y < box.center().y],
                         )
                         end_transformations = _sort_trans_bank(
-                            [t for t in back if t.disp.y >= box.center().y]
+                            [t for t in back if t.disp.y >= box.center().y],
                         )
                     case 1:
                         start_transformations = _sort_trans_bank(
-                            [t for t in back if t.disp.x < box.center().x]
+                            [t for t in back if t.disp.x < box.center().x],
                         )
                         end_transformations = _sort_trans_bank(
-                            [t for t in back if t.disp.x >= box.center().x]
+                            [t for t in back if t.disp.x >= box.center().x],
                         )
                     case 2:
                         start_transformations = _sort_trans_bank(
-                            [t for t in back if t.disp.y < box.center().y]
+                            [t for t in back if t.disp.y < box.center().y],
                         )
                         end_transformations = _sort_trans_bank(
-                            [t for t in back if t.disp.y >= box.center().y]
+                            [t for t in back if t.disp.y >= box.center().y],
                         )
                     case 3:
                         start_transformations = _sort_trans_bank(
-                            [t for t in back if t.disp.x > box.center().x]
+                            [t for t in back if t.disp.x > box.center().x],
                         )
                         end_transformations = _sort_trans_bank(
-                            [t for t in back if t.disp.x >= box.center().x]
+                            [t for t in back if t.disp.x >= box.center().x],
                         )
                     case _:
                         ...
@@ -1867,7 +1903,7 @@ def _sort_transformations(
                 # end_transformations.reverse()
     for angle in [-1, 0, 1]:
         start_transformations.extend(
-            _sort_trans_bank(trans_by_dir[(target_side + angle) % 4])
+            _sort_trans_bank(trans_by_dir[(target_side + angle) % 4]),
         )
 
     transformations = start_transformations + end_transformations
@@ -1881,13 +1917,13 @@ def _sort_trans_bank(transformations: Sequence[kdb.Trans]) -> list[kdb.Trans]:
         angle = transformations[0].angle
         match angle:
             case 0:
-                return list(sorted(transformations, key=lambda t: t.disp.y))
+                return sorted(transformations, key=lambda t: t.disp.y)
             case 1:
-                return list(sorted(transformations, key=lambda t: -t.disp.x))
+                return sorted(transformations, key=lambda t: -t.disp.x)
             case 2:
-                return list(sorted(transformations, key=lambda t: -t.disp.y))
+                return sorted(transformations, key=lambda t: -t.disp.y)
             case _:
-                return list(sorted(transformations, key=lambda t: t.disp.x))
+                return sorted(transformations, key=lambda t: t.disp.x)
     else:
         return []
 
@@ -1910,8 +1946,7 @@ def _route_to_side(
         y = (kdb.Trans(-router.t.angle, False, 0, 0) * router.t.disp).y
         if clockwise:
             return -y
-        else:
-            return y
+        return y
 
     sorted_rs = sorted(routers, key=_sort_route)
     for rs in sorted_rs:
@@ -2003,7 +2038,7 @@ def _backbone2bundle(
         _pts = [p.dup() for p in backbone]
         p1 = _pts[0]
 
-        for p2, e, dir in zip(_pts[1:], edges, dirs):
+        for p2, e, dir in zip(_pts[1:], edges, dirs, strict=False):
             _e = e.shifted(-x)
             if dir % 2:
                 p1.x = _e.p1.x
@@ -2037,14 +2072,17 @@ def route_ports_to_bundle(
     bundle_width = sum(tw[1] for tw in trans_ports) + (len(trans_ports) - 1) * spacing
 
     trans_mapping = {
-        norm_t: t for (t, _), (norm_t, _) in zip(ports_to_route, trans_ports)
+        norm_t: t
+        for (t, _), (norm_t, _) in zip(ports_to_route, trans_ports, strict=False)
     }
 
     def sort_port(port_width: tuple[kdb.Trans, int]) -> int:
         return -port_width[0].disp.y
 
     def append_straights(
-        straights: list[int], current_straights: list[int], reverse: bool
+        straights: list[int],
+        current_straights: list[int],
+        reverse: bool,
     ) -> None:
         if reverse:
             straights.extend(reversed(current_straights))
@@ -2053,7 +2091,7 @@ def route_ports_to_bundle(
             straights.extend(current_straights)
             current_straights.clear()
 
-    sorted_ports = list(sorted(trans_ports, key=sort_port))
+    sorted_ports = sorted(trans_ports, key=sort_port)
 
     base_bundle_position = inv_dir_trans * bundle_base_point
     bundle_position = base_bundle_position.dup()
@@ -2110,7 +2148,12 @@ def route_ports_to_bundle(
 
     bundle_position_x = max(
         tw[0].disp.x + ss + es + start_straight + end_straight
-        for tw, ss, es in zip(sorted_ports, bend_straight_lengths, straights)
+        for tw, ss, es in zip(
+            sorted_ports,
+            bend_straight_lengths,
+            straights,
+            strict=False,
+        )
     )
     bundle_position.x = max(bundle_position.x, bundle_position_x)
 
@@ -2118,7 +2161,7 @@ def route_ports_to_bundle(
     bundle_route_x = bundle_position.x
     port_dict: dict[kdb.Trans, list[kdb.Point]] = {}
 
-    for (_trans, _width), _end_straight in zip(sorted_ports, straights):
+    for (_trans, _width), _end_straight in zip(sorted_ports, straights, strict=False):
         bundle_route_y -= _width // 2
         t_e = kdb.Trans(2, False, bundle_route_x, bundle_route_y)
         pts = [
@@ -2192,10 +2235,10 @@ def _route_waypoints(
         all_routers: list[ManhattanRouter] = []
         start_manhattan_routers.sort(key=lambda sr: sr.end_transformation)
         end_manhattan_routers.sort(
-            key=lambda er: er.end_transformation * kdb.Trans.R180
+            key=lambda er: er.end_transformation * kdb.Trans.R180,
         )
 
-        for sr, er in zip(start_manhattan_routers, end_manhattan_routers):
+        for sr, er in zip(start_manhattan_routers, end_manhattan_routers, strict=False):
             router = ManhattanRouter(
                 bend90_radius=bend90_radius,
                 start_transformation=sr.start_transformation,
@@ -2206,76 +2249,79 @@ def _route_waypoints(
             router.finished = True
             all_routers.append(router)
         return all_routers
-    else:
-        if len(waypoints) < 2:
-            raise ValueError(
-                "If the waypoints should only contain one point, a direction "
-                "for the waypoint must be indicated, please pass a 'kdb.Trans'"
-                " object instead."
-            )
-        start_angle = vec_dir(waypoints[0] - waypoints[1])
-        end_angle = vec_dir(waypoints[-1] - waypoints[-2])
-        all_routers = []
-        bundle_points = _backbone2bundle(
-            backbone=waypoints,
-            port_widths=widths,
-            spacing=separation,
+    if len(waypoints) < 2:
+        raise ValueError(
+            "If the waypoints should only contain one point, a direction "
+            "for the waypoint must be indicated, please pass a 'kdb.Trans'"
+            " object instead.",
         )
-        start_manhattan_routers = route_smart(
-            start_ports=start_ts,
-            end_ports=[
-                kdb.Trans(start_angle, False, _bb[0].to_v()) for _bb in bundle_points
-            ],
-            widths=widths,
+    start_angle = vec_dir(waypoints[0] - waypoints[1])
+    end_angle = vec_dir(waypoints[-1] - waypoints[-2])
+    all_routers = []
+    bundle_points = _backbone2bundle(
+        backbone=waypoints,
+        port_widths=widths,
+        spacing=separation,
+    )
+    start_manhattan_routers = route_smart(
+        start_ports=start_ts,
+        end_ports=[
+            kdb.Trans(start_angle, False, _bb[0].to_v()) for _bb in bundle_points
+        ],
+        widths=widths,
+        bend90_radius=bend90_radius,
+        separation=separation,
+        starts=starts,
+        ends=cast(list[list[Step]], [[]] * len(starts)),
+        bboxes=bboxes,
+        sort_ports=sort_ports,
+        waypoints=None,
+        bbox_routing=bbox_routing,
+    )
+    end_manhattan_routers = route_smart(
+        end_ports=[
+            kdb.Trans(end_angle, False, _bb[-1].to_v()) for _bb in bundle_points
+        ],
+        start_ports=end_ts,
+        widths=widths,
+        bend90_radius=bend90_radius,
+        separation=separation,
+        starts=ends,
+        ends=cast(list[list[Step]], [[]] * len(ends)),
+        bboxes=bboxes,
+        sort_ports=sort_ports,
+        waypoints=None,
+        bbox_routing=bbox_routing,
+    )
+    start_manhattan_routers.sort(key=lambda sr: sr.start.pts[-1])
+    end_manhattan_routers.sort(key=lambda er: er.start.pts[-1])
+    bundle_points.sort(key=lambda _bb: _bb[0])
+    end_manhattan_routers = list(
+        er
+        for _, er in sorted(
+            zip(
+                sorted(bundle_points, key=lambda _bb: _bb[-1]),
+                end_manhattan_routers,
+                strict=False,
+            ),
+            key=lambda pair: pair[0][0],
+        )
+    )
+    for sr, _bb, er in zip(
+        start_manhattan_routers,
+        bundle_points,
+        end_manhattan_routers,
+        strict=False,
+    ):
+        router = ManhattanRouter(
             bend90_radius=bend90_radius,
-            separation=separation,
-            starts=starts,
-            ends=cast(list[list[Step]], [[]] * len(starts)),
-            bboxes=bboxes,
-            sort_ports=sort_ports,
-            waypoints=None,
-            bbox_routing=bbox_routing,
+            start_transformation=sr.start_transformation,
+            end_transformation=er.start_transformation,
+            start_points=sr.start.pts[:-1]
+            + _bb[1:-1]
+            + list(reversed(er.start.pts[:-1])),
         )
-        end_manhattan_routers = route_smart(
-            end_ports=[
-                kdb.Trans(end_angle, False, _bb[-1].to_v()) for _bb in bundle_points
-            ],
-            start_ports=end_ts,
-            widths=widths,
-            bend90_radius=bend90_radius,
-            separation=separation,
-            starts=ends,
-            ends=cast(list[list[Step]], [[]] * len(ends)),
-            bboxes=bboxes,
-            sort_ports=sort_ports,
-            waypoints=None,
-            bbox_routing=bbox_routing,
-        )
-        start_manhattan_routers.sort(key=lambda sr: sr.start.pts[-1])
-        end_manhattan_routers.sort(key=lambda er: er.start.pts[-1])
-        bundle_points.sort(key=lambda _bb: _bb[0])
-        end_manhattan_routers = list(
-            er
-            for _, er in sorted(
-                zip(
-                    sorted(bundle_points, key=lambda _bb: _bb[-1]),
-                    end_manhattan_routers,
-                ),
-                key=lambda pair: pair[0][0],
-            )
-        )
-        for sr, _bb, er in zip(
-            start_manhattan_routers, bundle_points, end_manhattan_routers
-        ):
-            router = ManhattanRouter(
-                bend90_radius=bend90_radius,
-                start_transformation=sr.start_transformation,
-                end_transformation=er.start_transformation,
-                start_points=sr.start.pts[:-1]
-                + _bb[1:-1]
-                + list(reversed(er.start.pts[:-1])),
-            )
-            router.start.t = router.end.t * kdb.Trans.R180
-            router.finished = True
-            all_routers.append(router)
-        return all_routers
+        router.start.t = router.end.t * kdb.Trans.R180
+        router.finished = True
+        all_routers.append(router)
+    return all_routers

--- a/src/kfactory/routing/optical.py
+++ b/src/kfactory/routing/optical.py
@@ -132,8 +132,8 @@ def route_bundle(
     | None = None,
     starts: dbu | list[dbu] | um | list[um] | list[Step] | list[list[Step]] = [],
     ends: dbu | list[dbu] | um | list[um] | list[Step] | list[list[Step]] = [],
-    start_angles: int | list[int] | float | list[float] | None = None,
-    end_angles: int | list[int] | float | list[float] | None = None,
+    start_angles: list[int] | float | list[float] | None = None,
+    end_angles: list[int] | float | list[float] | None = None,
     purpose: str | None = "routing",
 ) -> list[ManhattanRoute]:
     r"""Route a bundle from starting ports to end_ports.
@@ -416,7 +416,7 @@ def place90(
     """
     if len(kwargs) > 0:
         raise ValueError(
-            f"Additional args and kwargs are not allowed for route_smart.{kwargs=}"
+            f"Additional args and kwargs are not allowed for route_smart.{kwargs=}",
         )
     if allow_width_mismatch is None:
         allow_width_mismatch = config.allow_width_mismatch
@@ -427,12 +427,12 @@ def place90(
     if straight_factory is None:
         raise ValueError(
             "place90 needs to have a straight_factory set. Please pass a "
-            "straight_factory which takes kwargs 'width: int' and 'length: int'."
+            "straight_factory which takes kwargs 'width: int' and 'length: int'.",
         )
     if bend90_cell is None:
         raise ValueError(
             "place90 needs to be passed a fixed bend90 cell with two optical"
-            " ports which are 90° apart from each other with port_type 'port_type'."
+            " ports which are 90° apart from each other with port_type 'port_type'.",
         )
     route_start_port = p1.copy()
     route_start_port.name = None
@@ -449,11 +449,11 @@ def place90(
     if len(bend90_ports) != 2:
         raise AttributeError(
             f"{bend90_cell.name} should have 2 ports but has {len(bend90_ports)} ports"
-            f"with {port_type=}"
+            f"with {port_type=}",
         )
     if abs((bend90_ports[0].trans.angle - bend90_ports[1].trans.angle) % 4) != 1:
         raise AttributeError(
-            f"{bend90_cell.name} bend ports should be 90° apart from each other"
+            f"{bend90_cell.name} bend ports should be 90° apart from each other",
         )
 
     if (bend90_ports[1].trans.angle - bend90_ports[0].trans.angle) % 4 == 3:
@@ -463,10 +463,12 @@ def place90(
         b90p1 = bend90_ports[0]
         b90p2 = bend90_ports[1]
     assert b90p1.name is not None, logger.error(
-        "bend90_cell needs named ports, {}", b90p1
+        "bend90_cell needs named ports, {}",
+        b90p1,
     )
     assert b90p2.name is not None, logger.error(
-        "bend90_cell needs named ports, {}", b90p2
+        "bend90_cell needs named ports, {}",
+        b90p2,
     )
     b90c = kdb.Trans(
         b90p1.trans.rot,
@@ -475,7 +477,8 @@ def place90(
         b90p2.trans.disp.y if b90p1.trans.angle % 2 else b90p1.trans.disp.y,
     )
     b90r = max(
-        (b90p1.trans.disp - b90c.disp).length(), (b90p2.trans.disp - b90c.disp).length()
+        (b90p1.trans.disp - b90c.disp).length(),
+        (b90p2.trans.disp - b90c.disp).length(),
     )
     if taper_cell is not None:
         taper_ports = [p for p in taper_cell.ports if p.port_type == "optical"]
@@ -485,7 +488,7 @@ def place90(
         ):
             raise AttributeError(
                 "Taper must have only two optical ports that are 180° oriented to each"
-                " other"
+                " other",
             )
         if taper_ports[1].width == b90p1.width:
             taperp2, taperp1 = taper_ports
@@ -494,7 +497,7 @@ def place90(
         else:
             raise AttributeError(
                 "At least one of the taper's optical ports must be the same width as"
-                " the bend's ports"
+                " the bend's ports",
             )
         route = ManhattanRoute(
             backbone=list(pts).copy(),
@@ -605,9 +608,9 @@ def place90(
             raise ValueError(
                 f"distance between points {old_pt!s} and {pt!s} is too small to"
                 f" safely place bends {pt.to_s()=}, {old_pt.to_s()=},"
-                f" {pt.distance(old_pt)=} < {b90r=}"
+                f" {pt.distance(old_pt)=} < {b90r=}",
             )
-        elif (
+        if (
             pt.distance(old_pt) < 2 * b90r
             and i not in [1, len(pts) - 1]
             and not allow_small_routes
@@ -615,7 +618,7 @@ def place90(
             raise ValueError(
                 f"distance between points {old_pt!s} and {pt!s} is too small to"
                 f" safely place bends {pt=!s}, {old_pt=!s},"
-                f" {pt.distance(old_pt)=} < {2 * b90r=}"
+                f" {pt.distance(old_pt)=} < {2 * b90r=}",
             )
 
         vec = pt - old_pt
@@ -627,16 +630,16 @@ def place90(
         mirror = (vec_angle(vec_n) - vec_angle(vec)) % 4 != 3
         if (vec.y != 0) and (vec.x != 0):
             raise ValueError(
-                f"The vector between manhattan points is not manhattan {old_pt}, {pt}"
+                f"The vector between manhattan points is not manhattan {old_pt}, {pt}",
             )
         ang = (vec_angle(vec) + 2) % 4
         if ang is None:
             raise ValueError(
-                f"The vector between manhattan points is not manhattan {old_pt}, {pt}"
+                f"The vector between manhattan points is not manhattan {old_pt}, {pt}",
             )
         bend90.transform(kdb.Trans(ang, mirror, pt.x, pt.y) * b90c.inverted())
         length = int(
-            (bend90.ports[b90p1.name].trans.disp - old_bend_port.trans.disp).length()
+            (bend90.ports[b90p1.name].trans.disp - old_bend_port.trans.disp).length(),
         )
         route.length += int(length)
         if length > 0:
@@ -672,7 +675,7 @@ def place90(
                 )
                 route.instances.append(t1)
                 _l = int(
-                    length - (taperp1.trans.disp - taperp2.trans.disp).length() * 2
+                    length - (taperp1.trans.disp - taperp2.trans.disp).length() * 2,
                 )
                 if length - (taperp1.trans.disp - taperp2.trans.disp).length() * 2 != 0:
                     wg = c << straight_factory(
@@ -758,7 +761,7 @@ def place90(
             route.instances.append(t1)
             if length - (taperp1.trans.disp - taperp2.trans.disp).length() * 2 != 0:
                 _l = int(
-                    length - (taperp1.trans.disp - taperp2.trans.disp).length() * 2
+                    length - (taperp1.trans.disp - taperp2.trans.disp).length() * 2,
                 )
                 wg = c << straight_factory(
                     width=taperp2.width,
@@ -855,7 +858,7 @@ def route_loopback(
     ):
         raise ValueError(
             "for a standard loopback the ports must point in the same direction and"
-            "have to be parallel"
+            "have to be parallel",
         )
 
     pz = kdb.Point(0, 0)
@@ -889,16 +892,18 @@ def route_loopback(
             t2 *= kdb.Trans(2, False, end_straight, bend180_radius)
         else:
             t1 *= kdb.Trans(
-                2, False, start_straight + bend90_radius, -2 * bend90_radius
+                2,
+                False,
+                start_straight + bend90_radius,
+                -2 * bend90_radius,
             )
             t2 *= kdb.Trans(2, False, end_straight + bend90_radius, 2 * bend90_radius)
+    elif bend180_radius is not None:
+        t1 *= kdb.Trans(2, False, start_straight, bend180_radius)
+        t2 *= kdb.Trans(2, False, end_straight, -bend180_radius)
     else:
-        if bend180_radius is not None:
-            t1 *= kdb.Trans(2, False, start_straight, bend180_radius)
-            t2 *= kdb.Trans(2, False, end_straight, -bend180_radius)
-        else:
-            t1 *= kdb.Trans(2, False, start_straight + bend90_radius, 2 * bend90_radius)
-            t2 *= kdb.Trans(2, False, end_straight + bend90_radius, -2 * bend90_radius)
+        t1 *= kdb.Trans(2, False, start_straight + bend90_radius, 2 * bend90_radius)
+        t2 *= kdb.Trans(2, False, end_straight + bend90_radius, -2 * bend90_radius)
 
     return (
         pts_start
@@ -973,7 +978,7 @@ def route(
     if p1.width != p2.width and not allow_width_mismatch:
         raise ValueError(
             f"The ports have different widths {p1.width=} {p2.width=}. If this is"
-            "intentional, add `allow_width_mismatch=True` to override this."
+            "intentional, add `allow_width_mismatch=True` to override this.",
         )
 
     p1 = p1.copy()
@@ -986,13 +991,13 @@ def route(
 
     if len(bend90_ports) != 2:
         raise ValueError(
-            f"{bend90_cell.name} should have 2 ports but has {len(bend90_ports)} ports"
+            f"{bend90_cell.name} should have 2 ports but has {len(bend90_ports)} ports",
         )
 
     if abs((bend90_ports[0].trans.angle - bend90_ports[1].trans.angle) % 4) != 1:
         raise ValueError(
             f"{bend90_cell.name} bend ports should be 90° apart from each other. "
-            f"{bend90_ports[0]=} {bend90_ports[1]=}"
+            f"{bend90_ports[0]=} {bend90_ports[1]=}",
         )
     if (bend90_ports[1].trans.angle - bend90_ports[0].trans.angle) % 4 == 3:
         b90p1 = bend90_ports[1]
@@ -1014,7 +1019,7 @@ def route(
         max(
             (b90p1.trans.disp - b90c.disp).length(),
             (b90p2.trans.disp - b90c.disp).length(),
-        )
+        ),
     )
 
     if bend180_cell is not None:
@@ -1023,19 +1028,17 @@ def route(
         if len(bend180_ports) != 2:
             raise AttributeError(
                 f"{bend180_cell.name} should have 2 ports but has {len(bend180_ports)}"
-                " ports"
+                " ports",
             )
         if abs((bend180_ports[0].trans.angle - bend180_ports[1].trans.angle) % 4) != 0:
             raise AttributeError(
                 f"{bend180_cell.name} bend ports for bend180 should be 0° apart from"
-                f" each other, {bend180_ports[0]=} {bend180_ports[1]=}"
+                f" each other, {bend180_ports[0]=} {bend180_ports[1]=}",
             )
         d = 1 if bend180_ports[0].trans.angle in [0, 3] else -1
-        b180p1, b180p2 = list(
-            sorted(
-                bend180_ports,
-                key=lambda port: (d * port.trans.disp.x, d * port.trans.disp.y),
-            )
+        b180p1, b180p2 = sorted(
+            bend180_ports,
+            key=lambda port: (d * port.trans.disp.x, d * port.trans.disp.y),
         )
 
         b180r = int((b180p2.trans.disp - b180p1.trans.disp).length())
@@ -1113,7 +1116,7 @@ def route(
                         bend180.purpose = purpose
                         bend180.transform(
                             kdb.Trans((ang1 + 2) % 4, False, pt2.x, pt2.y)
-                            * b180p1.trans.inverted()
+                            * b180p1.trans.inverted(),
                         )
                         place90(
                             c=c,
@@ -1141,7 +1144,7 @@ def route(
                         bend180.purpose = purpose
                         bend180.transform(
                             kdb.Trans((ang1 + 2) % 4, False, pt2.x, pt2.y)
-                            * b180p2.trans.inverted()
+                            * b180p2.trans.inverted(),
                         )
                         place90(
                             c=c,

--- a/src/kfactory/routing/steps.py
+++ b/src/kfactory/routing/steps.py
@@ -52,7 +52,7 @@ class Left(Step):
                     bend_radius = router.router.bend90_radius
                     raise ValueError(
                         "If the next bend should be avoided the step needs to be bigger"
-                        f" than {2 * bend_radius=}"
+                        f" than {2 * bend_radius=}",
                     )
                 router.straight_nobend(self.dist)
             else:
@@ -84,7 +84,7 @@ class Right(Step):
                     bend_radius = router.router.bend90_radius
                     raise ValueError(
                         "If the next bend should be avoided the step needs to be bigger"
-                        f" than {2 * bend_radius=}"
+                        f" than {2 * bend_radius=}",
                     )
                 router.straight_nobend(self.dist)
             else:
@@ -123,7 +123,7 @@ class X(Step):
             raise ValueError(
                 "Cannot go to position {self.x=}, because the router is currently "
                 "going in the y direction with position "
-                f"{(router.t.disp.x, router.t.disp.y)}"
+                f"{(router.t.disp.x, router.t.disp.y)}",
             )
         if self.x:
             if _ib:
@@ -145,7 +145,7 @@ class Y(Step):
             raise ValueError(
                 "Cannot go to position {self.x=}, because the router is currently "
                 "going in the y direction with position "
-                f"{(router.t.disp.x, router.t.disp.y)}"
+                f"{(router.t.disp.x, router.t.disp.y)}",
             )
         if self.y:
             if _ib:
@@ -175,44 +175,43 @@ class XY(Step):
                         "XY step cannot go back. It is current pointing at 0"
                         " degrees.\n"
                         f"Current position: {router.t.disp!r}.\n"
-                        f"Target Position ({self.x},{self.y})"
+                        f"Target Position ({self.x},{self.y})",
                     )
                     if _ib:
                         router.straight_nobend(abs(dx))
                     else:
                         router.straight(abs(dx))
-                else:
-                    if sign * dx < router.t.disp.x + router.router.bend90_radius:
-                        raise ValueError("XY step cannot go back")
-                    router.straight_nobend(abs(dx))
-                    if self.y > router.t.disp.y:
-                        if a == 0:
-                            router.left()
-                        else:
-                            router.right()
-                    dy = self.y - router.t.disp.y
-                    if _ib:
-                        if abs(dy) < 0:
-                            raise ValueError(
-                                "XY's y-step is too small. It is current pointing"
-                                f" at {router.t.angle * 90}"
-                                " degrees.\n"
-                                f"Current position: {router.t.disp!r}.\n"
-                                f"Target Position ({self.x},{self.y})"
-                            )
-                        router.straight(abs(dy))
+                if sign * dx < router.t.disp.x + router.router.bend90_radius:
+                    raise ValueError("XY step cannot go back")
+                router.straight_nobend(abs(dx))
+                if self.y > router.t.disp.y:
+                    if a == 0:
+                        router.left()
                     else:
-                        if abs(dy) < router.router.bend90_radius:
-                            raise ValueError(
-                                "XY's y-step is too small. It is current pointing"
-                                f" at {router.t.angle * 90}"
-                                " degrees.\n"
-                                f"Current position: {router.t.disp!r}.\n"
-                                f"Target Position ({self.x},{self.y})\n"
-                                "Too small distance to place bend of "
-                                f"{router.router.bend90_radius} size"
-                            )
-                        router.straight_nobend(abs(dy))
+                        router.right()
+                dy = self.y - router.t.disp.y
+                if _ib:
+                    if abs(dy) < 0:
+                        raise ValueError(
+                            "XY's y-step is too small. It is current pointing"
+                            f" at {router.t.angle * 90}"
+                            " degrees.\n"
+                            f"Current position: {router.t.disp!r}.\n"
+                            f"Target Position ({self.x},{self.y})",
+                        )
+                    router.straight(abs(dy))
+                else:
+                    if abs(dy) < router.router.bend90_radius:
+                        raise ValueError(
+                            "XY's y-step is too small. It is current pointing"
+                            f" at {router.t.angle * 90}"
+                            " degrees.\n"
+                            f"Current position: {router.t.disp!r}.\n"
+                            f"Target Position ({self.x},{self.y})\n"
+                            "Too small distance to place bend of "
+                            f"{router.router.bend90_radius} size",
+                        )
+                    router.straight_nobend(abs(dy))
 
             case 1 | 3 if self.x == router.t.disp.x:
                 sign = -1 if a == 3 else 1
@@ -221,44 +220,43 @@ class XY(Step):
                         "XY step cannot go back. It is current pointing at 0"
                         " degrees.\n"
                         f"Current position: {router.t.disp!r}.\n"
-                        f"Target Position ({self.x},{self.y})"
+                        f"Target Position ({self.x},{self.y})",
                     )
                     if _ib:
                         router.straight_nobend(abs(dy))
                     else:
                         router.straight(abs(dy))
-                else:
-                    if sign * dy < router.t.disp.y + router.router.bend90_radius:
-                        raise ValueError("XY step cannot go back")
-                    router.straight_nobend(abs(dx))
-                    if self.x > router.t.disp.x:
-                        if a == 3:
-                            router.left()
-                        else:
-                            router.right()
-                    dx = self.x - router.t.disp.x
-                    if _ib:
-                        if abs(dy) < 0:
-                            raise ValueError(
-                                "XY's y-step is too small. It is current pointing"
-                                f" at {router.t.angle * 90}"
-                                " degrees.\n"
-                                f"Current position: {router.t.disp!r}.\n"
-                                f"Target Position ({self.x},{self.y})"
-                            )
-                        router.straight(abs(dy))
+                if sign * dy < router.t.disp.y + router.router.bend90_radius:
+                    raise ValueError("XY step cannot go back")
+                router.straight_nobend(abs(dx))
+                if self.x > router.t.disp.x:
+                    if a == 3:
+                        router.left()
                     else:
-                        if abs(dy) < router.router.bend90_radius:
-                            raise ValueError(
-                                "XY's y-step is too small. It is current pointing"
-                                f" at {router.t.angle * 90}"
-                                " degrees.\n"
-                                f"Current position: {router.t.disp!r}.\n"
-                                f"Target Position ({self.x},{self.y})\n"
-                                "Too small distance to place bend of "
-                                f"{router.router.bend90_radius} size"
-                            )
-                        router.straight_nobend(abs(dy))
+                        router.right()
+                dx = self.x - router.t.disp.x
+                if _ib:
+                    if abs(dy) < 0:
+                        raise ValueError(
+                            "XY's y-step is too small. It is current pointing"
+                            f" at {router.t.angle * 90}"
+                            " degrees.\n"
+                            f"Current position: {router.t.disp!r}.\n"
+                            f"Target Position ({self.x},{self.y})",
+                        )
+                    router.straight(abs(dy))
+                else:
+                    if abs(dy) < router.router.bend90_radius:
+                        raise ValueError(
+                            "XY's y-step is too small. It is current pointing"
+                            f" at {router.t.angle * 90}"
+                            " degrees.\n"
+                            f"Current position: {router.t.disp!r}.\n"
+                            f"Target Position ({self.x},{self.y})\n"
+                            "Too small distance to place bend of "
+                            f"{router.router.bend90_radius} size",
+                        )
+                    router.straight_nobend(abs(dy))
 
 
 class Steps(RootModel[list[Any]]):
@@ -274,7 +272,7 @@ class Steps(RootModel[list[Any]]):
             if not isinstance(step, Step):
                 raise ValueError(
                     "All Steps must implement an "
-                    "'execute(self, router: ManhattanRouterSide, include_bend: bool)"
+                    "'execute(self, router: ManhattanRouterSide, include_bend: bool)",
                 )
         return self
 

--- a/src/kfactory/routing/steps.py
+++ b/src/kfactory/routing/steps.py
@@ -182,7 +182,8 @@ class XY(Step):
                     else:
                         router.straight(abs(dx))
                 if sign * dx < router.t.disp.x + router.router.bend90_radius:
-                    raise ValueError("XY step cannot go back")
+                    msg = "XY step cannot go back"
+                    raise ValueError(msg)
                 router.straight_nobend(abs(dx))
                 if self.y > router.t.disp.y:
                     if a == 0:
@@ -227,7 +228,8 @@ class XY(Step):
                     else:
                         router.straight(abs(dy))
                 if sign * dy < router.t.disp.y + router.router.bend90_radius:
-                    raise ValueError("XY step cannot go back")
+                    msg = "XY step cannot go back"
+                    raise ValueError(msg)
                 router.straight_nobend(abs(dx))
                 if self.x > router.t.disp.x:
                     if a == 3:
@@ -270,9 +272,12 @@ class Steps(RootModel[list[Any]]):
     def _check_steps(self) -> Self:
         for step in self.root:
             if not isinstance(step, Step):
-                raise ValueError(
+                msg = (
                     "All Steps must implement an "
-                    "'execute(self, router: ManhattanRouterSide, include_bend: bool)",
+                    "'execute(self, router: ManhattanRouterSide, include_bend: bool)"
+                )
+                raise ValueError(
+                    msg,
                 )
         return self
 

--- a/src/kfactory/shapes.py
+++ b/src/kfactory/shapes.py
@@ -18,7 +18,9 @@ class VShapes:
     _bbox: kdb.DBox
 
     def __init__(
-        self, cell: VKCell, _shapes: Sequence[ShapeLike] | None = None
+        self,
+        cell: VKCell,
+        _shapes: Sequence[ShapeLike] | None = None,
     ) -> None:
         self.cell = cell
         self._shapes = list(_shapes) if _shapes is not None else []
@@ -30,7 +32,7 @@ class VShapes:
             isinstance(shape, kdb.Shape)
             and shape.cell.layout().dbu != self.cell.kcl.dbu
         ):
-            raise ValueError()
+            raise ValueError
         if isinstance(shape, kdb.DBox):
             shape = kdb.DPolygon(shape)
         elif isinstance(shape, kdb.Box):
@@ -72,7 +74,7 @@ class VShapes:
                     )
                 else:
                     new_shapes.append(
-                        shape.to_dtype(self.cell.kcl.dbu).transformed(trans)
+                        shape.to_dtype(self.cell.kcl.dbu).transformed(trans),
                     )
             else:
                 new_shapes.append(shape.dpolygon.transform(trans))

--- a/src/kfactory/shapes.py
+++ b/src/kfactory/shapes.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
-from collections.abc import Iterator, Sequence
 from typing import TYPE_CHECKING
 
 from . import kdb
 from .typings import DShapeLike, IShapeLike, ShapeLike
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator, Sequence
+
     from .kcell import VKCell
 
 

--- a/src/kfactory/technology/layer_map.py
+++ b/src/kfactory/technology/layer_map.py
@@ -47,16 +47,14 @@ class LayerPropertiesModel(BaseModel):
         """Convert string to the index with the dict dither2index."""
         if isinstance(v, str):
             return dither2index[v]
-        else:
-            return v
+        return v
 
     @field_validator("line_style", mode="before")
     def line_to_index(cls, v: str | int) -> int:
         """Convert string to the index with the dict dither2index."""
         if isinstance(v, str):
             return line2index[v]
-        else:
-            return v
+        return v
 
     # @staticmethod
     @field_serializer("dither_pattern")
@@ -122,7 +120,7 @@ def lyp_to_yaml(inp: pathlib.Path | str, out: pathlib.Path | str) -> None:
         lpnr = iter.current()
         if lpnr.has_children():
             layers.append(
-                LayerGroupModel(name=lpnr.name, members=kl2group(iter.first_child()))
+                LayerGroupModel(name=lpnr.name, members=kl2group(iter.first_child())),
             )
         else:
             layers.append(kl2lp(lpnr))
@@ -162,7 +160,7 @@ def kl2group(
         lpnr = iter.current()
         if lpnr.has_children():
             members.append(
-                LayerGroupModel(name=lpnr.name, members=kl2group(iter.first_child()))
+                LayerGroupModel(name=lpnr.name, members=kl2group(iter.first_child())),
             )
         else:
             members.append(kl2lp(lpnr))

--- a/src/kfactory/typings.py
+++ b/src/kfactory/typings.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Annotated, Any, ParamSpec, TypeAlias, TypeVar
 
 import klayout.db as kdb
-import klayout.lay as lay
+from klayout import lay
 
 if TYPE_CHECKING:
     from .instance import ProtoInstance
@@ -26,7 +26,8 @@ TInstance = TypeVar("TInstance", bound="ProtoInstance[Any]", covariant=True)
 
 KCellParams = ParamSpec("KCellParams")
 AnyTrans = TypeVar(
-    "AnyTrans", bound=kdb.Trans | kdb.DTrans | kdb.ICplxTrans | kdb.DCplxTrans
+    "AnyTrans",
+    bound=kdb.Trans | kdb.DTrans | kdb.ICplxTrans | kdb.DCplxTrans,
 )
 SerializableShape: TypeAlias = (
     kdb.Box

--- a/src/kfactory/utilities.py
+++ b/src/kfactory/utilities.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any, Literal
 
 from rich.json import JSON
@@ -10,6 +9,8 @@ from . import kdb
 from .conf import DEFAULT_TRANS, config
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     from .instance import Instance
     from .port import Port, ProtoPort
 
@@ -88,8 +89,8 @@ def check_inst_ports(p1: Port, p2: Port) -> int:
 
 
 def check_cell_ports(p1: ProtoPort[Any], p2: ProtoPort[Any]) -> int:
-    p1_ = Port(base=p1.base)
-    p2_ = Port(base=p2.base)
+    p1_ = p1.to_itype()
+    p2_ = p2.to_itype()
     check_int = 0
     if p1_.width != p2_.width:
         check_int += 1

--- a/src/kfactory/utilities.py
+++ b/src/kfactory/utilities.py
@@ -105,7 +105,8 @@ def instance_port_name(inst: Instance, port: Port) -> str:
 
 
 def pprint_ports(
-    ports: Iterable[ProtoPort[Any]], unit: Literal["dbu", "um", None] = None
+    ports: Iterable[ProtoPort[Any]],
+    unit: Literal["dbu", "um", None] = None,
 ) -> Table:
     """Print ports as a table.
 

--- a/src/kfactory/utils/fill.py
+++ b/src/kfactory/utils/fill.py
@@ -5,10 +5,10 @@ Filling empty regions in [KCells][kfactory.kcell.KCell] with filling cells.
 
 from collections.abc import Iterable
 
-from .. import kdb
-from ..conf import config, logger
-from ..kcell import KCell
-from ..layout import KCLayout
+from kfactory import kdb
+from kfactory.conf import config, logger
+from kfactory.kcell import KCell
+from kfactory.layout import KCLayout
 
 stop = False
 
@@ -248,13 +248,13 @@ def fill_tiled(
             queue_str = (
                 "var fill= "
                 + (
-                    " + ".join([layers, regions])
+                    f"{layers} + {regions}"
                     if regions and layers
                     else regions + layers
                 )
                 + "; var exclude = "
                 + (
-                    " + ".join([exlayers, exregions])
+                    f"{exlayers} + {exregions}"
                     if exregions and exlayers
                     else exregions + exlayers
                 )
@@ -266,7 +266,7 @@ def fill_tiled(
             queue_str = (
                 "var fill= "
                 + (
-                    " + ".join([layers, regions])
+                    f"{layers} + {regions}"
                     if regions and layers
                     else regions + layers
                 )

--- a/src/kfactory/utils/fill.py
+++ b/src/kfactory/utils/fill.py
@@ -210,26 +210,38 @@ def fill_tiled(
         exlayers = " + ".join(
             [
                 layer_name + f".sized({c.kcl.to_dbu(size)})" if size else layer_name
-                for layer_name, (_, size) in zip(exlayer_names, exclude_layers)
-            ]
+                for layer_name, (_, size) in zip(
+                    exlayer_names,
+                    exclude_layers,
+                    strict=False,
+                )
+            ],
         )
         exregions = " + ".join(
             [
                 region_name + f".sized({c.kcl.to_dbu(size)})" if size else region_name
-                for region_name, (_, size) in zip(exregion_names, exclude_regions)
-            ]
+                for region_name, (_, size) in zip(
+                    exregion_names,
+                    exclude_regions,
+                    strict=False,
+                )
+            ],
         )
         layers = " + ".join(
             [
                 layer_name + f".sized({c.kcl.to_dbu(size)})" if size else layer_name
-                for layer_name, (_, size) in zip(layer_names, fill_layers)
-            ]
+                for layer_name, (_, size) in zip(layer_names, fill_layers, strict=False)
+            ],
         )
         regions = " + ".join(
             [
                 region_name + f".sized({c.kcl.to_dbu(size)})" if size else region_name
-                for region_name, (_, size) in zip(region_names, fill_regions)
-            ]
+                for region_name, (_, size) in zip(
+                    region_names,
+                    fill_regions,
+                    strict=False,
+                )
+            ],
         )
 
         if exlayer_names or exregion_names:
@@ -267,7 +279,9 @@ def fill_tiled(
         c.kcl.start_changes()
         try:
             logger.debug(
-                "Filling {} with {}", c.kcl.future_cell_name or c.name, fill_cell.name
+                "Filling {} with {}",
+                c.kcl.future_cell_name or c.name,
+                fill_cell.name,
             )
             logger.debug("fill string: '{}'", queue_str)
             tp.execute(f"Fill {c.name}")

--- a/src/kfactory/utils/simplify.py
+++ b/src/kfactory/utils/simplify.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 
-from .. import kdb
+from kfactory import kdb
 
 
 def simplify(points: list[kdb.Point], tolerance: float) -> list[kdb.Point]:

--- a/src/kfactory/utils/violations.py
+++ b/src/kfactory/utils/violations.py
@@ -6,8 +6,8 @@ minimum space violations and then applies a fix.
 
 from typing import overload
 
-from .. import KCell, kdb
-from ..conf import config, logger
+from kfactory import KCell, kdb
+from kfactory.conf import config, logger
 
 __all__ = [
     "fix_spacing_minkowski_tiled",
@@ -107,9 +107,7 @@ def fix_spacing_tiled(
     if smooth_factor != 0 or smooth_absolute:
         keep = "true" if smooth_keep_hv else "false"
         smooth = (
-            min(int(smooth_factor * min_space), 1)
-            if not smooth_absolute
-            else smooth_absolute
+            smooth_absolute if smooth_absolute else min(int(smooth_factor * min_space), 1)
         )
         queue_str = (
             f"var sc = reg.space_check({min_space},"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,14 +56,16 @@ def wg_enc(LAYER: Layers) -> kf.LayerEnclosure:
 
 @pytest.fixture
 def straight_factory_dbu(
-    LAYER: Layers, wg_enc: kf.LayerEnclosure
+    LAYER: Layers,
+    wg_enc: kf.LayerEnclosure,
 ) -> Callable[..., kf.KCell]:
     return partial(kf.cells.straight.straight_dbu, layer=LAYER.WG, enclosure=wg_enc)
 
 
 @pytest.fixture
 def straight_factory(
-    LAYER: Layers, wg_enc: kf.LayerEnclosure
+    LAYER: Layers,
+    wg_enc: kf.LayerEnclosure,
 ) -> Callable[..., kf.KCell]:
     return partial(kf.cells.straight.straight, layer=LAYER.WG, enclosure=wg_enc)
 
@@ -71,7 +73,10 @@ def straight_factory(
 @pytest.fixture
 def straight(LAYER: Layers, wg_enc: kf.LayerEnclosure) -> kf.KCell:
     return kf.cells.straight.straight(
-        width=0.5, length=1, layer=LAYER.WG, enclosure=wg_enc
+        width=0.5,
+        length=1,
+        layer=LAYER.WG,
+        enclosure=wg_enc,
     )
 
 
@@ -83,35 +88,55 @@ def straight_blank(LAYER: Layers) -> kf.KCell:
 @pytest.fixture
 def bend90(LAYER: Layers, wg_enc: kf.LayerEnclosure) -> kf.KCell:
     return kf.cells.circular.bend_circular(
-        width=0.5, radius=10, layer=LAYER.WG, enclosure=wg_enc, angle=90
+        width=0.5,
+        radius=10,
+        layer=LAYER.WG,
+        enclosure=wg_enc,
+        angle=90,
     )
 
 
 @pytest.fixture
 def bend90_small(LAYER: Layers, wg_enc: kf.LayerEnclosure) -> kf.KCell:
     return kf.cells.circular.bend_circular(
-        width=0.5, radius=5, layer=LAYER.WG, enclosure=wg_enc, angle=90
+        width=0.5,
+        radius=5,
+        layer=LAYER.WG,
+        enclosure=wg_enc,
+        angle=90,
     )
 
 
 @pytest.fixture
 def bend180(LAYER: Layers, wg_enc: kf.LayerEnclosure) -> kf.KCell:
     return kf.cells.circular.bend_circular(
-        width=0.5, radius=10, layer=LAYER.WG, enclosure=wg_enc, angle=180
+        width=0.5,
+        radius=10,
+        layer=LAYER.WG,
+        enclosure=wg_enc,
+        angle=180,
     )
 
 
 @pytest.fixture
 def bend90_euler(LAYER: Layers, wg_enc: kf.LayerEnclosure) -> kf.KCell:
     return kf.cells.euler.bend_euler(
-        width=0.5, radius=10, layer=LAYER.WG, enclosure=wg_enc, angle=90
+        width=0.5,
+        radius=10,
+        layer=LAYER.WG,
+        enclosure=wg_enc,
+        angle=90,
     )
 
 
 @pytest.fixture
 def bend180_euler(LAYER: Layers, wg_enc: kf.LayerEnclosure) -> kf.KCell:
     return kf.cells.euler.bend_euler(
-        width=0.5, radius=10, layer=LAYER.WG, enclosure=wg_enc, angle=180
+        width=0.5,
+        radius=10,
+        layer=LAYER.WG,
+        enclosure=wg_enc,
+        angle=180,
     )
 
 
@@ -176,7 +201,10 @@ def pdk() -> kf.KCLayout:
             info=kf.kcell.Info(mesh_order=1),
         ),
         clad=kf.layer.LayerLevel(
-            layer=Layers().WGCLAD, thickness=3, zmin=0.22, material="sio2"
+            layer=Layers().WGCLAD,
+            thickness=3,
+            zmin=0.22,
+            material="sio2",
         ),
     )
     kcl = kf.KCLayout("Test_PDK", infos=Layers, layer_stack=layerstack)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,16 +7,6 @@ import pytest
 
 import kfactory as kf
 
-# kf.config.logfilter.level = kf.conf.LogLevel.ERROR
-
-
-# class LAYER_CLASS(kf.LayerEnum):
-#     kcl = kf.constant(kf.kcl)
-#     WG = (1, 0)
-#     WGCLAD = (111, 0)
-#     WGEXCLUDE = (1, 1)
-#     WGCLADEXCLUDE = (111, 1)
-
 
 class Layers(kf.LayerInfos):
     WG: kf.kdb.LayerInfo = kf.kdb.LayerInfo(1, 0)
@@ -27,9 +17,6 @@ class Layers(kf.LayerInfos):
     FILL2: kf.kdb.LayerInfo = kf.kdb.LayerInfo(3, 0)
     FILL3: kf.kdb.LayerInfo = kf.kdb.LayerInfo(10, 0)
 
-
-# kf.kcl.layers = kf.kcl.set_layers_from_infos(name="LAYER", layers=Layers())
-# kf.kcl.layer_infos = Layers()
 
 kf.kcl.infos = Layers()
 
@@ -207,8 +194,7 @@ def pdk() -> kf.KCLayout:
             material="sio2",
         ),
     )
-    kcl = kf.KCLayout("Test_PDK", infos=Layers, layer_stack=layerstack)
-    return kcl
+    return kf.KCLayout("Test_PDK", infos=Layers, layer_stack=layerstack)
 
 
 @pytest.fixture

--- a/tests/custom/show.py
+++ b/tests/custom/show.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     import kfactory
 
 

--- a/tests/test_all_angle.py
+++ b/tests/test_all_angle.py
@@ -10,7 +10,10 @@ import kfactory as kf
 def test_all_angle_bundle(LAYER: Layers) -> None:
     sf = partial(kf.cells.virtual.straight.virtual_straight, layer=LAYER.WG)
     bf = partial(
-        kf.cells.virtual.euler.virtual_bend_euler, layer=LAYER.WG, radius=10, width=1
+        kf.cells.virtual.euler.virtual_bend_euler,
+        layer=LAYER.WG,
+        radius=10,
+        width=1,
     )
 
     # vc = kf.VKCell("test_all_angle")
@@ -32,21 +35,29 @@ def test_all_angle_bundle(LAYER: Layers) -> None:
             c.create_port(
                 name=f"s{i}",
                 dcplx_trans=kf.kdb.DCplxTrans(
-                    1, a, False, -500 + r * np.cos(a_rad), -100 + r * np.sin(a_rad)
+                    1,
+                    a,
+                    False,
+                    -500 + r * np.cos(a_rad),
+                    -100 + r * np.sin(a_rad),
                 ),
                 layer=c.kcl.find_layer(LAYER.WG),
                 width=c.kcl.to_dbu(1),
-            )
+            ),
         )
         end_ports.append(
             c.create_port(
                 name=f"s{i + _l}",
                 dcplx_trans=kf.kdb.DCplxTrans(
-                    1, ae, False, 2510 + r * np.cos(ae_rad), 2410 + r * np.sin(ae_rad)
+                    1,
+                    ae,
+                    False,
+                    2510 + r * np.cos(ae_rad),
+                    2410 + r * np.sin(ae_rad),
                 ),
                 layer=c.kcl.find_layer(LAYER.WG),
                 width=c.kcl.to_dbu(1),
-            )
+            ),
         )
     backbone = [
         kf.kdb.DPoint(750, -550),

--- a/tests/test_cell.py
+++ b/tests/test_cell.py
@@ -122,7 +122,11 @@ def test_getter(LAYER: Layers) -> None:
 def test_array(straight: kf.KCell) -> None:
     c = kf.KCell()
     wg_array = c.create_inst(
-        straight, a=kf.kdb.Vector(15_000, 0), b=kf.kdb.Vector(0, 3_000), na=3, nb=5
+        straight,
+        a=kf.kdb.Vector(15_000, 0),
+        b=kf.kdb.Vector(0, 3_000),
+        na=3,
+        nb=5,
     )
     for b in range(5):
         for a in range(3):
@@ -133,7 +137,11 @@ def test_array(straight: kf.KCell) -> None:
 def test_array_indexerror(straight: kf.KCell) -> None:
     c = kf.KCell()
     wg_array = c.create_inst(
-        straight, a=kf.kdb.Vector(15_000, 0), b=kf.kdb.Vector(0, 3_000), na=3, nb=5
+        straight,
+        a=kf.kdb.Vector(15_000, 0),
+        b=kf.kdb.Vector(0, 3_000),
+        na=3,
+        nb=5,
     )
     regex = kf.config.logfilter.regex
     kf.config.logfilter.regex = r"^An error has been caught in function '__getitem__'"
@@ -253,10 +261,16 @@ def test_check_ports(LAYER: Layers) -> None:
     def test_multi_ports() -> kf.KCell:
         c = kcl.kcell()
         c.create_port(
-            name="a", trans=kf.kdb.Trans.R0, width=1000, layer=kcl.find_layer(1, 0)
+            name="a",
+            trans=kf.kdb.Trans.R0,
+            width=1000,
+            layer=kcl.find_layer(1, 0),
         )
         c.create_port(
-            name="a", trans=kf.kdb.Trans.R180, width=1000, layer=kcl.find_layer(1, 0)
+            name="a",
+            trans=kf.kdb.Trans.R180,
+            width=1000,
+            layer=kcl.find_layer(1, 0),
         )
         return c
 

--- a/tests/test_cell.py
+++ b/tests/test_cell.py
@@ -26,8 +26,7 @@ def test_euler_snapping(LAYER: Layers) -> None:
 
 @kf.cell
 def unnamed_cell(name: str = "a") -> kf.KCell:
-    c = kf.kcl.kcell(name)
-    return c
+    return kf.kcl.kcell(name)
 
 
 def test_unnamed_cell() -> None:
@@ -40,8 +39,7 @@ def test_unnamed_cell() -> None:
 def nested_list_dict(
     arg1: dict[str, list[dict[str, str | int] | int] | int],
 ) -> kf.KCell:
-    c = kf.kcl.kcell()
-    return c
+    return kf.kcl.kcell()
 
 
 def test_nested_dict_list() -> None:
@@ -78,8 +76,7 @@ def test_namecollision(LAYER: Layers) -> None:
 def test_nested_dic() -> None:
     @kf.kcl.cell
     def recursive_dict_cell(d: dict[str, dict[str, str] | str]) -> kf.KCell:
-        c = kf.KCell()
-        return c
+        return kf.KCell()
 
     recursive_dict_cell({"test": {"test2": "test3"}, "test4": "test5"})
 
@@ -169,8 +166,7 @@ def test_cell_decorator_error(LAYER: Layers) -> None:
 
     @kf.kcl.cell
     def wrong_cell() -> kf.KCell:
-        c = kcl2.kcell("wrong_test")
-        return c
+        return kcl2.kcell("wrong_test")
 
     regex = kf.config.logfilter.regex
     kf.config.logfilter.regex = (
@@ -210,17 +206,13 @@ def test_overwrite(LAYER: Layers) -> None:
 
     @kcl.cell
     def test_overwrite_cell() -> kf.KCell:
-        print("overwrite1")
-        c = kcl.kcell()
-        return c
+        return kcl.kcell()
 
     c1 = test_overwrite_cell()
 
     @kcl.cell(overwrite_existing=True)  # type: ignore[no-redef]
     def test_overwrite_cell() -> kf.KCell:
-        print("overwrite2")
-        c = kcl.kcell()
-        return c
+        return kcl.kcell()
 
     c2 = test_overwrite_cell()
 

--- a/tests/test_cells.py
+++ b/tests/test_cells.py
@@ -80,19 +80,19 @@ def taper(LAYER: Layers) -> kf.KCell:
     )
 
 
-cells = dict(
-    bend90=bend90,
-    bend180=bend180,
-    bend180_euler=bend180_euler,
-    bend90_euler=bend90_euler,
-    taper=taper,
-    straight=straight,
-)
+cells = {
+    "bend90": bend90,
+    "bend180": bend180,
+    "bend180_euler": bend180_euler,
+    "bend90_euler": bend90_euler,
+    "taper": taper,
+    "straight": straight,
+}
 
 cell_names = sorted(set(cells.keys()))
 
 
-@pytest.fixture(params=cell_names, scope="function")
+@pytest.fixture(params=cell_names)
 def cell_name(request: pytest.FixtureRequest) -> str:
     """Returns cell name."""
     return request.param  # type: ignore[no-any-return]

--- a/tests/test_cells.py
+++ b/tests/test_cells.py
@@ -11,8 +11,6 @@ from kfactory.conf import logger
 class GeometryDifference(ValueError):
     """Exception for Geometric differences."""
 
-    pass
-
 
 # class LAYER(kf.LayerEnum):  # type: ignore[unused-ignore, misc]
 #     kcl = kf.constant(kf.kcl)
@@ -25,31 +23,50 @@ wg_enc = kf.LayerEnclosure(name="WGSTD", sections=[(Layers().WGCLAD, 0, 2000)])
 
 def straight(LAYER: Layers) -> kf.KCell:
     return kf.cells.straight.straight(
-        width=0.5, length=1, layer=LAYER.WG, enclosure=wg_enc
+        width=0.5,
+        length=1,
+        layer=LAYER.WG,
+        enclosure=wg_enc,
     )
 
 
 def bend90(LAYER: Layers) -> kf.KCell:
     return kf.cells.circular.bend_circular(
-        width=1, radius=10, layer=LAYER.WG, enclosure=wg_enc, angle=90
+        width=1,
+        radius=10,
+        layer=LAYER.WG,
+        enclosure=wg_enc,
+        angle=90,
     )
 
 
 def bend180(LAYER: Layers) -> kf.KCell:
     return kf.cells.circular.bend_circular(
-        width=1, radius=10, layer=LAYER.WG, enclosure=wg_enc, angle=180
+        width=1,
+        radius=10,
+        layer=LAYER.WG,
+        enclosure=wg_enc,
+        angle=180,
     )
 
 
 def bend90_euler(LAYER: Layers) -> kf.KCell:
     return kf.cells.euler.bend_euler(
-        width=1, radius=10, layer=LAYER.WG, enclosure=wg_enc, angle=90
+        width=1,
+        radius=10,
+        layer=LAYER.WG,
+        enclosure=wg_enc,
+        angle=90,
     )
 
 
 def bend180_euler(LAYER: Layers) -> kf.KCell:
     return kf.cells.euler.bend_euler(
-        width=1, radius=10, layer=LAYER.WG, enclosure=wg_enc, angle=180
+        width=1,
+        radius=10,
+        layer=LAYER.WG,
+        enclosure=wg_enc,
+        angle=180,
     )
 
 
@@ -72,7 +89,7 @@ cells = dict(
     straight=straight,
 )
 
-cell_names = list(sorted(set(cells.keys())))
+cell_names = sorted(set(cells.keys()))
 
 
 @pytest.fixture(params=cell_names, scope="function")
@@ -123,7 +140,7 @@ def test_cells(cell_name: str, LAYER: Layers) -> None:
                 run_cell.write(ref_file.name)
 
             raise GeometryDifference(
-                f"Differences found in {cell!r} on layer {layer_tuple}"
+                f"Differences found in {cell!r} on layer {layer_tuple}",
             )
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,9 +12,9 @@ def test_custom_show() -> None:
         lyrdb: kf.rdb.ReportDatabase | Path | str | None = None,
         l2n: kf.kdb.LayoutToNetlist | Path | str | None = None,
         keep_position: bool = True,
-        save_options: kf.kdb.SaveLayoutOptions = kf.save_layout_options(),
+        save_options: kf.kdb.SaveLayoutOptions | None = None,
         use_libraries: bool = True,
-        library_save_options: kf.kdb.SaveLayoutOptions = kf.save_layout_options(),
+        library_save_options: kf.kdb.SaveLayoutOptions | None = None,
     ) -> None:
         nonlocal showed
         showed = True

--- a/tests/test_dkcell.py
+++ b/tests/test_dkcell.py
@@ -7,8 +7,7 @@ import kfactory as kf
 def test_unnamed_dkcell(kcl: kf.KCLayout) -> None:
     @kcl.cell
     def unnamed_dkcell(name: str = "a") -> kf.DKCell:
-        c = kcl.dkcell(name)
-        return c
+        return kcl.dkcell(name)
 
     c1 = unnamed_dkcell("test_unnamed_dkcell")
     c2 = unnamed_dkcell("test_unnamed_dkcell")
@@ -25,8 +24,7 @@ def test_nested_dict_list_dkcell(kcl: kf.KCLayout) -> None:
     def nested_list_dict_dkcell(
         arg1: dict[str, list[dict[str, str | int] | int] | int],
     ) -> kf.DKCell:
-        c = kcl.dkcell("test_nested_list_dict_dkcell")
-        return c
+        return kcl.dkcell("test_nested_list_dict_dkcell")
 
     c = nested_list_dict_dkcell(dl)
     assert dl == c.settings["arg1"]

--- a/tests/test_enclosure.py
+++ b/tests/test_enclosure.py
@@ -16,7 +16,7 @@ def mmi_enc(layer: kf.kdb.LayerInfo, enclosure: kf.LayerEnclosure) -> kf.KCell:
             kf.kdb.Point(0, 500),
             kf.kdb.Point(2000, 250),
             kf.kdb.Point(2000, -250),
-        ]
+        ],
     )
 
     for t in [
@@ -55,7 +55,7 @@ def test_layer_multi_enc(LAYER: Layers) -> None:
             (LAYER.WGCLAD, -4000, -3900),
             (LAYER.WGCLAD, -100, 100),
             (LAYER.WGCLAD, -500, -400),
-        ]
+        ],
     )
     mmi_enc(LAYER.WG, enc)
 
@@ -80,7 +80,7 @@ def test_layer_merge_enc(LAYER: Layers) -> None:
             (LAYER.WGCLAD, -5000, -3000),
             (LAYER.WGCLAD, -4000, -2000),
             (LAYER.WGCLAD, -2000, 1000),
-        ]
+        ],
     )
     mmi_enc(LAYER.WG, enc)
 
@@ -116,7 +116,7 @@ def test_um_enclosure_nodbu(LAYER: Layers) -> None:
                 (LAYER.WGCLAD, -5, -3),
                 (LAYER.WGCLAD, -4, -2),
                 (LAYER.WGCLAD, -2, 1),
-            ]
+            ],
         )
 
 
@@ -162,7 +162,7 @@ def test_pdkenclosure(LAYER: Layers, straight_blank: kf.KCell) -> None:
             -wg_box.height() // 2 - 1000,
             wg_box.height() // 2 + 1000,
             wg_box.height() // 2 + 1000,
-        )
+        ),
     )
     for port in c.ports:
         port_wg_ex.insert(box.transformed(port.trans))

--- a/tests/test_extrude.py
+++ b/tests/test_extrude.py
@@ -7,7 +7,10 @@ from kfactory.enclosure import extrude_path_dynamic
 
 @kf.cell
 def taper_dyn(
-    length: float, width: float, layer: kf.kdb.LayerInfo, enclosure: kf.LayerEnclosure
+    length: float,
+    width: float,
+    layer: kf.kdb.LayerInfo,
+    enclosure: kf.LayerEnclosure,
 ) -> kf.KCell:
     c = kf.KCell()
 
@@ -23,7 +26,10 @@ def taper_dyn(
 
 @kf.cell
 def taper_static(
-    length: float, width: float, layer: kf.kdb.LayerInfo, enclosure: kf.LayerEnclosure
+    length: float,
+    width: float,
+    layer: kf.kdb.LayerInfo,
+    enclosure: kf.LayerEnclosure,
 ) -> kf.KCell:
     c = kf.KCell()
 

--- a/tests/test_fill.py
+++ b/tests/test_fill.py
@@ -8,8 +8,8 @@ def test_tiled_fill_space(fill_cell: kf.KCell, LAYER: Layers) -> None:
     c.shapes(LAYER.WG).insert(kf.kdb.DPolygon.ellipse(kf.kdb.DBox(5000, 3000), 512))
     c.shapes(LAYER.WGCLAD).insert(
         kf.kdb.DPolygon(
-            [kf.kdb.DPoint(0, 0), kf.kdb.DPoint(5000, 0), kf.kdb.DPoint(5000, 3000)]
-        )
+            [kf.kdb.DPoint(0, 0), kf.kdb.DPoint(5000, 0), kf.kdb.DPoint(5000, 3000)],
+        ),
     )
     kf.utils.fill_tiled(
         c,
@@ -30,8 +30,8 @@ def test_tiled_fill_vector(fill_cell: kf.KCell, LAYER: Layers) -> None:
     c.shapes(LAYER.WG).insert(kf.kdb.DPolygon.ellipse(kf.kdb.DBox(5000, 3000), 512))
     c.shapes(LAYER.WGCLAD).insert(
         kf.kdb.DPolygon(
-            [kf.kdb.DPoint(0, 0), kf.kdb.DPoint(5000, 0), kf.kdb.DPoint(5000, 3000)]
-        )
+            [kf.kdb.DPoint(0, 0), kf.kdb.DPoint(5000, 0), kf.kdb.DPoint(5000, 3000)],
+        ),
     )
 
     poly = kf.kdb.DPolygon(
@@ -40,7 +40,7 @@ def test_tiled_fill_vector(fill_cell: kf.KCell, LAYER: Layers) -> None:
             kf.kdb.DPoint(-1000, 400),
             kf.kdb.DPoint(-1000, -400),
             kf.kdb.DPoint(-2000, -400),
-        ]
+        ],
     )
 
     poly.insert_hole(kf.kdb.DBox(-1800, -200, -1200, 200))

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -11,7 +11,8 @@ def test_grid_dbu_1d(straight_factory_dbu: Callable[..., kf.KCell]) -> None:
         c,
         kcells=[
             straight_factory_dbu(
-                width=randint(500, 2500) * 2, length=randint(2000, 20_000)
+                width=randint(500, 2500) * 2,
+                length=randint(2000, 20_000),
             )
             for _ in range(10)
         ],
@@ -28,7 +29,8 @@ def test_grid_dbu_2d(straight_factory_dbu: Callable[..., kf.KCell]) -> None:
         kcells=[
             [
                 straight_factory_dbu(
-                    width=randint(500, 2500) * 2, length=randint(2000, 20_000)
+                    width=randint(500, 2500) * 2,
+                    length=randint(2000, 20_000),
                 )
                 for _ in range(10)
             ]
@@ -47,7 +49,8 @@ def test_grid_dbu_2d_uneven(straight_factory_dbu: Callable[..., kf.KCell]) -> No
         kcells=[
             [
                 straight_factory_dbu(
-                    width=randint(500, 2500) * 2, length=randint(2000, 20_000)
+                    width=randint(500, 2500) * 2,
+                    length=randint(2000, 20_000),
                 )
                 for _ in range(10 + j**2)
             ]
@@ -67,7 +70,8 @@ def test_grid_dbu_2d_rotation(straight_factory_dbu: Callable[..., kf.KCell]) -> 
         kcells=[
             [
                 straight_factory_dbu(
-                    width=randint(500, 2500) * 2, length=randint(2000, 20_000)
+                    width=randint(500, 2500) * 2,
+                    length=randint(2000, 20_000),
                 )
                 for _ in range(10)
             ]
@@ -87,7 +91,8 @@ def test_grid_dbu_1d_shape(straight_factory_dbu: Callable[..., kf.KCell]) -> Non
         c,
         kcells=[
             straight_factory_dbu(
-                width=randint(500, 2500) * 2, length=randint(2000, 20_000)
+                width=randint(500, 2500) * 2,
+                length=randint(2000, 20_000),
             )
             for _ in range(10)
         ],
@@ -105,7 +110,8 @@ def test_grid_dbu_2d_shape(straight_factory_dbu: Callable[..., kf.KCell]) -> Non
         kcells=[
             [
                 straight_factory_dbu(
-                    width=randint(500, 2500) * 2, length=randint(2000, 20_000)
+                    width=randint(500, 2500) * 2,
+                    length=randint(2000, 20_000),
                 )
                 for _ in range(10)
             ]
@@ -127,7 +133,8 @@ def test_grid_dbu_2d_shape_rotation(
         kcells=[
             [
                 straight_factory_dbu(
-                    width=randint(500, 2500) * 2, length=randint(2000, 20_000)
+                    width=randint(500, 2500) * 2,
+                    length=randint(2000, 20_000),
                 )
                 for _ in range(10)
             ]
@@ -147,7 +154,8 @@ def test_grid_1d(straight_factory_dbu: Callable[..., kf.KCell]) -> None:
         c,
         kcells=[
             straight_factory_dbu(
-                width=randint(500, 2500) * 2, length=randint(2000, 20_000)
+                width=randint(500, 2500) * 2,
+                length=randint(2000, 20_000),
             ).to_dtype()
             for _ in range(10)
         ],
@@ -164,7 +172,8 @@ def test_grid_2d(straight_factory_dbu: Callable[..., kf.KCell]) -> None:
         kcells=[
             [
                 straight_factory_dbu(
-                    width=randint(500, 2500) * 2, length=randint(2000, 20_000)
+                    width=randint(500, 2500) * 2,
+                    length=randint(2000, 20_000),
                 ).to_dtype()
                 for _ in range(10)
             ]
@@ -183,7 +192,8 @@ def test_grid_2d_uneven(straight_factory_dbu: Callable[..., kf.KCell]) -> None:
         kcells=[
             [
                 straight_factory_dbu(
-                    width=randint(500, 2500) * 2, length=randint(2000, 20_000)
+                    width=randint(500, 2500) * 2,
+                    length=randint(2000, 20_000),
                 ).to_dtype()
                 for _ in range(10 + j**2)
             ]
@@ -203,7 +213,8 @@ def test_grid_2d_rotation(straight_factory_dbu: Callable[..., kf.KCell]) -> None
         kcells=[
             [
                 straight_factory_dbu(
-                    width=randint(500, 2500) * 2, length=randint(2000, 20_000)
+                    width=randint(500, 2500) * 2,
+                    length=randint(2000, 20_000),
                 ).to_dtype()
                 for _ in range(10)
             ]
@@ -224,7 +235,8 @@ def test_grid_1d_shape(straight_factory_dbu: Callable[..., kf.KCell]) -> None:
         kcells=[
             [
                 straight_factory_dbu(
-                    width=randint(500, 2500) * 2, length=randint(2000, 20_000)
+                    width=randint(500, 2500) * 2,
+                    length=randint(2000, 20_000),
                 ).to_dtype()
                 for _ in range(10)
             ]
@@ -244,7 +256,8 @@ def test_grid_2d_shape(straight_factory_dbu: Callable[..., kf.KCell]) -> None:
         kcells=[
             [
                 straight_factory_dbu(
-                    width=randint(500, 2500) * 2, length=randint(2000, 20_000)
+                    width=randint(500, 2500) * 2,
+                    length=randint(2000, 20_000),
                 ).to_dtype()
                 for _ in range(10)
             ]
@@ -266,7 +279,8 @@ def test_grid_2d_shape_rotation(
         kcells=[
             [
                 straight_factory_dbu(
-                    width=randint(500, 2500) * 2, length=randint(2000, 20_000)
+                    width=randint(500, 2500) * 2,
+                    length=randint(2000, 20_000),
                 ).to_dtype()
                 for _ in range(10)
             ]
@@ -286,7 +300,8 @@ def test_flexgrid_dbu_1d(straight_factory_dbu: Callable[..., kf.KCell]) -> None:
         c,
         kcells=[
             straight_factory_dbu(
-                width=randint(500, 2500) * 2, length=randint(2000, 20_000)
+                width=randint(500, 2500) * 2,
+                length=randint(2000, 20_000),
             )
             for _ in range(10)
         ],
@@ -303,7 +318,8 @@ def test_flexgrid_dbu_2d(straight_factory_dbu: Callable[..., kf.KCell]) -> None:
         kcells=[
             [
                 straight_factory_dbu(
-                    width=randint(500, 2500) * 2, length=randint(2000, 20_000)
+                    width=randint(500, 2500) * 2,
+                    length=randint(2000, 20_000),
                 )
                 for _ in range(10)
             ]
@@ -324,7 +340,8 @@ def test_flexgrid_dbu_2d_rotation(
         kcells=[
             [
                 straight_factory_dbu(
-                    width=randint(500, 2500) * 2, length=randint(2000, 20_000)
+                    width=randint(500, 2500) * 2,
+                    length=randint(2000, 20_000),
                 )
                 for _ in range(10)
             ]
@@ -343,7 +360,8 @@ def test_flexgrid_dbu_1d_shape(straight_factory_dbu: Callable[..., kf.KCell]) ->
         c,
         kcells=[
             straight_factory_dbu(
-                width=randint(500, 2500) * 2, length=randint(2000, 20_000)
+                width=randint(500, 2500) * 2,
+                length=randint(2000, 20_000),
             )
             for _ in range(10)
         ],
@@ -361,7 +379,8 @@ def test_flexgrid_dbu_2d_shape(straight_factory_dbu: Callable[..., kf.KCell]) ->
         kcells=[
             [
                 straight_factory_dbu(
-                    width=randint(500, 2500) * 2, length=randint(2000, 20_000)
+                    width=randint(500, 2500) * 2,
+                    length=randint(2000, 20_000),
                 )
                 for _ in range(10)
             ]
@@ -383,7 +402,8 @@ def test_flexgrid_dbu_2d_shape_rotation(
         kcells=[
             [
                 straight_factory_dbu(
-                    width=randint(500, 2500) * 2, length=randint(2000, 20_000)
+                    width=randint(500, 2500) * 2,
+                    length=randint(2000, 20_000),
                 )
                 for _ in range(10)
             ]
@@ -406,7 +426,8 @@ def test_flexgrid_2d_shape_rotation(
         kcells=[
             [
                 straight_factory(
-                    width=round(uniform(0.5, 2.5)) * 2, length=round(uniform(2, 20))
+                    width=round(uniform(0.5, 2.5)) * 2,
+                    length=round(uniform(2, 20)),
                 ).to_dtype()
                 for _ in range(10)
             ]

--- a/tests/test_instance.py
+++ b/tests/test_instance.py
@@ -84,12 +84,13 @@ def test_dmirror(LAYER: Layers) -> None:
     b2.dmirror((p1.x, p1.y), (p2.x, p2.y))
 
     c.shapes(c.kcl.find_layer(LAYER.WG)).insert(
-        kf.kdb.DEdge(mp1, mp2).transformed(disp)
+        kf.kdb.DEdge(mp1, mp2).transformed(disp),
     )
 
 
 def _instances_equal(
-    instance1: kf.kcell.ProtoTInstance[Any], instance2: kf.kcell.ProtoTInstance[Any]
+    instance1: kf.kcell.ProtoTInstance[Any],
+    instance2: kf.kcell.ProtoTInstance[Any],
 ) -> bool:
     return (
         instance1.instance.cell_index == instance2.instance.cell_index
@@ -98,12 +99,16 @@ def _instances_equal(
 
 
 _DBUInstanceTuple: TypeAlias = tuple[
-    kf.kcell.Instance, kf.kcell.Instance, kf.kcell.Instance
+    kf.kcell.Instance,
+    kf.kcell.Instance,
+    kf.kcell.Instance,
 ]
 
 
 _UMInstanceTuple: TypeAlias = tuple[
-    kf.kcell.DInstance, kf.kcell.DInstance, kf.kcell.DInstance
+    kf.kcell.DInstance,
+    kf.kcell.DInstance,
+    kf.kcell.DInstance,
 ]
 
 
@@ -453,10 +458,14 @@ def test_vinstance_connect_by_port(kcl: kf.KCLayout, LAYER: Layers) -> None:
     c = kcl.vkcell()
     straight_factory = kf.factories.straight.straight_dbu_factory(kcl)
     straight = straight_factory(
-        width=kcl.to_dbu(5), length=kcl.to_dbu(10), layer=LAYER.WG
+        width=kcl.to_dbu(5),
+        length=kcl.to_dbu(10),
+        layer=LAYER.WG,
     )
     straight2 = straight_factory(
-        width=kcl.to_dbu(5), length=kcl.to_dbu(10), layer=LAYER.WG
+        width=kcl.to_dbu(5),
+        length=kcl.to_dbu(10),
+        layer=LAYER.WG,
     )
     ref = c << straight
     ref2 = c << straight2
@@ -466,15 +475,20 @@ def test_vinstance_connect_by_port(kcl: kf.KCLayout, LAYER: Layers) -> None:
 
 
 def test_vinstance_connect_by_port_use_angle_false(
-    kcl: kf.KCLayout, LAYER: Layers
+    kcl: kf.KCLayout,
+    LAYER: Layers,
 ) -> None:
     c = kcl.vkcell()
     straight_factory = kf.factories.straight.straight_dbu_factory(kcl)
     straight = straight_factory(
-        width=kcl.to_dbu(5), length=kcl.to_dbu(10), layer=LAYER.WG
+        width=kcl.to_dbu(5),
+        length=kcl.to_dbu(10),
+        layer=LAYER.WG,
     )
     straight2 = straight_factory(
-        width=kcl.to_dbu(5), length=kcl.to_dbu(10), layer=LAYER.WG
+        width=kcl.to_dbu(5),
+        length=kcl.to_dbu(10),
+        layer=LAYER.WG,
     )
     ref = c << straight
     ref2 = c << straight2
@@ -484,15 +498,20 @@ def test_vinstance_connect_by_port_use_angle_false(
 
 
 def test_vinstance_connect_by_port_use_mirror_false(
-    kcl: kf.KCLayout, LAYER: Layers
+    kcl: kf.KCLayout,
+    LAYER: Layers,
 ) -> None:
     c = kcl.vkcell()
     straight_factory = kf.factories.straight.straight_dbu_factory(kcl)
     straight = straight_factory(
-        width=kcl.to_dbu(5), length=kcl.to_dbu(10), layer=LAYER.WG
+        width=kcl.to_dbu(5),
+        length=kcl.to_dbu(10),
+        layer=LAYER.WG,
     )
     straight2 = straight_factory(
-        width=kcl.to_dbu(5), length=kcl.to_dbu(10), layer=LAYER.WG
+        width=kcl.to_dbu(5),
+        length=kcl.to_dbu(10),
+        layer=LAYER.WG,
     )
     ref = c << straight
     ref2 = c << straight2
@@ -502,15 +521,20 @@ def test_vinstance_connect_by_port_use_mirror_false(
 
 
 def test_vinstance_connect_by_port_use_mirror_Use_angle_false(
-    kcl: kf.KCLayout, LAYER: Layers
+    kcl: kf.KCLayout,
+    LAYER: Layers,
 ) -> None:
     c = kcl.vkcell()
     straight_factory = kf.factories.straight.straight_dbu_factory(kcl)
     straight = straight_factory(
-        width=kcl.to_dbu(5), length=kcl.to_dbu(10), layer=LAYER.WG
+        width=kcl.to_dbu(5),
+        length=kcl.to_dbu(10),
+        layer=LAYER.WG,
     )
     straight2 = straight_factory(
-        width=kcl.to_dbu(5), length=kcl.to_dbu(10), layer=LAYER.WG
+        width=kcl.to_dbu(5),
+        length=kcl.to_dbu(10),
+        layer=LAYER.WG,
     )
     ref = c << straight
     ref2 = c << straight2
@@ -523,10 +547,14 @@ def test_vinstance_connect_by_str(kcl: kf.KCLayout, LAYER: Layers) -> None:
     c = kcl.vkcell()
     straight_factory = kf.factories.straight.straight_dbu_factory(kcl)
     straight = straight_factory(
-        width=kcl.to_dbu(5), length=kcl.to_dbu(10), layer=LAYER.WG
+        width=kcl.to_dbu(5),
+        length=kcl.to_dbu(10),
+        layer=LAYER.WG,
     )
     straight2 = straight_factory(
-        width=kcl.to_dbu(5), length=kcl.to_dbu(20), layer=LAYER.WG
+        width=kcl.to_dbu(5),
+        length=kcl.to_dbu(20),
+        layer=LAYER.WG,
     )
     ref = c << straight
     ref2 = c << straight2
@@ -539,16 +567,24 @@ def test_vinstance_errors(kcl: kf.KCLayout, LAYER: Layers) -> None:
     c = kcl.vkcell()
     straight_factory = kf.factories.straight.straight_dbu_factory(kcl)
     straight = straight_factory(
-        width=kcl.to_dbu(5), length=kcl.to_dbu(10), layer=LAYER.WG
+        width=kcl.to_dbu(5),
+        length=kcl.to_dbu(10),
+        layer=LAYER.WG,
     )
     straight2 = straight_factory(
-        width=kcl.to_dbu(10), length=kcl.to_dbu(20), layer=LAYER.WG
+        width=kcl.to_dbu(10),
+        length=kcl.to_dbu(20),
+        layer=LAYER.WG,
     )
     straight3 = straight_factory(
-        width=kcl.to_dbu(5), length=kcl.to_dbu(20), layer=LAYER.FILL1
+        width=kcl.to_dbu(5),
+        length=kcl.to_dbu(20),
+        layer=LAYER.FILL1,
     )
     straight4 = straight_factory(
-        width=kcl.to_dbu(5), length=kcl.to_dbu(20), layer=LAYER.WG
+        width=kcl.to_dbu(5),
+        length=kcl.to_dbu(20),
+        layer=LAYER.WG,
     ).dup()
     straight4.ports["o1"].port_type = "non-optical"
     ref = c << straight
@@ -556,11 +592,11 @@ def test_vinstance_errors(kcl: kf.KCLayout, LAYER: Layers) -> None:
     ref3 = c << straight3
     ref4 = c << straight4
     ref5 = c << straight.dup()
-    with pytest.raises(exceptions.PortWidthMismatch):
+    with pytest.raises(exceptions.PortWidthMismatchError):
         ref.connect("o1", ref2.ports["o2"])
-    with pytest.raises(exceptions.PortLayerMismatch):
+    with pytest.raises(exceptions.PortLayerMismatchError):
         ref.connect("o1", ref3.ports["o2"])
-    with pytest.raises(exceptions.PortTypeMismatch):
+    with pytest.raises(exceptions.PortTypeMismatchError):
         ref.connect("o1", ref4.ports["o1"])
     with pytest.raises(ValueError):
         ref.connect("o1", ref5)  # type: ignore

--- a/tests/test_instance_group.py
+++ b/tests/test_instance_group.py
@@ -13,14 +13,17 @@ def _instances_equal(instance1: kf.Instance, instance2: kf.Instance) -> bool:
 
 
 _InstanceGroupTuple: TypeAlias = tuple[
-    kf.InstanceGroup, kf.InstanceGroup, kf.InstanceGroup
+    kf.InstanceGroup,
+    kf.InstanceGroup,
+    kf.InstanceGroup,
 ]
 
 
 def _instance_group_equal(
-    instance1: kf.InstanceGroup, instance2: kf.InstanceGroup
+    instance1: kf.InstanceGroup,
+    instance2: kf.InstanceGroup,
 ) -> bool:
-    for i1, i2 in zip(instance1.insts, instance2.insts):
+    for i1, i2 in zip(instance1.insts, instance2.insts, strict=False):
         if not _instances_equal(i1, i2):
             return False
     return True

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -7,7 +7,8 @@ import kfactory as kf
 
 def test_layer_infos_valid() -> None:
     layer_info = kf.LayerInfos(
-        layer1=kf.kdb.LayerInfo(1, 0), layer2=kf.kdb.LayerInfo(2, 0)
+        layer1=kf.kdb.LayerInfo(1, 0),
+        layer2=kf.kdb.LayerInfo(2, 0),
     )
     assert layer_info.layer1.layer == 1
     assert layer_info.layer1.datatype == 0

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -31,7 +31,9 @@ def test_cell_decorator(kcl: kf.KCLayout, LAYER: Layers) -> None:
 def test_set_settings_functionality(kcl: kf.KCLayout) -> None:
     @kcl.cell(set_settings=True)
     def test_set_settings(
-        name: str = "test_set_settings", width: float = 10.0, height: float = 5.0
+        name: str = "test_set_settings",
+        width: float = 10.0,
+        height: float = 5.0,
     ) -> kf.KCell:
         c = kcl.kcell(name=name)
         return c
@@ -42,7 +44,9 @@ def test_set_settings_functionality(kcl: kf.KCLayout) -> None:
 
     @kcl.cell(set_settings=False)
     def test_set_settings_no_settings(
-        name: str = "test_set_settings_no", width: float = 10.0, height: float = 5.0
+        name: str = "test_set_settings_no",
+        width: float = 10.0,
+        height: float = 5.0,
     ) -> kf.KCell:
         c = kcl.kcell(name=name)
         return c
@@ -51,7 +55,8 @@ def test_set_settings_functionality(kcl: kf.KCLayout) -> None:
     assert cell_without_settings.settings == kf.KCellSettings()
 
     test_set_settings_partial = functools.partial(
-        test_set_settings, name="test_set_settings_partial"
+        test_set_settings,
+        name="test_set_settings_partial",
     )
     cell_with_settings_partial = test_set_settings_partial()
     assert cell_with_settings_partial.function_name == "test_set_settings"
@@ -131,7 +136,9 @@ def test_cell_with_different_kcl(kcl: kf.KCLayout) -> None:
 def test_cell_parameters(kcl: kf.KCLayout) -> None:
     @kcl.cell
     def test_cell_with_empty_parameters(
-        name: str, width: float, height: float
+        name: str,
+        width: float,
+        height: float,
     ) -> kf.KCell:
         cell = kcl.kcell(name=name)
         return cell
@@ -155,17 +162,17 @@ def test_check_instances(kcl: kf.KCLayout) -> None:
 
     with pytest.raises(ValueError):
         kcl.cell(check_instances=kf.kcell.CHECK_INSTANCES.RAISE)(
-            test_cell_with_rotation
+            test_cell_with_rotation,
         )("test_rase")
 
     cell = kcl.cell(check_instances=kf.kcell.CHECK_INSTANCES.FLATTEN)(
-        test_cell_with_rotation
+        test_cell_with_rotation,
     )("test_flatten")
 
     assert len(cell.insts) == 0
 
     cell2 = kcl.cell(check_instances=kf.kcell.CHECK_INSTANCES.VINSTANCES)(
-        test_cell_with_rotation
+        test_cell_with_rotation,
     )("test_vinstances")
 
     assert cell2 is not cell
@@ -173,7 +180,7 @@ def test_check_instances(kcl: kf.KCLayout) -> None:
     assert len(cell2.insts) == 1
 
     kcl.cell(check_instances=kf.kcell.CHECK_INSTANCES.IGNORE)(test_cell_with_rotation)(
-        "test_ignore"
+        "test_ignore",
     )
 
 

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -5,6 +5,7 @@ import pytest
 from conftest import Layers
 
 import kfactory as kf
+from kfactory.exceptions import CellNameError, NonInferableReturnAnnotationError
 
 
 def test_cell_decorator(kcl: kf.KCLayout, LAYER: Layers) -> None:
@@ -35,8 +36,7 @@ def test_set_settings_functionality(kcl: kf.KCLayout) -> None:
         width: float = 10.0,
         height: float = 5.0,
     ) -> kf.KCell:
-        c = kcl.kcell(name=name)
-        return c
+        return kcl.kcell(name=name)
 
     cell_with_settings = test_set_settings()
     assert cell_with_settings.settings["width"] == 10.0
@@ -48,8 +48,7 @@ def test_set_settings_functionality(kcl: kf.KCLayout) -> None:
         width: float = 10.0,
         height: float = 5.0,
     ) -> kf.KCell:
-        c = kcl.kcell(name=name)
-        return c
+        return kcl.kcell(name=name)
 
     cell_without_settings = test_set_settings_no_settings()
     assert cell_without_settings.settings == kf.KCellSettings()
@@ -118,7 +117,7 @@ def test_cell_name_already_exists(kcl: kf.KCLayout) -> None:
         kcl.kcell(name=name)
         return cell1
 
-    with pytest.raises(kf.exceptions.CellNameError):
+    with pytest.raises(CellNameError):
         test_cell_name_already_exists("cell1")
 
 
@@ -140,11 +139,10 @@ def test_cell_parameters(kcl: kf.KCLayout) -> None:
         width: float,
         height: float,
     ) -> kf.KCell:
-        cell = kcl.kcell(name=name)
-        return cell
+        return kcl.kcell(name=name)
 
     with pytest.raises(TypeError):
-        test_cell_with_empty_parameters(name="test_cell_with_empty_parameters")  # type: ignore
+        test_cell_with_empty_parameters(name="test_cell_with_empty_parameters")
 
 
 def test_check_instances(kcl: kf.KCLayout) -> None:
@@ -190,28 +188,23 @@ def test_cell_decorator_types(kcl: kf.KCLayout) -> None:
 
     @kcl.cell(output_type=KCellSubclass)
     def test_cell(name: str) -> kf.KCell:
-        cell = kcl.kcell(name=name)
-        return cell
+        return kcl.kcell(name=name)
 
     @kcl.cell(layout_cache=True, output_type=kf.KCell)
     def test_kcell(name: str) -> kf.KCell:
-        cell = kcl.kcell(name=name)
-        return cell
+        return kcl.kcell(name=name)
 
     @kcl.cell(output_type=kf.DKCell)
     def test_k_to_dkcell(name: str) -> kf.KCell:
-        cell = kcl.kcell(name=name)
-        return cell
+        return kcl.kcell(name=name)
 
     @kcl.cell(output_type=kf.DKCell)
     def test_dkcell(name: str) -> kf.DKCell:
-        cell = kcl.dkcell(name=name)
-        return cell
+        return kcl.dkcell(name=name)
 
     @kcl.cell
     def test_dk_to_kcell(name: str) -> kf.DKCell:
-        cell = kcl.dkcell(name=name)
-        return cell
+        return kcl.dkcell(name=name)
 
     k_to_dkcell = test_k_to_dkcell("test_d_to_kcell")
     kcell = test_kcell("test_lcell")
@@ -225,7 +218,7 @@ def test_cell_decorator_types(kcl: kf.KCLayout) -> None:
     assert isinstance(dkcell, kf.DKCell)
     assert isinstance(dk_to_kcell, kf.DKCell)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(NonInferableReturnAnnotationError):
 
         @kcl.cell
         def test_no_output_type():  # type: ignore[no-untyped-def]  # noqa: ANN202

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -10,7 +10,10 @@ import kfactory as kf
 
 @kf.cell  # type: ignore[misc, unused-ignore]
 def sample(
-    s: str = "a", i: int = 3, f: float = 2.0, t: tuple[int, ...] = (1,)
+    s: str = "a",
+    i: int = 3,
+    f: float = 2.0,
+    t: tuple[int, ...] = (1,),
 ) -> kf.KCell:
     with NamedTemporaryFile("a", suffix=".oas") as temp_file:
         c = kf.KCell()
@@ -28,7 +31,7 @@ def sample(
                         kf.kdb.Point(0, 0),
                         kf.kdb.Point(500, 0),
                         kf.kdb.Point(250, 250),
-                    ]
+                    ],
                 ),
             },
         }

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -139,23 +139,10 @@ def test_metainfo_read_cell(straight: kf.KCell) -> None:
         kcell.read(t.name)
         kf.config.logfilter.regex = ""
 
-        # TODO: wait for KLayout update https://github.com/KLayout/klayout/issues/1609
-
-        # for i, port in enumerate(straight.ports):
-        #     read_port = kcell.ports[i]
-
-        #     assert port.name == read_port.name
-        #     assert port.trans == read_port.trans
-        #     assert port.dcplx_trans == read_port.dcplx_trans
-        #     assert port.port_type == read_port.port_type
-        #     assert port.width == read_port.width
-
 
 def test_nometainfo_read(straight: kf.KCell) -> None:
     """Test whether we can turn of metadata writing."""
     with NamedTemporaryFile("a", suffix=".oas") as t:
-        # save = kf.save_layout_options()
-        # save.write_context_info = True
         straight.kcl.write(t.name, kf.save_layout_options(write_context_info=False))
 
         kcl = kf.KCLayout("TEST_META")
@@ -188,8 +175,6 @@ def test_info_dump(kcl: kf.KCLayout) -> None:
     assert c.settings == c.settings.model_copy()
 
     with NamedTemporaryFile("a", suffix=".oas") as t:
-        # save = kf.save_layout_options()
-        # save.write_context_info = True
         c.kcl.write(t.name)
         kcl = kf.KCLayout("TEST_META2")
         kcl.read(t.name)

--- a/tests/test_pdk.py
+++ b/tests/test_pdk.py
@@ -12,27 +12,15 @@ kf.config.max_cellname_length = 200
 def test_pdk(LAYER: Layers) -> None:
     pdk = kf.KCLayout("PDK")
 
-    # class LAYER(kf.kcell.LayerEnum):
-    #     kcl = kf.constant(pdk)
-    #     WG = (1, 0)
-    #     WGEX = (1, 1)
-    class LAYERS(kf.LayerInfos):
-        WG: kf.kdb.LayerInfo = kf.kdb.LayerInfo(1, 0)
-        WGEX: kf.kdb.LayerInfo = kf.kdb.LayerInfo(1, 1)
-
     pdk.infos = LAYER
     for layer in LAYER.model_dump().values():
         assert getattr(pdk.layers, layer.name).layer == layer.layer
 
 
-def test_clear(LAYER: Layers) -> None:
+def test_clear() -> None:
     kcl = kf.KCLayout("CLEAR")
     kcl.layer(500, 0)
-    kcl.infos = kf.LayerInfos(**{"WG": kf.kdb.LayerInfo(1, 0)})
-    # kcl.layers = kcl.layerenum_from_dict(layers=LAYER)
-    # kcl.layers = kcl.layerenum_from_dict(
-    #     layers=kf.LayerInfos(WG=kf.kdb.LayerInfo(1, 0))
-    # )
+    kcl.infos = kf.LayerInfos(WG=kf.kdb.LayerInfo(1, 0))
     assert kcl.layers.WG == 1
     kcl.clear(keep_layers=True)
     assert kcl.layers.WG == 0
@@ -52,10 +40,10 @@ def test_kcell_delete(LAYER: Layers) -> None:
 
     s1 = s()
     _kcl.delete_cell(s1)
-    assert s1._destroyed() is True
+    assert s1.destroyed()
 
     s1 = s()
-    assert s1._destroyed() is False
+    assert not s1.destroyed()
 
 
 def test_multi_pdk(LAYER: Layers) -> None:
@@ -198,86 +186,101 @@ def test_multi_pdk_read_write(LAYER: Layers) -> None:
 
 
 def test_merge_read_shapes(LAYER: Layers) -> None:
-    with NamedTemporaryFile("w+b", suffix=".oas") as temp_file:
-        with pytest.raises(kf.kcell.MergeError):
-            kcl_1 = kf.KCLayout("MERGE_BASE_SHAPES", infos=Layers)
-            s_base = kf.factories.straight.straight_dbu_factory(kcl_1)(
-                width=1000, length=10_000, layer=LAYER.WG
-            )
-            s_copy = s_base.dup()
-            s_copy.name = "Straight"
+    with (
+        NamedTemporaryFile("w+b", suffix=".oas") as temp_file,
+        pytest.raises(kf.kcell.MergeError),
+    ):
+        kcl_1 = kf.KCLayout("MERGE_BASE_SHAPES", infos=Layers)
+        s_base = kf.factories.straight.straight_dbu_factory(kcl_1)(
+            width=1000,
+            length=10_000,
+            layer=LAYER.WG,
+        )
+        s_copy = s_base.dup()
+        s_copy.name = "Straight"
 
-            kcl_2 = kf.KCLayout("MERGE_READ_SHAPES", infos=Layers)
-            kcl_2.layers = kcl_2.layerenum_from_dict(layers=LAYER)
-            s_base = kf.factories.straight.straight_dbu_factory(kcl_2)(
-                width=1100, length=10_000, layer=LAYER.WG
-            )
-            s_copy = s_base.dup()
-            s_copy.name = "Straight"
+        kcl_2 = kf.KCLayout("MERGE_READ_SHAPES", infos=Layers)
+        kcl_2.layers = kcl_2.layerenum_from_dict(layers=LAYER)
+        s_base = kf.factories.straight.straight_dbu_factory(kcl_2)(
+            width=1100,
+            length=10_000,
+            layer=LAYER.WG,
+        )
+        s_copy = s_base.dup()
+        s_copy.name = "Straight"
 
-            kcl_2.write(temp_file.name)
+        kcl_2.write(temp_file.name)
 
-            kf.config.logfilter.regex = "(?:Found poly)|(?:MetaInfo 'kfactory:)"
-            kcl_1.read(temp_file.name)
-            kf.config.logfilter.regex = None
+        kf.config.logfilter.regex = "(?:Found poly)|(?:MetaInfo 'kfactory:)"
+        kcl_1.read(temp_file.name)
+        kf.config.logfilter.regex = None
 
 
 def test_merge_read_instances(LAYER: Layers) -> None:
-    with NamedTemporaryFile("w+b", suffix=".oas") as temp_file:
-        with pytest.raises(kf.kcell.MergeError):
-            kcl_1 = kf.KCLayout("MERGE_BASE_INSTANCES", infos=Layers)
-            kcl_1.layers = kcl_1.layerenum_from_dict(layers=LAYER)
+    with (
+        NamedTemporaryFile("w+b", suffix=".oas") as temp_file,
+        pytest.raises(kf.kcell.MergeError),
+    ):
+        kcl_1 = kf.KCLayout("MERGE_BASE_INSTANCES", infos=Layers)
+        kcl_1.layers = kcl_1.layerenum_from_dict(layers=LAYER)
 
-            enc1 = kf.LayerEnclosure(sections=[(LAYER.WG, 0, 200)], name="CLAD")
-            s_base = kf.factories.straight.straight_dbu_factory(kcl_1)(
-                width=1000, length=10_000, layer=LAYER.WGEXCLUDE, enclosure=enc1
-            )
-            s_copy = kcl_1.kcell("Straight")
-            s_copy << s_base
+        enc1 = kf.LayerEnclosure(sections=[(LAYER.WG, 0, 200)], name="CLAD")
+        s_base = kf.factories.straight.straight_dbu_factory(kcl_1)(
+            width=1000,
+            length=10_000,
+            layer=LAYER.WGEXCLUDE,
+            enclosure=enc1,
+        )
+        s_copy = kcl_1.kcell("Straight")
+        s_copy << s_base
 
-            kcl_2 = kf.KCLayout("MERGE_READ_INSTANCES", infos=Layers)
-            kcl_2.layers = kcl_2.layerenum_from_dict(layers=LAYER)
-            enc2 = kf.LayerEnclosure(sections=[(LAYER.WG, 0, 200)], name="CLAD")
-            s_base = kf.factories.straight.straight_dbu_factory(kcl_2)(
-                width=1000, length=10_000, layer=LAYER.WGEXCLUDE, enclosure=enc2
-            )
-            s_copy = kcl_2.kcell("Straight")
-            copy = s_copy << s_base
-            copy.movey(-500)
+        kcl_2 = kf.KCLayout("MERGE_READ_INSTANCES", infos=Layers)
+        kcl_2.layers = kcl_2.layerenum_from_dict(layers=LAYER)
+        enc2 = kf.LayerEnclosure(sections=[(LAYER.WG, 0, 200)], name="CLAD")
+        s_base = kf.factories.straight.straight_dbu_factory(kcl_2)(
+            width=1000,
+            length=10_000,
+            layer=LAYER.WGEXCLUDE,
+            enclosure=enc2,
+        )
+        s_copy = kcl_2.kcell("Straight")
+        copy = s_copy << s_base
+        copy.movey(-500)
 
-            kcl_2.write(temp_file.name)
+        kcl_2.write(temp_file.name)
 
-            kf.config.logfilter.regex = "Found instance"
-            kcl_1.read(temp_file.name)
-            kf.config.logfilter.regex = None
+        kf.config.logfilter.regex = "Found instance"
+        kcl_1.read(temp_file.name)
+        kf.config.logfilter.regex = None
 
 
 def test_merge_properties() -> None:
-    with NamedTemporaryFile("w+b", suffix=".oas") as temp_file:
-        with pytest.raises(kf.kcell.MergeError):
-            kcl_1 = kf.KCLayout("MERGE_BASE_PROPERTIES", infos=Layers)
-            c = kcl_1.kcell("properties_cell")
-            c.info["test_prop"] = "kcl_1"
+    with (
+        NamedTemporaryFile("w+b", suffix=".oas") as temp_file,
+        pytest.raises(kf.kcell.MergeError),
+    ):
+        kcl_1 = kf.KCLayout("MERGE_BASE_PROPERTIES", infos=Layers)
+        c = kcl_1.kcell("properties_cell")
+        c.info["test_prop"] = "kcl_1"
 
-            kcl_2 = kf.KCLayout("MERGE_READ_PROPERTIES", infos=Layers)
-            c = kcl_2.kcell("properties_cell")
-            c.info["test_prop"] = "kcl_2"
+        kcl_2 = kf.KCLayout("MERGE_READ_PROPERTIES", infos=Layers)
+        c = kcl_2.kcell("properties_cell")
+        c.info["test_prop"] = "kcl_2"
 
-            kcl_2.write(temp_file.name)
+        kcl_2.write(temp_file.name)
 
-            regex = kf.config.logfilter.regex
-            kf.config.logfilter.regex = (
-                "MetaInfo differs between existing 'kcl_1' and loaded 'kcl_2'"
-            )
-            kcl_1.read(temp_file.name)
-            kf.config.logfilter.regex = regex
+        regex = kf.config.logfilter.regex
+        kf.config.logfilter.regex = (
+            "MetaInfo differs between existing 'kcl_1' and loaded 'kcl_2'"
+        )
+        kcl_1.read(temp_file.name)
+        kf.config.logfilter.regex = regex
 
 
 def test_pdk_cell_infosettings(straight: kf.KCell, LAYER: Layers) -> None:
     kcl = kf.KCLayout("INFOSETTINGS", infos=Layers)
     c = kcl.kcell()
     _wg = c << straight
-    _wg.cell
     assert _wg.cell.settings == straight.settings
     assert _wg.cell.info == straight.info
 

--- a/tests/test_rename.py
+++ b/tests/test_rename.py
@@ -17,7 +17,7 @@ def port_tests(rename_f: Callable[..., None] | None = None) -> kf.KCell:
 
     i = 0
     for angle in range(4):
-        for x, y in zip(port_x_coords, port_y_coords):
+        for x, y in zip(port_x_coords, port_y_coords, strict=False):
             point = (
                 kf.kdb.Trans(angle, False, 0, 0) * kf.kdb.Trans(0, False, offset, 0)
             ) * kf.kdb.Point(x, y)
@@ -48,26 +48,21 @@ def test_rename_default(func: Callable[..., None]) -> None:
 
     indexes = list(range(4 * xl))
     # east:
-    inds_east = list(
-        sorted(
-            indexes[2 * xl : 3 * xl],
-            key=lambda i: (-port_y_coords[i - 2 * xl], -port_x_coords[i - 2 * xl]),
-        )
+    inds_east = sorted(
+        indexes[2 * xl : 3 * xl],
+        key=lambda i: (-port_y_coords[i - 2 * xl], -port_x_coords[i - 2 * xl]),
     )
-    inds_north = list(
-        sorted(
-            indexes[xl : 2 * xl],
-            key=lambda i: (-port_y_coords[i - xl], -port_x_coords[i - xl]),
-        )
+    inds_north = sorted(
+        indexes[xl : 2 * xl],
+        key=lambda i: (-port_y_coords[i - xl], -port_x_coords[i - xl]),
     )
-    inds_west = list(
-        sorted(indexes[:xl], key=lambda i: (-port_y_coords[i], -port_x_coords[i]))
+    inds_west = sorted(
+        indexes[:xl],
+        key=lambda i: (-port_y_coords[i], -port_x_coords[i]),
     )
-    inds_south = list(
-        sorted(
-            indexes[3 * xl : 4 * xl],
-            key=lambda i: (-port_y_coords[i - 3 * xl], -port_x_coords[i - 3 * xl]),
-        )
+    inds_south = sorted(
+        indexes[3 * xl : 4 * xl],
+        key=lambda i: (-port_y_coords[i - 3 * xl], -port_x_coords[i - 3 * xl]),
     )
 
     assert [p.name for p in port_list] == [
@@ -128,11 +123,14 @@ def test_rename_setter(LAYER: Layers) -> None:
     for i, _port in enumerate(c1.ports):
         match i % 4:
             case 1:
-                assert _port.name is not None and _port.name[1:] == str(i + 2)
+                assert _port.name is not None
+                assert _port.name[1:] == str(i + 2)
             case 2:
-                assert _port.name is not None and _port.name[1:] == str(i)
+                assert _port.name is not None
+                assert _port.name[1:] == str(i)
             case _:
-                assert _port.name is not None and _port.name[1:] == str(i + 1)
+                assert _port.name is not None
+                assert _port.name[1:] == str(i + 1)
 
     kcl.rename_function = kf.port.rename_by_direction
 
@@ -166,15 +164,18 @@ def test_rename_setter(LAYER: Layers) -> None:
     for i, _port in enumerate(c2.ports):
         match i % 4:
             case 1:
-                assert _port.name is not None and _port.name[1:] == str(i % 4 + 1), (
+                assert _port.name is not None
+                assert _port.name[1:] == str(i % 4 + 1), (
                     f"Expected {i % 4 + 1=!s}, original name {dir_list[i]}"
                 )
             case 2:
-                assert _port.name is not None and _port.name[1:] == str(i % 4 - 1), (
+                assert _port.name is not None
+                assert _port.name[1:] == str(i % 4 - 1), (
                     f"Expected {i % 4 - 1=!s}, original name {dir_list[i]}"
                 )
             case _:
-                assert _port.name is not None and _port.name[1:] == str(i % 4), (
+                assert _port.name is not None
+                assert _port.name[1:] == str(i % 4), (
                     f"Expected {i % 4=!s}, original name {dir_list[i]}"
                 )
 

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -737,3 +737,7 @@ def test_placer_error(
             bend90_cell=bend90_small,
             on_placer_error="error",
         )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -31,7 +31,6 @@ def test_route_straight(
     x: int,
     bend90: kf.KCell,
     straight_factory_dbu: Callable[..., kf.KCell],
-    LAYER: Layers,
     optical_port: kf.Port,
 ) -> None:
     c = kf.KCell()
@@ -48,7 +47,7 @@ def test_route_straight(
 
 
 @pytest.mark.parametrize(
-    "x,y,angle2",
+    ("x", "y", "angle2"),
     [
         (20000, 20000, 2),
         (10000, 10000, 3),
@@ -65,7 +64,6 @@ def test_route_straight(
 def test_route_bend90(
     bend90: kf.KCell,
     straight_factory_dbu: Callable[..., kf.KCell],
-    LAYER: Layers,
     optical_port: kf.Port,
     x: int,
     y: int,
@@ -90,7 +88,7 @@ def test_route_bend90(
 
 
 @pytest.mark.parametrize(
-    "x,y,angle2",
+    ("x", "y", "angle2"),
     [
         (20000, 20000, 2),
         (10000, 10000, 3),
@@ -108,7 +106,6 @@ def test_route_bend90(
 def test_route_bend90_invert(
     bend90: kf.KCell,
     straight_factory_dbu: Callable[..., kf.KCell],
-    LAYER: Layers,
     optical_port: kf.Port,
     x: int,
     y: int,
@@ -133,7 +130,7 @@ def test_route_bend90_invert(
 
 
 @pytest.mark.parametrize(
-    "x,y,angle2",
+    ("x", "y", "angle2"),
     [
         (40000, 40000, 2),
         (20000, 20000, 3),
@@ -143,7 +140,6 @@ def test_route_bend90_invert(
 def test_route_bend90_euler(
     bend90_euler: kf.KCell,
     straight_factory_dbu: Callable[..., kf.KCell],
-    LAYER: Layers,
     optical_port: kf.Port,
     x: int,
     y: int,
@@ -167,7 +163,6 @@ def test_route_bend90_euler(
 
 
 def test_route_bundle(
-    LAYER: Layers,
     optical_port: kf.Port,
     bend90_euler: kf.KCell,
     straight_factory_dbu: Callable[..., kf.KCell],
@@ -182,20 +177,20 @@ def test_route_bundle(
                 False,
                 i * 200_000 - 50_000,
                 (4 - i) * 6_000 if i < 5 else (i - 5) * 6_000,
-            )
+            ),
         )
         for i in range(10)
     ]
     p_end = [
         optical_port.copy(
-            kf.kdb.Trans(3, False, i * 200_000 + i**2 * 19_000 + 500_000, 300_000)
+            kf.kdb.Trans(3, False, i * 200_000 + i**2 * 19_000 + 500_000, 300_000),
         )
         for i in range(10)
     ]
 
     c.shapes(kcl.find_layer(10, 0)).insert(kf.kdb.Box(-50_000, 0, 1_750_000, -100_000))
     c.shapes(kcl.find_layer(10, 0)).insert(
-        kf.kdb.Box(1_000_000, 500_000, p_end[-1].x, 600_000)
+        kf.kdb.Box(1_000_000, 500_000, p_end[-1].x, 600_000),
     )
 
     routes = kf.routing.optical.route_bundle(
@@ -218,7 +213,6 @@ def test_route_bundle(
 def test_route_length(
     bend90_euler: kf.KCell,
     straight_factory_dbu: Callable[..., kf.KCell],
-    LAYER: Layers,
     optical_port: kf.Port,
     taper: kf.KCell,
 ) -> None:
@@ -251,7 +245,17 @@ _test_smart_routing_kcl = kf.KCLayout("TEST_SMART_ROUTING", infos=Layers)
 
 
 @pytest.mark.parametrize(
-    "indirect,sort_ports,start_bbox,start_angle,m2,m1,z,p1,p2",
+    (
+        "indirect",
+        "sort_ports",
+        "start_bbox",
+        "start_angle",
+        "m2",
+        "m1",
+        "z",
+        "p1",
+        "p2",
+    ),
     smart_bundle_routing_params,
 )
 def test_smart_routing(
@@ -271,7 +275,7 @@ def test_smart_routing(
     kcl = _test_smart_routing_kcl
     c = kcl.kcell(
         name=f"test_smart_routing_{start_bbox=}_{sort_ports=}_{indirect=}_{start_angle=}"
-        f"{m2=}_{m1=}_{z=}_{p1=}_{p2=}"
+        f"{m2=}_{m1=}_{z=}_{p1=}_{p2=}",
     )
     c.name = c.name.replace("=", "")
 
@@ -424,7 +428,6 @@ def test_smart_routing(
                 straight_factory=straight_factory_dbu,
             )
 
-    # (indirect, sort_ports, start_bbox, start_angle, m2, m1, z, p1, p2)
     match (indirect, sort_ports, start_bbox, start_angle, m2, m1, z, p1, p2):
         case (
             (True, False, False, -1, True, False, False, True, False)
@@ -636,7 +639,8 @@ def test_route_smart_waypoints_pts(
 
 
 def test_route_generic_reorient(
-    bend90_small: kf.KCell, straight_factory_dbu: Callable[..., kf.KCell], LAYER: Layers
+    bend90_small: kf.KCell,
+    straight_factory_dbu: Callable[..., kf.KCell],
 ) -> None:
     c = kf.KCell(name="test_route_generic_reorient")
 
@@ -658,7 +662,6 @@ def test_route_generic_reorient(
         )
         for i in range(10)
     ]
-    # end_ports.reverse()
 
     c.add_ports(start_ports + end_ports)
 
@@ -678,7 +681,9 @@ def test_route_generic_reorient(
 
 
 def test_placer_error(
-    bend90_small: kf.KCell, straight_factory_dbu: Callable[..., kf.KCell], LAYER: Layers
+    bend90_small: kf.KCell,
+    straight_factory_dbu: Callable[..., kf.KCell],
+    LAYER: Layers,
 ) -> None:
     c = kf.KCell(name="test_placer_error")
 
@@ -690,7 +695,10 @@ def test_placer_error(
         trans=kf.kdb.Trans(2, False, 200_000, 0),
     )
     ps2 = kf.Port(
-        name="start2", width=500, layer_info=LAYER.WG, trans=kf.kdb.Trans(0, 5_000)
+        name="start2",
+        width=500,
+        layer_info=LAYER.WG,
+        trans=kf.kdb.Trans(0, 5_000),
     )
     pe2 = kf.Port(
         name="end2",
@@ -699,7 +707,10 @@ def test_placer_error(
         trans=kf.kdb.Trans(2, False, 200_000, 5_000),
     )
     ps3 = kf.Port(
-        name="start3", width=500, layer_info=LAYER.WG, trans=kf.kdb.Trans(0, 10_000)
+        name="start3",
+        width=500,
+        layer_info=LAYER.WG,
+        trans=kf.kdb.Trans(0, 10_000),
     )
     pe3 = kf.Port(
         name="end3",

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -92,7 +92,7 @@ def test_info_restrict_types() -> None:
     assert valid_data.key3 == [1, 2, 3]
 
     with pytest.raises(ValidationError):
-        Info(key1=set([1, 2, 3]))
+        Info(key1={1, 2, 3})
 
     info_with_none = Info(key1=None)
     assert info_with_none.key1 is None

--- a/tests/test_spiral.py
+++ b/tests/test_spiral.py
@@ -31,7 +31,10 @@ def bend_circular(
         for x, y in [
             [np.sin(_angle / 180 * np.pi) * r, (-np.cos(_angle / 180 * np.pi) + 1) * r]
             for _angle in np.linspace(
-                0, angle, int(angle // angle_step + 0.5), endpoint=True
+                0,
+                angle,
+                int(angle // angle_step + 0.5),
+                endpoint=True,
             )
         ]
     ]
@@ -89,7 +92,10 @@ def dbend_circular(
         for x, y in [
             [np.sin(_angle / 180 * np.pi) * r, (-np.cos(_angle / 180 * np.pi) + 1) * r]
             for _angle in np.linspace(
-                0, angle, int(angle // angle_step + 0.5), endpoint=True
+                0,
+                angle,
+                int(angle // angle_step + 0.5),
+                endpoint=True,
             )
         ]
     ]

--- a/tests/test_transformations.py
+++ b/tests/test_transformations.py
@@ -15,7 +15,9 @@ import kfactory as kf
     ],
 )
 def test_rotation(
-    center: kf.kdb.Point | None, straight: kf.KCell, LAYER: Layers
+    center: kf.kdb.Point | None,
+    straight: kf.KCell,
+    LAYER: Layers,
 ) -> None:
     c = kf.KCell()
 
@@ -28,7 +30,7 @@ def test_rotation(
 
     if center:
         c.shapes(c.kcl.find_layer(LAYER.WGCLAD)).insert(
-            kf.kdb.Box(10).transformed(kf.kdb.Trans(center.to_v()))
+            kf.kdb.Box(10).transformed(kf.kdb.Trans(center.to_v())),
         )
 
     c.add_ports(wg1.ports)
@@ -46,7 +48,9 @@ def test_rotation(
     ],
 )
 def test_drotation(
-    center: kf.kdb.DPoint | None, straight: kf.KCell, LAYER: Layers
+    center: kf.kdb.DPoint | None,
+    straight: kf.KCell,
+    LAYER: Layers,
 ) -> None:
     c = kf.KCell()
 
@@ -60,7 +64,7 @@ def test_drotation(
 
     if center:
         c.shapes(c.kcl.find_layer(LAYER.WGCLAD)).insert(
-            kf.kdb.DBox(0.01).transformed(kf.kdb.DCplxTrans(center.to_v()))
+            kf.kdb.DBox(0.01).transformed(kf.kdb.DCplxTrans(center.to_v())),
         )
 
     c.add_ports(wg1.ports)
@@ -68,7 +72,7 @@ def test_drotation(
 
 
 @pytest.mark.parametrize(
-    "from_name,use_mirror,apply_mirror,expected_transformation",
+    ("from_name", "use_mirror", "apply_mirror", "expected_transformation"),
     [
         (True, True, True, kf.kdb.Trans(1, False, 11_000, -10_000)),
         (True, True, False, kf.kdb.Trans(1, False, 11_000, -10_000)),

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1,5 +1,6 @@
 import pytest
 
+from kfactory.exceptions import InvalidMetaDataError
 from kfactory.serialization import check_metadata_type, convert_metadata_type
 
 
@@ -23,6 +24,12 @@ def test_check_metadata_type() -> None:
     assert check_metadata_type((1, 2, 3)) == (1, 2, 3)
     assert check_metadata_type([1, 2, 3]) == [1, 2, 3]
     assert check_metadata_type({"key": "value"}) == {"key": "value"}
+    with pytest.raises(
+        InvalidMetaDataError,
+        match=" value={1, 2, 3}, type(value)=<class 'set",
+    ):
+        check_metadata_type({1, 2, 3})  # type: ignore[arg-type]
 
-    with pytest.raises(ValueError):
-        check_metadata_type(set([1, 2, 3]))  # type: ignore
+
+if __name__ == "__main__":
+    test_check_metadata_type()

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -24,10 +24,7 @@ def test_check_metadata_type() -> None:
     assert check_metadata_type((1, 2, 3)) == (1, 2, 3)
     assert check_metadata_type([1, 2, 3]) == [1, 2, 3]
     assert check_metadata_type({"key": "value"}) == {"key": "value"}
-    with pytest.raises(
-        InvalidMetaDataError,
-        match=" value={1, 2, 3}, type(value)=<class 'set",
-    ):
+    with pytest.raises(InvalidMetaDataError):
         check_metadata_type({1, 2, 3})  # type: ignore[arg-type]
 
 

--- a/tests/test_violations.py
+++ b/tests/test_violations.py
@@ -5,19 +5,26 @@ import kfactory as kf
 
 def test_min_width_minkowski(straight: kf.KCell, LAYER: Layers) -> None:
     kf.utils.violations.fix_width_minkowski_tiled(
-        c=straight, min_width=500, ref=LAYER.WG
+        c=straight,
+        min_width=500,
+        ref=LAYER.WG,
     )
 
 
 def test_min_spacing_minkowski(straight: kf.KCell, LAYER: Layers) -> None:
     kf.utils.violations.fix_spacing_minkowski_tiled(
-        c=straight, min_space=500, ref=LAYER.WG
+        c=straight,
+        min_space=500,
+        ref=LAYER.WG,
     )
 
 
 def test_min_width_and_spacing_minkowski(straight: kf.KCell, LAYER: Layers) -> None:
     kf.utils.violations.fix_width_and_spacing_minkowski_tiled(
-        c=straight, min_space=500, min_width=250, ref=LAYER.WG
+        c=straight,
+        min_space=500,
+        min_width=250,
+        ref=LAYER.WG,
     )
 
 
@@ -27,5 +34,7 @@ def test_min_spacing_drc(straight: kf.KCell, LAYER: Layers) -> None:
 
 def test_min_spacing_sizing(straight: kf.KCell, LAYER: Layers) -> None:
     kf.utils.violations.fix_spacing_sizing_tiled(
-        c=straight, min_space=500, layer=LAYER.WG
+        c=straight,
+        min_space=500,
+        layer=LAYER.WG,
     )

--- a/tests/test_virtual.py
+++ b/tests/test_virtual.py
@@ -9,7 +9,9 @@ import kfactory as kf
 def test_virtual_cell(kcl: kf.KCLayout) -> None:
     c = kcl.vkcell("TEST_VIRTUAL_CELL")
     c.shapes(kcl.find_layer(1, 0)).insert(
-        kf.kdb.DPolygon([kf.kdb.DPoint(0, 0), kf.kdb.DPoint(1, 0), kf.kdb.DPoint(0, 1)])
+        kf.kdb.DPolygon(
+            [kf.kdb.DPoint(0, 0), kf.kdb.DPoint(1, 0), kf.kdb.DPoint(0, 1)],
+        ),
     )
 
 
@@ -19,7 +21,9 @@ def test_virtual_inst(straight: kf.KCell) -> None:
 
 
 def test_virtual_cell_insert(
-    LAYER: Layers, straight: kf.KCell, wg_enc: kf.LayerEnclosure
+    LAYER: Layers,
+    straight: kf.KCell,
+    wg_enc: kf.LayerEnclosure,
 ) -> None:
     c = kf.KCell()
 
@@ -37,7 +41,10 @@ def test_virtual_cell_insert(
     e3 = vc << e_bend
     e4 = vc << e_bend
     _s = kf.cells.virtual.straight.virtual_straight(
-        width=0.5, length=10, layer=LAYER.WG, enclosure=wg_enc
+        width=0.5,
+        length=10,
+        layer=LAYER.WG,
+        enclosure=wg_enc,
     )
     s = vc << _s
 
@@ -73,7 +80,6 @@ def test_all_angle_route(LAYER: Layers, wg_enc: kf.LayerEnclosure) -> None:
             enclosure=wg_enc,
         ),
     )
-    # kf.VInstance(vc, kf.kdb.DCplxTrans()).insert_into(c)
     file = Path("test_all_angle.oas")
     vc.write(file)
     assert file.is_file()


### PR DESCRIPTION
## Summary by Sourcery

Add `strict=False` to all zip functions.

Bug Fixes:
- Fixed a potential TypeError when using zip with iterables of different lengths.

Chores:
- Applied ruff check fix.