### PR TITLE
Add ruff Naming rule and fix most errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,12 +114,13 @@ target-version = "py311"
 
 [tool.ruff.lint]
 select = [
-    "E",  # pycodestyle
     "F",  # pyflakes
+    "E",  # pycodestyle
+    "W",  # pycodestyle
     "UP", # pyupgrade
+    "N",  # pep8-naming
     # "D",   # pydocstyle
     "I",   # isort
-    "W",   # pycodestyle
     "ANN", # annotations
     "RUF", # ruff
 ]

--- a/src/kfactory/conf.py
+++ b/src/kfactory/conf.py
@@ -111,7 +111,7 @@ class LogLevel(str, Enum):
     CRITICAL = "CRITICAL"
 
 
-class CHECK_INSTANCES(str, Enum):  # noqa: N801
+class CheckInstance(str, Enum):
     RAISE = "error"
     FLATTEN = "flatten"
     VINSTANCES = "vinstances"
@@ -221,7 +221,7 @@ class Settings(BaseSettings):
     cell_overwrite_existing: bool = False
     connect_use_angle: bool = True
     connect_use_mirror: bool = True
-    check_instances: CHECK_INSTANCES = CHECK_INSTANCES.RAISE
+    check_instances: CheckInstance = CheckInstance.RAISE
     max_cellname_length: int = 99
     debug_names: bool = False
 

--- a/src/kfactory/conf.py
+++ b/src/kfactory/conf.py
@@ -111,7 +111,7 @@ class LogLevel(str, Enum):
     CRITICAL = "CRITICAL"
 
 
-class CHECK_INSTANCES(str, Enum):
+class CHECK_INSTANCES(str, Enum):  # noqa: N801
     RAISE = "error"
     FLATTEN = "flatten"
     VINSTANCES = "vinstances"

--- a/src/kfactory/conf.py
+++ b/src/kfactory/conf.py
@@ -111,7 +111,7 @@ class LogLevel(str, Enum):
     CRITICAL = "CRITICAL"
 
 
-class CheckInstance(str, Enum):
+class CheckInstances(str, Enum):
     RAISE = "error"
     FLATTEN = "flatten"
     VINSTANCES = "vinstances"
@@ -220,7 +220,7 @@ class Settings(BaseSettings):
     cell_overwrite_existing: bool = False
     connect_use_angle: bool = True
     connect_use_mirror: bool = True
-    check_instances: CheckInstance = CheckInstance.RAISE
+    check_instances: CheckInstances = CheckInstances.RAISE
     max_cellname_length: int = 99
     debug_names: bool = False
 

--- a/src/kfactory/decorators.py
+++ b/src/kfactory/decorators.py
@@ -10,7 +10,7 @@ from typing_extensions import Unpack
 if TYPE_CHECKING:
     from cachetools import Cache
 
-    from .conf import CheckInstance
+    from .conf import CheckInstances
     from .kcell import TKCell
     from .layout import KCLayout
     from .protocols import KCellFunc
@@ -23,7 +23,7 @@ class ModuleCellKWargs(TypedDict, total=False):
     set_settings: bool
     set_name: bool
     check_ports: bool
-    check_instances: CheckInstance | None
+    check_instances: CheckInstances | None
     snap_ports: bool
     add_port_layers: bool
     cache: Cache[int, Any] | dict[int, Any] | None
@@ -42,7 +42,7 @@ class KCellDecoratorKWargs(TypedDict, total=False):
     set_settings: bool
     set_name: bool
     check_ports: bool
-    check_instances: CheckInstance | None
+    check_instances: CheckInstances | None
     snap_ports: bool
     add_port_layers: bool
     cache: Cache[int, Any] | dict[int, Any] | None

--- a/src/kfactory/decorators.py
+++ b/src/kfactory/decorators.py
@@ -10,7 +10,7 @@ from typing_extensions import Unpack
 if TYPE_CHECKING:
     from cachetools import Cache
 
-    from .conf import CHECK_INSTANCES
+    from .conf import CheckInstance
     from .kcell import TKCell
     from .layout import KCLayout
     from .protocols import KCellFunc
@@ -23,7 +23,7 @@ class ModuleCellKWargs(TypedDict, total=False):
     set_settings: bool
     set_name: bool
     check_ports: bool
-    check_instances: CHECK_INSTANCES | None
+    check_instances: CheckInstance | None
     snap_ports: bool
     add_port_layers: bool
     cache: Cache[int, Any] | dict[int, Any] | None
@@ -42,7 +42,7 @@ class KCellDecoratorKWargs(TypedDict, total=False):
     set_settings: bool
     set_name: bool
     check_ports: bool
-    check_instances: CHECK_INSTANCES | None
+    check_instances: CheckInstance | None
     snap_ports: bool
     add_port_layers: bool
     cache: Cache[int, Any] | dict[int, Any] | None

--- a/src/kfactory/enclosure.py
+++ b/src/kfactory/enclosure.py
@@ -1180,6 +1180,7 @@ class KCellLayerEnclosures(BaseModel):
         return hash(tuple(self.enclosures))
 
     @field_validator("enclosures")
+    @classmethod
     def enclosures_must_have_main_layer(
         cls, v: list[LayerEnclosure]
     ) -> list[LayerEnclosure]:

--- a/src/kfactory/exceptions.py
+++ b/src/kfactory/exceptions.py
@@ -26,7 +26,7 @@ class MergeError(ValueError):
     """Raised if two layout's have conflicting cell definitions."""
 
 
-class PortWidthMismatch(ValueError):
+class PortWidthMismatchError(ValueError):
     """Error thrown when two ports don't have a matching `width`."""
 
     def __init__(
@@ -55,7 +55,7 @@ class PortWidthMismatch(ValueError):
             )
 
 
-class PortLayerMismatch(ValueError):
+class PortLayerMismatchError(ValueError):
     """Error thrown when two ports don't have a matching `layer`."""
 
     def __init__(
@@ -95,7 +95,7 @@ class PortLayerMismatch(ValueError):
             )
 
 
-class PortTypeMismatch(ValueError):
+class PortTypeMismatchError(ValueError):
     """Error thrown when two ports don't have a matching `port_type`."""
 
     def __init__(

--- a/src/kfactory/factories/euler.py
+++ b/src/kfactory/factories/euler.py
@@ -91,32 +91,29 @@ def euler_bend_points(
     if eth == 0:
         return [kdb.DPoint(0, 0)]
 
-    # Curve min radius
-    R = radius
-
     # Total displaced angle
     th = eth / 2
 
     # Total length of curve
-    Ltot = 4 * R * th
+    total_length = 4 * radius * th
 
     # Compute curve ##
-    a = np.sqrt(R**2 * np.abs(th))
+    a = np.sqrt(radius**2 * np.abs(th))
     sq2pi = np.sqrt(2 * np.pi)
 
     # Function for computing curve coords
-    (fasin, facos) = fresnel(np.sqrt(2 / np.pi) * R * th / a)
+    (fasin, facos) = fresnel(np.sqrt(2 / np.pi) * radius * th / a)
 
     def _xy(s: float) -> kdb.DPoint:
         if th == 0:
             return kdb.DPoint(0, 0)
-        elif s <= Ltot / 2:
+        elif s <= total_length / 2:
             (fsin, fcos) = fresnel(s / (sq2pi * a))
-            X = sq2pi * a * fcos
-            Y = sq2pi * a * fsin
+            x = sq2pi * a * fcos
+            y = sq2pi * a * fsin
         else:
-            (fsin, fcos) = fresnel((Ltot - s) / (sq2pi * a))
-            X = (
+            (fsin, fcos) = fresnel((total_length - s) / (sq2pi * a))
+            x = (
                 sq2pi
                 * a
                 * (
@@ -125,7 +122,7 @@ def euler_bend_points(
                     + np.sin(2 * th) * (fasin - fsin)
                 )
             )
-            Y = (
+            y = (
                 sq2pi
                 * a
                 * (
@@ -134,13 +131,13 @@ def euler_bend_points(
                     + np.sin(2 * th) * (facos - fcos)
                 )
             )
-        return kdb.DPoint(X, Y)
+        return kdb.DPoint(x, y)
 
     # Parametric step size
-    step = Ltot / max(int(th * resolution), 1)
+    step = total_length / max(int(th * resolution), 1)
 
     # Generate points
-    points = [_xy(i * step) for i in range(int(round(Ltot / step)) + 1)]
+    points = [_xy(i * step) for i in range(int(round(total_length / step)) + 1)]
 
     return points
 
@@ -153,20 +150,19 @@ def euler_endpoint(
 ) -> tuple[float, float]:
     """Gives the end point of a simple Euler bend as a i3.Coord2."""
     th = abs(angle_amount) * np.pi / 180 / 2
-    R = radius
     clockwise = angle_amount < 0
 
     (fsin, fcos) = fresnel(np.sqrt(2 * th / np.pi))
 
     a = 2 * np.sqrt(2 * np.pi * th) * (np.cos(th) * fcos + np.sin(th) * fsin)
-    r = a * R
-    X = r * np.cos(th)
-    Y = r * np.sin(th)
+    r = a * radius
+    x = r * np.cos(th)
+    y = r * np.sin(th)
 
     if clockwise:
-        Y *= -1
+        y *= -1
 
-    return X + start_point[0], Y + start_point[1]
+    return x + start_point[0], y + start_point[1]
 
 
 def euler_sbend_points(

--- a/src/kfactory/instance.py
+++ b/src/kfactory/instance.py
@@ -352,22 +352,23 @@ class ProtoTInstance(ProtoInstance[TUnit], Generic[TUnit]):
         if use_angle is None:
             use_angle = config.connect_use_angle
 
-        if isinstance(other, Instance):
+        if isinstance(other, ProtoTInstance):
             if other_port_name is None:
                 raise ValueError(
                     "portname cannot be None if an Instance Object is given. For"
                     "complex connections (non-90 degree and floating point ports) use"
                     "route_cplx instead"
                 )
-            op = Port(base=other.ports[other_port_name].base)
-        elif isinstance(other, ProtoPort):
-            op = Port(base=other.base)
+            op = other.ports[other_port_name].to_itype()
         else:
-            raise ValueError("other_instance must be of type Instance or Port")
+            op = other.to_itype()
         if isinstance(port, ProtoPort):
             p = Port(base=port.base.transformed(self.dcplx_trans.inverted()))
         else:
-            p = Port(base=self.cell.ports[port].base)
+            p = self.cell.ports[port].to_itype()
+
+        assert isinstance(p, Port) and isinstance(op, Port)
+
         if p.width != op.width and not allow_width_mismatch:
             raise PortWidthMismatchError(self, other, p, op)
         if p.layer != op.layer and not allow_layer_mismatch:
@@ -896,13 +897,13 @@ class VInstance(ProtoInstance[float], UMGeometricObject):
                     "complex connections (non-90 degree and floating point ports) use"
                     "route_cplx instead"
                 )
-            op = Port(base=other.ports[other_port_name].base)
+            op = other.ports[other_port_name].to_itype()
         else:
-            op = Port(base=other.base)
+            op = other.to_itype()
         if isinstance(port, ProtoPort):
-            p = Port(base=port.copy(self.trans.inverted()).base)
+            p = port.copy(self.trans.inverted()).to_itype()
         else:
-            p = Port(base=self.cell.ports[port].base)
+            p = self.cell.ports[port].to_itype()
 
         assert isinstance(p, Port) and isinstance(op, Port)
 

--- a/src/kfactory/instance.py
+++ b/src/kfactory/instance.py
@@ -16,9 +16,9 @@ from ruamel.yaml.representer import BaseRepresenter, MappingNode
 
 from .conf import PROPID, config, logger
 from .exceptions import (
-    PortLayerMismatch,
-    PortTypeMismatch,
-    PortWidthMismatch,
+    PortLayerMismatchError,
+    PortTypeMismatchError,
+    PortWidthMismatchError,
 )
 from .geometry import DBUGeometricObject, GeometricObject, UMGeometricObject
 from .instance_ports import (
@@ -369,11 +369,11 @@ class ProtoTInstance(ProtoInstance[TUnit], Generic[TUnit]):
         else:
             p = Port(base=self.cell.ports[port].base)
         if p.width != op.width and not allow_width_mismatch:
-            raise PortWidthMismatch(self, other, p, op)
+            raise PortWidthMismatchError(self, other, p, op)
         if p.layer != op.layer and not allow_layer_mismatch:
-            raise PortLayerMismatch(self.cell.kcl, self, other, p, op)
+            raise PortLayerMismatchError(self.cell.kcl, self, other, p, op)
         if p.port_type != op.port_type and not allow_type_mismatch:
-            raise PortTypeMismatch(self, other, p, op)
+            raise PortTypeMismatchError(self, other, p, op)
         if p.base.dcplx_trans or op.base.dcplx_trans:
             dconn_trans = kdb.DCplxTrans.M90 if mirror else kdb.DCplxTrans.R180
             match (use_mirror, use_angle):
@@ -901,11 +901,11 @@ class VInstance(ProtoInstance[float], UMGeometricObject):
         assert isinstance(p, Port) and isinstance(op, Port)
 
         if p.width != op.width and not allow_width_mismatch:
-            raise PortWidthMismatch(self, other, p, op)
+            raise PortWidthMismatchError(self, other, p, op)
         if p.layer != op.layer and not allow_layer_mismatch:
-            raise PortLayerMismatch(self.cell.kcl, self, other, p, op)
+            raise PortLayerMismatchError(self.cell.kcl, self, other, p, op)
         if p.port_type != op.port_type and not allow_type_mismatch:
-            raise PortTypeMismatch(self, other, p, op)
+            raise PortTypeMismatchError(self, other, p, op)
         dconn_trans = kdb.DCplxTrans.M90 if mirror else kdb.DCplxTrans.R180
         match (use_mirror, use_angle):
             case True, True:

--- a/src/kfactory/kcell.py
+++ b/src/kfactory/kcell.py
@@ -50,7 +50,7 @@ from ruamel.yaml.constructor import SafeConstructor
 from ruamel.yaml.representer import BaseRepresenter, MappingNode
 
 from . import kdb, rdb
-from .conf import DEFAULT_TRANS, CheckInstance, ShowFunction, config, logger
+from .conf import DEFAULT_TRANS, CheckInstances, ShowFunction, config, logger
 from .cross_section import SymmetricalCrossSection
 from .exceptions import LockedError, MergeError
 from .geometry import DBUGeometricObject, GeometricObject, UMGeometricObject
@@ -96,7 +96,7 @@ if TYPE_CHECKING:
 
 __all__ = [
     "BaseKCell",
-    "CheckInstance",
+    "CheckInstances",
     "DKCell",
     "KCell",
 ]

--- a/src/kfactory/kcell.py
+++ b/src/kfactory/kcell.py
@@ -50,7 +50,7 @@ from ruamel.yaml.constructor import SafeConstructor
 from ruamel.yaml.representer import BaseRepresenter, MappingNode
 
 from . import kdb, rdb
-from .conf import CHECK_INSTANCES, DEFAULT_TRANS, ShowFunction, config, logger
+from .conf import DEFAULT_TRANS, CheckInstance, ShowFunction, config, logger
 from .cross_section import SymmetricalCrossSection
 from .exceptions import LockedError, MergeError
 from .geometry import DBUGeometricObject, GeometricObject, UMGeometricObject
@@ -95,8 +95,8 @@ if TYPE_CHECKING:
     from .layout import KCLayout
 
 __all__ = [
-    "CHECK_INSTANCES",
     "BaseKCell",
+    "CheckInstance",
     "DKCell",
     "KCell",
 ]

--- a/src/kfactory/layout.py
+++ b/src/kfactory/layout.py
@@ -25,7 +25,7 @@ from pydantic import (
 )
 
 from . import __version__
-from .conf import CheckInstance, config, logger
+from .conf import CheckInstances, config, logger
 from .cross_section import (
     CrossSectionModel,
     CrossSectionSpec,
@@ -488,7 +488,7 @@ class KCLayout(
         set_settings: bool = ...,
         set_name: bool = ...,
         check_ports: bool = ...,
-        check_instances: CheckInstance | None = ...,
+        check_instances: CheckInstances | None = ...,
         snap_ports: bool = ...,
         add_port_layers: bool = ...,
         cache: Cache[int, Any] | dict[int, Any] | None = ...,
@@ -513,7 +513,7 @@ class KCLayout(
         set_settings: bool = ...,
         set_name: bool = ...,
         check_ports: bool = ...,
-        check_instances: CheckInstance | None = ...,
+        check_instances: CheckInstances | None = ...,
         snap_ports: bool = ...,
         add_port_layers: bool = ...,
         cache: Cache[int, Any] | dict[int, Any] | None = ...,
@@ -539,7 +539,7 @@ class KCLayout(
         set_settings: bool = True,
         set_name: bool = True,
         check_ports: bool = True,
-        check_instances: CheckInstance | None = None,
+        check_instances: CheckInstances | None = None,
         snap_ports: bool = True,
         add_port_layers: bool = True,
         cache: Cache[int, Any] | dict[int, Any] | None = None,
@@ -761,7 +761,7 @@ class KCLayout(
                                 "`check_ports=False` to the @cell decorator"
                             )
                     match check_instances:
-                        case CheckInstance.RAISE:
+                        case CheckInstances.RAISE:
                             if any(inst.is_complex() for inst in cell.each_inst()):
                                 raise ValueError(
                                     "Most foundries will not allow off-grid "
@@ -774,10 +774,10 @@ class KCLayout(
                                         if inst.is_complex()
                                     )
                                 )
-                        case CheckInstance.FLATTEN:
+                        case CheckInstances.FLATTEN:
                             if any(inst.is_complex() for inst in cell.each_inst()):
                                 cell.flatten()
-                        case CheckInstance.VINSTANCES:
+                        case CheckInstances.VINSTANCES:
                             if any(inst.is_complex() for inst in cell.each_inst()):
                                 complex_insts = [
                                     inst
@@ -790,7 +790,7 @@ class KCLayout(
                                     )
                                     vinst.trans = inst.dcplx_trans
                                     inst.delete()
-                        case CheckInstance.IGNORE:
+                        case CheckInstances.IGNORE:
                             pass
                     cell.insert_vinsts(recursive=False)
                     if snap_ports:

--- a/src/kfactory/layout.py
+++ b/src/kfactory/layout.py
@@ -279,6 +279,7 @@ class KCLayout(
         kcls[self.name] = self
 
     @model_validator(mode="before")
+    @classmethod
     def _validate_layers(cls, data: dict[str, Any]) -> dict[str, Any]:
         data["layers"] = layerenum_from_dict(
             layers=data["infos"], layout=data["library"].layout()

--- a/src/kfactory/layout.py
+++ b/src/kfactory/layout.py
@@ -25,7 +25,7 @@ from pydantic import (
 )
 
 from . import __version__
-from .conf import CHECK_INSTANCES, config, logger
+from .conf import CheckInstance, config, logger
 from .cross_section import (
     CrossSectionModel,
     CrossSectionSpec,
@@ -488,7 +488,7 @@ class KCLayout(
         set_settings: bool = ...,
         set_name: bool = ...,
         check_ports: bool = ...,
-        check_instances: CHECK_INSTANCES | None = ...,
+        check_instances: CheckInstance | None = ...,
         snap_ports: bool = ...,
         add_port_layers: bool = ...,
         cache: Cache[int, Any] | dict[int, Any] | None = ...,
@@ -513,7 +513,7 @@ class KCLayout(
         set_settings: bool = ...,
         set_name: bool = ...,
         check_ports: bool = ...,
-        check_instances: CHECK_INSTANCES | None = ...,
+        check_instances: CheckInstance | None = ...,
         snap_ports: bool = ...,
         add_port_layers: bool = ...,
         cache: Cache[int, Any] | dict[int, Any] | None = ...,
@@ -539,7 +539,7 @@ class KCLayout(
         set_settings: bool = True,
         set_name: bool = True,
         check_ports: bool = True,
-        check_instances: CHECK_INSTANCES | None = None,
+        check_instances: CheckInstance | None = None,
         snap_ports: bool = True,
         add_port_layers: bool = True,
         cache: Cache[int, Any] | dict[int, Any] | None = None,
@@ -761,7 +761,7 @@ class KCLayout(
                                 "`check_ports=False` to the @cell decorator"
                             )
                     match check_instances:
-                        case CHECK_INSTANCES.RAISE:
+                        case CheckInstance.RAISE:
                             if any(inst.is_complex() for inst in cell.each_inst()):
                                 raise ValueError(
                                     "Most foundries will not allow off-grid "
@@ -774,10 +774,10 @@ class KCLayout(
                                         if inst.is_complex()
                                     )
                                 )
-                        case CHECK_INSTANCES.FLATTEN:
+                        case CheckInstance.FLATTEN:
                             if any(inst.is_complex() for inst in cell.each_inst()):
                                 cell.flatten()
-                        case CHECK_INSTANCES.VINSTANCES:
+                        case CheckInstance.VINSTANCES:
                             if any(inst.is_complex() for inst in cell.each_inst()):
                                 complex_insts = [
                                     inst
@@ -790,7 +790,7 @@ class KCLayout(
                                     )
                                     vinst.trans = inst.dcplx_trans
                                     inst.delete()
-                        case CHECK_INSTANCES.IGNORE:
+                        case CheckInstance.IGNORE:
                             pass
                     cell.insert_vinsts(recursive=False)
                     if snap_ports:

--- a/src/kfactory/port.py
+++ b/src/kfactory/port.py
@@ -626,11 +626,7 @@ class Port(ProtoPort[int]):
     ) -> None: ...
 
     @overload
-    def __init__(
-        self,
-        *,
-        base: BasePort,
-    ) -> None: ...
+    def __init__(self, *, base: BasePort) -> None: ...
 
     def __init__(
         self,

--- a/src/kfactory/routing/electrical.py
+++ b/src/kfactory/routing/electrical.py
@@ -95,7 +95,7 @@ def route_elec(
     c_.shapes(layer).insert(path.polygon())
 
 
-def route_L(
+def route_L(  # noqa: N802
     c: KCell,
     input_ports: Sequence[Port],
     output_orientation: int = 1,

--- a/src/kfactory/settings.py
+++ b/src/kfactory/settings.py
@@ -13,6 +13,7 @@ class KCellSettings(BaseModel, extra="allow", validate_assignment=True, frozen=T
         super().__init__(**kwargs)
 
     @model_validator(mode="before")
+    @classmethod
     def restrict_types(cls, data: dict[str, Any]) -> dict[str, MetaData]:
         for name, value in data.items():
             data[name] = convert_metadata_type(value)
@@ -35,6 +36,7 @@ class KCellSettingsUnits(
         super().__init__(**kwargs)
 
     @model_validator(mode="before")
+    @classmethod
     def restrict_types(cls, data: dict[str, str]) -> dict[str, str]:
         for name, value in data.items():
             data[name] = str(value)
@@ -55,6 +57,7 @@ class Info(BaseModel, extra="allow", validate_assignment=True):
         super().__init__(**kwargs)
 
     @model_validator(mode="before")
+    @classmethod
     def restrict_types(
         cls,
         data: dict[str, MetaData],

--- a/src/kfactory/technology/layer_map.py
+++ b/src/kfactory/technology/layer_map.py
@@ -32,6 +32,7 @@ class LayerPropertiesModel(BaseModel):
     valid: bool = True
 
     @model_validator(mode="before")
+    @classmethod
     def color_to_frame_fill(cls, data: dict[str, Any]) -> dict[str, Any]:
         """Convert a color string to a frame fill."""
         if "color" in data:
@@ -43,6 +44,7 @@ class LayerPropertiesModel(BaseModel):
         return data
 
     @field_validator("dither_pattern", mode="before")
+    @classmethod
     def dither_to_index(cls, v: str | int) -> int:
         """Convert string to the index with the dict dither2index."""
         if isinstance(v, str):
@@ -51,6 +53,7 @@ class LayerPropertiesModel(BaseModel):
             return v
 
     @field_validator("line_style", mode="before")
+    @classmethod
     def line_to_index(cls, v: str | int) -> int:
         """Convert string to the index with the dict dither2index."""
         if isinstance(v, str):
@@ -58,14 +61,15 @@ class LayerPropertiesModel(BaseModel):
         else:
             return v
 
-    # @staticmethod
     @field_serializer("dither_pattern")
-    def dither_to_json(value: int) -> str:  # type: ignore[misc]
+    @staticmethod
+    def dither_to_json(value: int) -> str:
         """Convert dither int to string key on json dump."""
         return index2dither[value]
 
     @field_serializer("line_style")
-    def line_to_json(value: int) -> str:  # type: ignore[misc]
+    @staticmethod
+    def line_to_json(value: int) -> str:
         """Convert dither int to string key on json dump."""
         return index2line[value]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,7 +38,7 @@ cell_copy_lock = RLock()
 
 
 @pytest.fixture(scope="module")
-def LAYER() -> Layers:
+def layers() -> Layers:
     return Layers()
 
 
@@ -50,84 +50,84 @@ def kcl() -> kf.KCLayout:
 
 
 @pytest.fixture
-def wg_enc(LAYER: Layers) -> kf.LayerEnclosure:
-    return kf.LayerEnclosure(name="WGSTD", sections=[(LAYER.WGCLAD, 0, 2000)])
+def wg_enc(layers: Layers) -> kf.LayerEnclosure:
+    return kf.LayerEnclosure(name="WGSTD", sections=[(layers.WGCLAD, 0, 2000)])
 
 
 @pytest.fixture
 def straight_factory_dbu(
-    LAYER: Layers, wg_enc: kf.LayerEnclosure
+    layers: Layers, wg_enc: kf.LayerEnclosure
 ) -> Callable[..., kf.KCell]:
-    return partial(kf.cells.straight.straight_dbu, layer=LAYER.WG, enclosure=wg_enc)
+    return partial(kf.cells.straight.straight_dbu, layer=layers.WG, enclosure=wg_enc)
 
 
 @pytest.fixture
 def straight_factory(
-    LAYER: Layers, wg_enc: kf.LayerEnclosure
+    layers: Layers, wg_enc: kf.LayerEnclosure
 ) -> Callable[..., kf.KCell]:
-    return partial(kf.cells.straight.straight, layer=LAYER.WG, enclosure=wg_enc)
+    return partial(kf.cells.straight.straight, layer=layers.WG, enclosure=wg_enc)
 
 
 @pytest.fixture
-def straight(LAYER: Layers, wg_enc: kf.LayerEnclosure) -> kf.KCell:
+def straight(layers: Layers, wg_enc: kf.LayerEnclosure) -> kf.KCell:
     return kf.cells.straight.straight(
-        width=0.5, length=1, layer=LAYER.WG, enclosure=wg_enc
+        width=0.5, length=1, layer=layers.WG, enclosure=wg_enc
     )
 
 
 @pytest.fixture
-def straight_blank(LAYER: Layers) -> kf.KCell:
-    return kf.cells.straight.straight(width=0.5, length=1, layer=LAYER.WG)
+def straight_blank(layers: Layers) -> kf.KCell:
+    return kf.cells.straight.straight(width=0.5, length=1, layer=layers.WG)
 
 
 @pytest.fixture
-def bend90(LAYER: Layers, wg_enc: kf.LayerEnclosure) -> kf.KCell:
+def bend90(layers: Layers, wg_enc: kf.LayerEnclosure) -> kf.KCell:
     return kf.cells.circular.bend_circular(
-        width=0.5, radius=10, layer=LAYER.WG, enclosure=wg_enc, angle=90
+        width=0.5, radius=10, layer=layers.WG, enclosure=wg_enc, angle=90
     )
 
 
 @pytest.fixture
-def bend90_small(LAYER: Layers, wg_enc: kf.LayerEnclosure) -> kf.KCell:
+def bend90_small(layers: Layers, wg_enc: kf.LayerEnclosure) -> kf.KCell:
     return kf.cells.circular.bend_circular(
-        width=0.5, radius=5, layer=LAYER.WG, enclosure=wg_enc, angle=90
+        width=0.5, radius=5, layer=layers.WG, enclosure=wg_enc, angle=90
     )
 
 
 @pytest.fixture
-def bend180(LAYER: Layers, wg_enc: kf.LayerEnclosure) -> kf.KCell:
+def bend180(layers: Layers, wg_enc: kf.LayerEnclosure) -> kf.KCell:
     return kf.cells.circular.bend_circular(
-        width=0.5, radius=10, layer=LAYER.WG, enclosure=wg_enc, angle=180
+        width=0.5, radius=10, layer=layers.WG, enclosure=wg_enc, angle=180
     )
 
 
 @pytest.fixture
-def bend90_euler(LAYER: Layers, wg_enc: kf.LayerEnclosure) -> kf.KCell:
+def bend90_euler(layers: Layers, wg_enc: kf.LayerEnclosure) -> kf.KCell:
     return kf.cells.euler.bend_euler(
-        width=0.5, radius=10, layer=LAYER.WG, enclosure=wg_enc, angle=90
+        width=0.5, radius=10, layer=layers.WG, enclosure=wg_enc, angle=90
     )
 
 
 @pytest.fixture
-def bend180_euler(LAYER: Layers, wg_enc: kf.LayerEnclosure) -> kf.KCell:
+def bend180_euler(layers: Layers, wg_enc: kf.LayerEnclosure) -> kf.KCell:
     return kf.cells.euler.bend_euler(
-        width=0.5, radius=10, layer=LAYER.WG, enclosure=wg_enc, angle=180
+        width=0.5, radius=10, layer=layers.WG, enclosure=wg_enc, angle=180
     )
 
 
 @pytest.fixture
-def taper(LAYER: Layers, wg_enc: kf.LayerEnclosure) -> kf.KCell:
-    return taper_cell(LAYER=LAYER.WG, wg_enc=wg_enc)
+def taper(layers: Layers, wg_enc: kf.LayerEnclosure) -> kf.KCell:
+    return taper_cell(layers=layers.WG, wg_enc=wg_enc)
 
 
 @kf.kcl.cell(set_name=False)
-def taper_cell(LAYER: kf.kdb.LayerInfo, wg_enc: kf.LayerEnclosure) -> kf.KCell:
-    if kf.kcl.layout.cell("taper") is None:
+def taper_cell(layers: kf.kdb.LayerInfo, wg_enc: kf.LayerEnclosure) -> kf.KCell:
+    if kf.kcl.layout_cell("taper") is None:
         c = kf.cells.taper.taper(
             width1=0.5,
             width2=1,
             length=10,
-            layer=LAYER,
+            layer=layers,
             enclosure=wg_enc,
         )
         c = c.dup()
@@ -138,11 +138,11 @@ def taper_cell(LAYER: kf.kdb.LayerInfo, wg_enc: kf.LayerEnclosure) -> kf.KCell:
 
 
 @pytest.fixture
-def optical_port(LAYER: Layers) -> kf.Port:
+def optical_port(layers: Layers) -> kf.Port:
     return kf.Port(
         name="o1",
         trans=kf.kdb.Trans.R0,
-        layer=kf.kcl.find_layer(LAYER.WG),
+        layer=kf.kcl.find_layer(layers.WG),
         width=500,
         port_type="optical",
     )

--- a/tests/test_all_angle.py
+++ b/tests/test_all_angle.py
@@ -7,10 +7,10 @@ from conftest import Layers
 import kfactory as kf
 
 
-def test_all_angle_bundle(LAYER: Layers) -> None:
-    sf = partial(kf.cells.virtual.straight.virtual_straight, layer=LAYER.WG)
+def test_all_angle_bundle(layers: Layers) -> None:
+    sf = partial(kf.cells.virtual.straight.virtual_straight, layer=layers.WG)
     bf = partial(
-        kf.cells.virtual.euler.virtual_bend_euler, layer=LAYER.WG, radius=10, width=1
+        kf.cells.virtual.euler.virtual_bend_euler, layer=layers.WG, radius=10, width=1
     )
 
     # vc = kf.VKCell("test_all_angle")
@@ -34,7 +34,7 @@ def test_all_angle_bundle(LAYER: Layers) -> None:
                 dcplx_trans=kf.kdb.DCplxTrans(
                     1, a, False, -500 + r * np.cos(a_rad), -100 + r * np.sin(a_rad)
                 ),
-                layer=c.kcl.find_layer(LAYER.WG),
+                layer=c.kcl.find_layer(layers.WG),
                 width=c.kcl.to_dbu(1),
             )
         )
@@ -44,7 +44,7 @@ def test_all_angle_bundle(LAYER: Layers) -> None:
                 dcplx_trans=kf.kdb.DCplxTrans(
                     1, ae, False, 2510 + r * np.cos(ae_rad), 2410 + r * np.sin(ae_rad)
                 ),
-                layer=c.kcl.find_layer(LAYER.WG),
+                layer=c.kcl.find_layer(layers.WG),
                 width=c.kcl.to_dbu(1),
             )
         )

--- a/tests/test_cell.py
+++ b/tests/test_cell.py
@@ -14,13 +14,13 @@ def test_enclosure_name(straight_factory_dbu: Callable[..., kf.KCell]) -> None:
     assert wg.name == "straight_W1000_L10000_LWG_EWGSTD"
 
 
-def test_circular_snapping(LAYER: Layers) -> None:
-    b = kf.cells.circular.bend_circular(width=1, radius=10, layer=LAYER.WG, angle=90)
+def test_circular_snapping(layers: Layers) -> None:
+    b = kf.cells.circular.bend_circular(width=1, radius=10, layer=layers.WG, angle=90)
     assert b.ports["o2"].dcplx_trans.disp == kf.kcl.to_um(b.ports["o2"].trans.disp)
 
 
-def test_euler_snapping(LAYER: Layers) -> None:
-    b = kf.cells.euler.bend_euler(width=1, radius=10, layer=LAYER.WG, angle=90)
+def test_euler_snapping(layers: Layers) -> None:
+    b = kf.cells.euler.bend_euler(width=1, radius=10, layer=layers.WG, angle=90)
     assert b.ports["o2"].dcplx_trans.disp == kf.kcl.to_um(b.ports["o2"].trans.disp)
 
 
@@ -54,13 +54,13 @@ def test_nested_dict_list() -> None:
     assert dl is not c.settings["arg1"]
 
 
-def test_no_snap(LAYER: Layers) -> None:
+def test_no_snap(layers: Layers) -> None:
     c = kf.KCell()
 
     c.create_port(
         width=c.kcl.to_dbu(1),
         dcplx_trans=kf.kdb.DCplxTrans(1, 90, False, 0.0005, 0),
-        layer=c.kcl.find_layer(LAYER.WG),
+        layer=c.kcl.find_layer(layers.WG),
     )
 
     p = c.ports[0]
@@ -68,9 +68,9 @@ def test_no_snap(LAYER: Layers) -> None:
     assert p.dcplx_trans.disp != c.kcl.to_um(p.trans.disp)
 
 
-def test_namecollision(LAYER: Layers) -> None:
-    b1 = kf.cells.circular.bend_circular(width=1, radius=10.5, layer=LAYER.WG)
-    b2 = kf.cells.circular.bend_circular(width=1, radius=10.5000005, layer=LAYER.WG)
+def test_namecollision(layers: Layers) -> None:
+    b1 = kf.cells.circular.bend_circular(width=1, radius=10.5, layer=layers.WG)
+    b2 = kf.cells.circular.bend_circular(width=1, radius=10.5000005, layer=layers.WG)
 
     assert b1.name != b2.name
 
@@ -84,25 +84,25 @@ def test_nested_dic() -> None:
     recursive_dict_cell({"test": {"test2": "test3"}, "test4": "test5"})
 
 
-def test_ports_cell(LAYER: Layers) -> None:
+def test_ports_cell(layers: Layers) -> None:
     c = kf.KCell()
     c.create_port(
         name="o1",
         width=c.kcl.to_dbu(1),
         dcplx_trans=kf.kdb.DCplxTrans(1, 90, False, 0.0005, 0),
-        layer=c.kcl.find_layer(LAYER.WG),
+        layer=c.kcl.find_layer(layers.WG),
     )
     assert c["o1"]
     assert "o1" in c.ports
 
 
-def test_ports_instance(LAYER: Layers) -> None:
+def test_ports_instance(layers: Layers) -> None:
     c = kf.KCell()
     c.create_port(
         name="o1",
         width=c.kcl.to_dbu(1),
         dcplx_trans=kf.kdb.DCplxTrans(1, 90, False, 0.0005, 0),
-        layer=c.kcl.find_layer(LAYER.WG),
+        layer=c.kcl.find_layer(layers.WG),
     )
     c2 = kf.KCell()
     ref = c2 << c
@@ -112,9 +112,9 @@ def test_ports_instance(LAYER: Layers) -> None:
     assert "o1" in ref.ports
 
 
-def test_getter(LAYER: Layers) -> None:
+def test_getter(layers: Layers) -> None:
     c = kf.KCell()
-    c << kf.cells.straight.straight(width=1, length=10, layer=LAYER.WG)
+    c << kf.cells.straight.straight(width=1, length=10, layer=layers.WG)
     assert c.y == 0
     assert c.dy == 0
 
@@ -156,7 +156,7 @@ def test_invalid_array(monkeypatch: pytest.MonkeyPatch, straight: kf.KCell) -> N
     kf.config.logfilter.regex = regex
 
 
-def test_cell_decorator_error(LAYER: Layers) -> None:
+def test_cell_decorator_error(layers: Layers) -> None:
     kcl2 = kf.KCLayout("decorator_test")
 
     @kf.kcl.cell
@@ -173,7 +173,7 @@ def test_cell_decorator_error(LAYER: Layers) -> None:
     kf.config.logfilter.regex = regex
 
 
-def test_info(LAYER: Layers) -> None:
+def test_info(layers: Layers) -> None:
     @kf.kcl.cell(info={"test": 42})
     def test_info_cell(test: int) -> kf.KCell:
         return kf.kcl.kcell()
@@ -182,22 +182,22 @@ def test_info(LAYER: Layers) -> None:
     assert c.info["test"] == 42
 
 
-def test_flatten(LAYER: Layers) -> None:
+def test_flatten(layers: Layers) -> None:
     c = kf.KCell()
-    _ = c << kf.cells.straight.straight(width=1, length=10, layer=LAYER.WG)
+    _ = c << kf.cells.straight.straight(width=1, length=10, layer=layers.WG)
     assert len(c.insts) == 1, "c.insts should have 1 inst after adding a cell"
     c.flatten()
     assert len(c.insts) == 0, "c.insts should have 0 insts after flatten()"
 
 
-def test_size_info(LAYER: Layers) -> None:
+def test_size_info(layers: Layers) -> None:
     c = kf.KCell()
-    ref = c << kf.cells.straight.straight(width=1, length=10, layer=LAYER.WG)
+    ref = c << kf.cells.straight.straight(width=1, length=10, layer=layers.WG)
     assert ref.size_info.ne[0] == 10000
     assert ref.dsize_info.ne[0] == 10
 
 
-def test_overwrite(LAYER: Layers) -> None:
+def test_overwrite(layers: Layers) -> None:
     kcl = kf.KCLayout("CELL_OVERWRITE")
 
     @kcl.cell
@@ -220,7 +220,7 @@ def test_overwrite(LAYER: Layers) -> None:
     assert c1._destroyed()
 
 
-def test_layout_cache(LAYER: Layers) -> None:
+def test_layout_cache(layers: Layers) -> None:
     kcl_write = kf.KCLayout("TEST_LAYOUT_CACHE_WRITE")
     kcl_read = kf.KCLayout("TEST_LAYOUT_CACHE_READ")
 
@@ -245,9 +245,9 @@ def test_layout_cache(LAYER: Layers) -> None:
     assert s_write.bbox() == s_read.bbox()
 
 
-def test_check_ports(LAYER: Layers) -> None:
+def test_check_ports(layers: Layers) -> None:
     kcl = kf.KCLayout("CHECK_PORTS", infos=Layers)
-    kcl.layers = kcl.layerenum_from_dict(layers=LAYER)
+    kcl.layers = kcl.layerenum_from_dict(layers=layers)
 
     @kcl.cell
     def test_multi_ports() -> kf.KCell:
@@ -399,13 +399,13 @@ def test_lock(straight: kf.KCell, bend90: kf.KCell) -> None:
             straight.transform(kf.kdb.Trans.R90)
 
 
-def test_cell_in_threads(LAYER: Layers, wg_enc: kf.LayerEnclosure) -> None:
+def test_cell_in_threads(layers: Layers, wg_enc: kf.LayerEnclosure) -> None:
     def taper() -> kf.KCell:
         return kf.cells.taper.taper(
             width1=0.5,
             width2=1,
             length=10,
-            layer=LAYER.WG,
+            layer=layers.WG,
             enclosure=wg_enc,
         )
 

--- a/tests/test_cells.py
+++ b/tests/test_cells.py
@@ -8,57 +8,51 @@ import kfactory as kf
 from kfactory.conf import logger
 
 
-class GeometryDifference(ValueError):
+class GeometryDifferenceError(ValueError):
     """Exception for Geometric differences."""
 
-    pass
-
-
-# class LAYER(kf.LayerEnum):  # type: ignore[unused-ignore, misc]
-#     kcl = kf.constant(kf.kcl)
-#     WG = (1, 0)
-#     WGCLAD = (111, 0)
+    ...
 
 
 wg_enc = kf.LayerEnclosure(name="WGSTD", sections=[(Layers().WGCLAD, 0, 2000)])
 
 
-def straight(LAYER: Layers) -> kf.KCell:
+def straight(layers: Layers) -> kf.KCell:
     return kf.cells.straight.straight(
-        width=0.5, length=1, layer=LAYER.WG, enclosure=wg_enc
+        width=0.5, length=1, layer=layers.WG, enclosure=wg_enc
     )
 
 
-def bend90(LAYER: Layers) -> kf.KCell:
+def bend90(layers: Layers) -> kf.KCell:
     return kf.cells.circular.bend_circular(
-        width=1, radius=10, layer=LAYER.WG, enclosure=wg_enc, angle=90
+        width=1, radius=10, layer=layers.WG, enclosure=wg_enc, angle=90
     )
 
 
-def bend180(LAYER: Layers) -> kf.KCell:
+def bend180(layers: Layers) -> kf.KCell:
     return kf.cells.circular.bend_circular(
-        width=1, radius=10, layer=LAYER.WG, enclosure=wg_enc, angle=180
+        width=1, radius=10, layer=layers.WG, enclosure=wg_enc, angle=180
     )
 
 
-def bend90_euler(LAYER: Layers) -> kf.KCell:
+def bend90_euler(layers: Layers) -> kf.KCell:
     return kf.cells.euler.bend_euler(
-        width=1, radius=10, layer=LAYER.WG, enclosure=wg_enc, angle=90
+        width=1, radius=10, layer=layers.WG, enclosure=wg_enc, angle=90
     )
 
 
-def bend180_euler(LAYER: Layers) -> kf.KCell:
+def bend180_euler(layers: Layers) -> kf.KCell:
     return kf.cells.euler.bend_euler(
-        width=1, radius=10, layer=LAYER.WG, enclosure=wg_enc, angle=180
+        width=1, radius=10, layer=layers.WG, enclosure=wg_enc, angle=180
     )
 
 
-def taper(LAYER: Layers) -> kf.KCell:
+def taper(layers: Layers) -> kf.KCell:
     return kf.cells.taper.taper(
         width1=0.5,
         width2=1,
         length=10,
-        layer=LAYER.WG,
+        layer=layers.WG,
         enclosure=wg_enc,
     )
 
@@ -81,10 +75,10 @@ def cell_name(request: pytest.FixtureRequest) -> str:
     return request.param  # type: ignore[no-any-return]
 
 
-def test_cells(cell_name: str, LAYER: Layers) -> None:
+def test_cells(cell_name: str, layers: Layers) -> None:
     """Ensure cells have the same geometry as their golden references."""
     gds_ref = pathlib.Path(__file__).parent / "test_data" / "ref"
-    cell = cells[cell_name](LAYER)
+    cell = cells[cell_name](layers)
     ref_file = gds_ref / f"{cell.name}.gds"
     run_cell = cell
     if not ref_file.exists():
@@ -122,19 +116,19 @@ def test_cells(cell_name: str, LAYER: Layers) -> None:
                 logger.info(f"replacing file {str(ref_file)!r}")
                 run_cell.write(ref_file.name)
 
-            raise GeometryDifference(
+            raise GeometryDifferenceError(
                 f"Differences found in {cell!r} on layer {layer_tuple}"
             )
 
 
-def test_additional_info(LAYER: Layers, wg_enc: kf.LayerEnclosure) -> None:
+def test_additional_info(layers: Layers, wg_enc: kf.LayerEnclosure) -> None:
     test_bend_euler = partial(
         kf.factories.euler.bend_euler_factory(
             kcl=kf.kcl,
             additional_info={"creation_time": "2023-02-12Z23:00:00"},
             overwrite_existing=True,
         ),
-        layer=LAYER.WG,
+        layer=layers.WG,
         radius=10,
     )
 

--- a/tests/test_cplxcells.py
+++ b/tests/test_cplxcells.py
@@ -36,13 +36,13 @@ def simple_cplx_cell(layer: kf.kdb.LayerInfo) -> kf.KCell:
     return c
 
 
-def test_cell(LAYER: Layers) -> None:
-    simple_cplx_cell(LAYER.WG)
+def test_cell(layers: Layers) -> None:
+    simple_cplx_cell(layers.WG)
 
 
-def test_connected_cell(LAYER: Layers) -> None:
+def test_connected_cell(layers: Layers) -> None:
     c = kf.KCell()
-    layer = LAYER.WG
+    layer = layers.WG
     sckc1 = c << simple_cplx_cell(layer)
     sckc2 = c << simple_cplx_cell(layer)
     sckc2.connect("o1", sckc1, "o1")

--- a/tests/test_enclosure.py
+++ b/tests/test_enclosure.py
@@ -36,8 +36,8 @@ def test_enclosure(layers: Layers) -> None:
     kf.LayerEnclosure([(layers.WG, 500, -250)])
 
 
-def test_enc(LAYER: Layers, wg_enc: kf.LayerEnclosure) -> None:
-    mmi_enc(LAYER.WG, wg_enc)
+def test_enc(layers: Layers, wg_enc: kf.LayerEnclosure) -> None:
+    mmi_enc(layers.WG, wg_enc)
 
 
 def test_neg_enc(layers: Layers) -> None:

--- a/tests/test_enclosure.py
+++ b/tests/test_enclosure.py
@@ -32,75 +32,75 @@ def mmi_enc(layer: kf.kdb.LayerInfo, enclosure: kf.LayerEnclosure) -> kf.KCell:
     return c
 
 
-def test_enclosure(LAYER: Layers) -> None:
-    kf.LayerEnclosure([(LAYER.WG, 500, -250)])
+def test_enclosure(layers: Layers) -> None:
+    kf.LayerEnclosure([(layers.WG, 500, -250)])
 
 
-def test_enc(LAYER: Layers, wg_enc: kf.LayerEnclosure) -> None:
+def test_enc(layers: Layers, wg_enc: kf.LayerEnclosure) -> None:
     wg_enc
 
-    mmi_enc(LAYER.WG, wg_enc)
+    mmi_enc(layers.WG, wg_enc)
 
 
-def test_neg_enc(LAYER: Layers) -> None:
-    enc = kf.LayerEnclosure([(LAYER.WGCLAD, -1500, 1000)])
+def test_neg_enc(layers: Layers) -> None:
+    enc = kf.LayerEnclosure([(layers.WGCLAD, -1500, 1000)])
 
-    mmi_enc(LAYER.WG, enc)
+    mmi_enc(layers.WG, enc)
 
 
-def test_layer_multi_enc(LAYER: Layers) -> None:
+def test_layer_multi_enc(layers: Layers) -> None:
     enc = kf.LayerEnclosure(
         [
-            (LAYER.WGCLAD, -5000, -5400),
-            (LAYER.WGCLAD, -4000, -3900),
-            (LAYER.WGCLAD, -100, 100),
-            (LAYER.WGCLAD, -500, -400),
+            (layers.WGCLAD, -5000, -5400),
+            (layers.WGCLAD, -4000, -3900),
+            (layers.WGCLAD, -100, 100),
+            (layers.WGCLAD, -500, -400),
         ]
     )
-    mmi_enc(LAYER.WG, enc)
+    mmi_enc(layers.WG, enc)
 
 
-def test_bbox_enc(LAYER: Layers) -> None:
+def test_bbox_enc(layers: Layers) -> None:
     enc = kf.LayerEnclosure(
         [
-            (LAYER.WGCLAD, -5000, -5400),
-            (LAYER.WGCLAD, -4000, -3900),
-            (LAYER.WGCLAD, -100, 100),
-            (LAYER.WGCLAD, -500, -400),
+            (layers.WGCLAD, -5000, -5400),
+            (layers.WGCLAD, -4000, -3900),
+            (layers.WGCLAD, -100, 100),
+            (layers.WGCLAD, -500, -400),
         ],
-        main_layer=LAYER.WG,
+        main_layer=layers.WG,
     )
     c = kf.KCell(name="BBOX_ENC")
-    enc.apply_bbox(c, ref=LAYER.WG)
+    enc.apply_bbox(c, ref=layers.WG)
 
 
-def test_layer_merge_enc(LAYER: Layers) -> None:
+def test_layer_merge_enc(layers: Layers) -> None:
     enc = kf.LayerEnclosure(
         [
-            (LAYER.WGCLAD, -5000, -3000),
-            (LAYER.WGCLAD, -4000, -2000),
-            (LAYER.WGCLAD, -2000, 1000),
+            (layers.WGCLAD, -5000, -3000),
+            (layers.WGCLAD, -4000, -2000),
+            (layers.WGCLAD, -2000, 1000),
         ]
     )
-    mmi_enc(LAYER.WG, enc)
+    mmi_enc(layers.WG, enc)
 
 
-def test_um_enclosure(LAYER: Layers) -> None:
+def test_um_enclosure(layers: Layers) -> None:
     kcl = kf.KCLayout("TEST_UM_ENCLOSURE")
     enc = kf.LayerEnclosure(
         [
-            (LAYER.WGCLAD, -5000, -3000),
-            (LAYER.WGCLAD, -4000, -2000),
-            (LAYER.WGCLAD, -2000, 1000),
+            (layers.WGCLAD, -5000, -3000),
+            (layers.WGCLAD, -4000, -2000),
+            (layers.WGCLAD, -2000, 1000),
         ],
         kcl=kcl,
     )
 
     enc_um = kf.LayerEnclosure(
         dsections=[
-            (LAYER.WGCLAD, -5, -3),
-            (LAYER.WGCLAD, -4, -2),
-            (LAYER.WGCLAD, -2, 1),
+            (layers.WGCLAD, -5, -3),
+            (layers.WGCLAD, -4, -2),
+            (layers.WGCLAD, -2, 1),
         ],
         kcl=kcl,
     )
@@ -108,47 +108,47 @@ def test_um_enclosure(LAYER: Layers) -> None:
     assert enc == enc_um
 
 
-def test_um_enclosure_nodbu(LAYER: Layers) -> None:
+def test_um_enclosure_nodbu(layers: Layers) -> None:
     """When defining um sections, kcl must be defined."""
     with pytest.raises(AssertionError):
         kf.LayerEnclosure(
             dsections=[
-                (LAYER.WGCLAD, -5, -3),
-                (LAYER.WGCLAD, -4, -2),
-                (LAYER.WGCLAD, -2, 1),
+                (layers.WGCLAD, -5, -3),
+                (layers.WGCLAD, -4, -2),
+                (layers.WGCLAD, -2, 1),
             ]
         )
 
 
-def test_pdkenclosure(LAYER: Layers, straight_blank: kf.KCell) -> None:
+def test_pdkenclosure(layers: Layers, straight_blank: kf.KCell) -> None:
     c = kf.KCell(name="wg_slab")
 
     wg_box = kf.kdb.Box(10000, 500)
-    c.shapes(c.kcl.find_layer(LAYER.WG)).insert(wg_box)
-    c.shapes(c.kcl.find_layer(LAYER.WGCLAD)).insert(wg_box.enlarged(0, 2500))
+    c.shapes(c.kcl.find_layer(layers.WG)).insert(wg_box)
+    c.shapes(c.kcl.find_layer(layers.WGCLAD)).insert(wg_box.enlarged(0, 2500))
     c.create_port(
         trans=kf.kdb.Trans(0, False, wg_box.right, 0),
         width=wg_box.height(),
-        layer=c.kcl.find_layer(LAYER.WG),
+        layer=c.kcl.find_layer(layers.WG),
     )
     c.create_port(
         trans=kf.kdb.Trans(2, False, wg_box.left, 0),
         width=wg_box.height(),
-        layer=c.kcl.find_layer(LAYER.WG),
+        layer=c.kcl.find_layer(layers.WG),
     )
 
     enc1 = kf.LayerEnclosure(
         sections=[
-            (LAYER.WGEXCLUDE, 1000),
+            (layers.WGEXCLUDE, 1000),
         ],
         name="WGEX",
-        main_layer=LAYER.WG,
+        main_layer=layers.WG,
     )
 
     enc2 = kf.LayerEnclosure(
         name="CLADEX",
-        main_layer=LAYER.WGCLAD,
-        sections=[(LAYER.WGEXCLUDE, 1000), (LAYER.WGCLADEXCLUDE, 2000)],
+        main_layer=layers.WGCLAD,
+        sections=[(layers.WGEXCLUDE, 1000), (layers.WGCLADEXCLUDE, 2000)],
     )
 
     pdkenc = kf.KCellEnclosure(enclosures=[enc1, enc2])
@@ -170,9 +170,9 @@ def test_pdkenclosure(LAYER: Layers, straight_blank: kf.KCell) -> None:
     port_wg_ex.merge()
 
     assert (
-        kf.kdb.Region(c.shapes(c.kcl.find_layer(LAYER.WGEXCLUDE))) & port_wg_ex
+        kf.kdb.Region(c.shapes(c.kcl.find_layer(layers.WGEXCLUDE))) & port_wg_ex
     ).is_empty()
     assert (
-        (kf.kdb.Region(c.shapes(c.kcl.find_layer(LAYER.WGCLADEXCLUDE))) & port_wg_ex)
+        (kf.kdb.Region(c.shapes(c.kcl.find_layer(layers.WGCLADEXCLUDE))) & port_wg_ex)
         - port_wg_ex
     ).is_empty()

--- a/tests/test_extrude.py
+++ b/tests/test_extrude.py
@@ -35,17 +35,17 @@ def taper_static(
     return c
 
 
-def test_dynamic_sine_taper(LAYER: Layers, wg_enc: kf.LayerEnclosure) -> None:
-    taper_dyn(10, 1, LAYER.WG, wg_enc)
+def test_dynamic_sine_taper(layers: Layers, wg_enc: kf.LayerEnclosure) -> None:
+    taper_dyn(10, 1, layers.WG, wg_enc)
 
 
-def test_static_sine_taper(LAYER: Layers, wg_enc: kf.LayerEnclosure) -> None:
-    taper_static(10, 1, LAYER.WG, wg_enc)
+def test_static_sine_taper(layers: Layers, wg_enc: kf.LayerEnclosure) -> None:
+    taper_static(10, 1, layers.WG, wg_enc)
 
 
-def test_enc_extrude_dyn(LAYER: Layers, wg_enc: kf.LayerEnclosure) -> None:
+def test_enc_extrude_dyn(layers: Layers, wg_enc: kf.LayerEnclosure) -> None:
     width = 10
-    layer = LAYER.WG
+    layer = layers.WG
     enclosure = wg_enc
     c = kf.KCell()
 
@@ -57,9 +57,9 @@ def test_enc_extrude_dyn(LAYER: Layers, wg_enc: kf.LayerEnclosure) -> None:
     enclosure.extrude_path_dynamic(c, path, layer, _width)
 
 
-def test_enc_extrude_static(LAYER: Layers, wg_enc: kf.LayerEnclosure) -> None:
+def test_enc_extrude_static(layers: Layers, wg_enc: kf.LayerEnclosure) -> None:
     width = 10
-    layer = LAYER.WG
+    layer = layers.WG
     enclosure = wg_enc
     c = kf.KCell()
 

--- a/tests/test_fill.py
+++ b/tests/test_fill.py
@@ -3,10 +3,10 @@ from conftest import Layers
 import kfactory as kf
 
 
-def test_tiled_fill_space(fill_cell: kf.KCell, LAYER: Layers) -> None:
+def test_tiled_fill_space(fill_cell: kf.KCell, layers: Layers) -> None:
     c = kf.KCell()
-    c.shapes(LAYER.WG).insert(kf.kdb.DPolygon.ellipse(kf.kdb.DBox(5000, 3000), 512))
-    c.shapes(LAYER.WGCLAD).insert(
+    c.shapes(layers.WG).insert(kf.kdb.DPolygon.ellipse(kf.kdb.DBox(5000, 3000), 512))
+    c.shapes(layers.WGCLAD).insert(
         kf.kdb.DPolygon(
             [kf.kdb.DPoint(0, 0), kf.kdb.DPoint(5000, 0), kf.kdb.DPoint(5000, 3000)]
         )
@@ -14,21 +14,21 @@ def test_tiled_fill_space(fill_cell: kf.KCell, LAYER: Layers) -> None:
     kf.utils.fill_tiled(
         c,
         fill_cell,
-        [(LAYER.WG, 0)],
+        [(layers.WG, 0)],
         exclude_layers=[
-            (LAYER.WGEXCLUDE, 100),
-            (LAYER.WGCLAD, 0),
-            (LAYER.WGCLADEXCLUDE, 0),
+            (layers.WGEXCLUDE, 100),
+            (layers.WGCLAD, 0),
+            (layers.WGCLADEXCLUDE, 0),
         ],
         x_space=5,
         y_space=5,
     )
 
 
-def test_tiled_fill_vector(fill_cell: kf.KCell, LAYER: Layers) -> None:
+def test_tiled_fill_vector(fill_cell: kf.KCell, layers: Layers) -> None:
     c = kf.KCell()
-    c.shapes(LAYER.WG).insert(kf.kdb.DPolygon.ellipse(kf.kdb.DBox(5000, 3000), 512))
-    c.shapes(LAYER.WGCLAD).insert(
+    c.shapes(layers.WG).insert(kf.kdb.DPolygon.ellipse(kf.kdb.DBox(5000, 3000), 512))
+    c.shapes(layers.WGCLAD).insert(
         kf.kdb.DPolygon(
             [kf.kdb.DPoint(0, 0), kf.kdb.DPoint(5000, 0), kf.kdb.DPoint(5000, 3000)]
         )
@@ -45,15 +45,15 @@ def test_tiled_fill_vector(fill_cell: kf.KCell, LAYER: Layers) -> None:
 
     poly.insert_hole(kf.kdb.DBox(-1800, -200, -1200, 200))
 
-    c.shapes(LAYER.WGEXCLUDE).insert(poly)
+    c.shapes(layers.WGEXCLUDE).insert(poly)
     kf.utils.fill_tiled(
         c,
         fill_cell,
-        [(LAYER.WG, 0)],
+        [(layers.WG, 0)],
         exclude_layers=[
-            (LAYER.WGEXCLUDE, 100),
-            (LAYER.WGCLAD, 0),
-            (LAYER.WGCLADEXCLUDE, 0),
+            (layers.WGEXCLUDE, 100),
+            (layers.WGCLAD, 0),
+            (layers.WGCLADEXCLUDE, 0),
         ],
         row_step=kf.kdb.DVector(35, 5),
         col_step=kf.kdb.DVector(-5, 50),

--- a/tests/test_instance.py
+++ b/tests/test_instance.py
@@ -8,16 +8,16 @@ import kfactory as kf
 from kfactory import exceptions
 
 
-def test_instance_xsize(LAYER: Layers) -> None:
+def test_instance_xsize(layers: Layers) -> None:
     c = kf.KCell()
-    ref = c << kf.cells.straight.straight(width=0.5, length=1, layer=LAYER.WG)
+    ref = c << kf.cells.straight.straight(width=0.5, length=1, layer=layers.WG)
     assert ref.xsize
 
 
-def test_instance_center(LAYER: Layers) -> None:
+def test_instance_center(layers: Layers) -> None:
     c = kf.KCell()
-    ref1 = c << kf.cells.straight.straight(width=0.5, length=1, layer=LAYER.WG)
-    ref2 = c << kf.cells.straight.straight(width=0.5, length=1, layer=LAYER.WG)
+    ref1 = c << kf.cells.straight.straight(width=0.5, length=1, layer=layers.WG)
+    ref2 = c << kf.cells.straight.straight(width=0.5, length=1, layer=layers.WG)
 
     ref1.center = ref2.center
     ref2.center = (ref1.center[0], ref2.center[1] + 1000)
@@ -25,9 +25,9 @@ def test_instance_center(LAYER: Layers) -> None:
     assert ref2.center == (ref1.center[0], ref1.center[1] + 11_000)
 
 
-def test_instance_d_move(LAYER: Layers) -> None:
+def test_instance_d_move(layers: Layers) -> None:
     c = kf.KCell()
-    ref = c << kf.cells.straight.straight(width=0.5, length=1, layer=LAYER.WG)
+    ref = c << kf.cells.straight.straight(width=0.5, length=1, layer=layers.WG)
 
     ref.dmovex(10)
     ref.dmovex(10.0)
@@ -46,10 +46,10 @@ def test_instance_d_move(LAYER: Layers) -> None:
     ref.dmirror_x(0)
 
 
-def test_instance_mirror(LAYER: Layers) -> None:
+def test_instance_mirror(layers: Layers) -> None:
     """Test arbitrary mirror."""
     c = kf.KCell()
-    b = kf.cells.euler.bend_euler(width=1, radius=10, layer=LAYER.WG)
+    b = kf.cells.euler.bend_euler(width=1, radius=10, layer=layers.WG)
 
     c << b
     b2 = c << b
@@ -63,13 +63,15 @@ def test_instance_mirror(LAYER: Layers) -> None:
 
     b2.mirror((p1.x, p1.y), (p2.x, p2.y))
 
-    c.shapes(c.kcl.find_layer(LAYER.WG)).insert(kf.kdb.Edge(mp1, mp2).transformed(disp))
+    c.shapes(c.kcl.find_layer(layers.WG)).insert(
+        kf.kdb.Edge(mp1, mp2).transformed(disp)
+    )
 
 
-def test_dmirror(LAYER: Layers) -> None:
+def test_dmirror(layers: Layers) -> None:
     """Test arbitrary mirror."""
     c = kf.KCell()
-    b = kf.cells.euler.bend_euler(width=1, radius=10, layer=LAYER.WG)
+    b = kf.cells.euler.bend_euler(width=1, radius=10, layer=layers.WG)
 
     c << b
     b2 = c << b
@@ -83,7 +85,7 @@ def test_dmirror(LAYER: Layers) -> None:
 
     b2.dmirror((p1.x, p1.y), (p2.x, p2.y))
 
-    c.shapes(c.kcl.find_layer(LAYER.WG)).insert(
+    c.shapes(c.kcl.find_layer(layers.WG)).insert(
         kf.kdb.DEdge(mp1, mp2).transformed(disp)
     )
 
@@ -449,14 +451,14 @@ def test_center(dbu_instance_tuple: _DBUInstanceTuple) -> None:
     assert _instances_equal(instance1, instance3)
 
 
-def test_vinstance_connect_by_port(kcl: kf.KCLayout, LAYER: Layers) -> None:
+def test_vinstance_connect_by_port(kcl: kf.KCLayout, layers: Layers) -> None:
     c = kcl.vkcell()
     straight_factory = kf.factories.straight.straight_dbu_factory(kcl)
     straight = straight_factory(
-        width=kcl.to_dbu(5), length=kcl.to_dbu(10), layer=LAYER.WG
+        width=kcl.to_dbu(5), length=kcl.to_dbu(10), layer=layers.WG
     )
     straight2 = straight_factory(
-        width=kcl.to_dbu(5), length=kcl.to_dbu(10), layer=LAYER.WG
+        width=kcl.to_dbu(5), length=kcl.to_dbu(10), layer=layers.WG
     )
     ref = c << straight
     ref2 = c << straight2
@@ -466,15 +468,15 @@ def test_vinstance_connect_by_port(kcl: kf.KCLayout, LAYER: Layers) -> None:
 
 
 def test_vinstance_connect_by_port_use_angle_false(
-    kcl: kf.KCLayout, LAYER: Layers
+    kcl: kf.KCLayout, layers: Layers
 ) -> None:
     c = kcl.vkcell()
     straight_factory = kf.factories.straight.straight_dbu_factory(kcl)
     straight = straight_factory(
-        width=kcl.to_dbu(5), length=kcl.to_dbu(10), layer=LAYER.WG
+        width=kcl.to_dbu(5), length=kcl.to_dbu(10), layer=layers.WG
     )
     straight2 = straight_factory(
-        width=kcl.to_dbu(5), length=kcl.to_dbu(10), layer=LAYER.WG
+        width=kcl.to_dbu(5), length=kcl.to_dbu(10), layer=layers.WG
     )
     ref = c << straight
     ref2 = c << straight2
@@ -484,15 +486,15 @@ def test_vinstance_connect_by_port_use_angle_false(
 
 
 def test_vinstance_connect_by_port_use_mirror_false(
-    kcl: kf.KCLayout, LAYER: Layers
+    kcl: kf.KCLayout, layers: Layers
 ) -> None:
     c = kcl.vkcell()
     straight_factory = kf.factories.straight.straight_dbu_factory(kcl)
     straight = straight_factory(
-        width=kcl.to_dbu(5), length=kcl.to_dbu(10), layer=LAYER.WG
+        width=kcl.to_dbu(5), length=kcl.to_dbu(10), layer=layers.WG
     )
     straight2 = straight_factory(
-        width=kcl.to_dbu(5), length=kcl.to_dbu(10), layer=LAYER.WG
+        width=kcl.to_dbu(5), length=kcl.to_dbu(10), layer=layers.WG
     )
     ref = c << straight
     ref2 = c << straight2
@@ -501,16 +503,16 @@ def test_vinstance_connect_by_port_use_mirror_false(
     assert c.bbox() == kdb.DBox(7.5, -30, 12.5, -10)
 
 
-def test_vinstance_connect_by_port_use_mirror_Use_angle_false(
-    kcl: kf.KCLayout, LAYER: Layers
+def test_vinstance_connect_by_port_use_mirror_use_angle_false(
+    kcl: kf.KCLayout, layers: Layers
 ) -> None:
     c = kcl.vkcell()
     straight_factory = kf.factories.straight.straight_dbu_factory(kcl)
     straight = straight_factory(
-        width=kcl.to_dbu(5), length=kcl.to_dbu(10), layer=LAYER.WG
+        width=kcl.to_dbu(5), length=kcl.to_dbu(10), layer=layers.WG
     )
     straight2 = straight_factory(
-        width=kcl.to_dbu(5), length=kcl.to_dbu(10), layer=LAYER.WG
+        width=kcl.to_dbu(5), length=kcl.to_dbu(10), layer=layers.WG
     )
     ref = c << straight
     ref2 = c << straight2
@@ -519,14 +521,14 @@ def test_vinstance_connect_by_port_use_mirror_Use_angle_false(
     assert c.bbox() == kdb.DBox(7.5, -22.5, 20, -10)
 
 
-def test_vinstance_connect_by_str(kcl: kf.KCLayout, LAYER: Layers) -> None:
+def test_vinstance_connect_by_str(kcl: kf.KCLayout, layers: Layers) -> None:
     c = kcl.vkcell()
     straight_factory = kf.factories.straight.straight_dbu_factory(kcl)
     straight = straight_factory(
-        width=kcl.to_dbu(5), length=kcl.to_dbu(10), layer=LAYER.WG
+        width=kcl.to_dbu(5), length=kcl.to_dbu(10), layer=layers.WG
     )
     straight2 = straight_factory(
-        width=kcl.to_dbu(5), length=kcl.to_dbu(20), layer=LAYER.WG
+        width=kcl.to_dbu(5), length=kcl.to_dbu(20), layer=layers.WG
     )
     ref = c << straight
     ref2 = c << straight2
@@ -535,20 +537,20 @@ def test_vinstance_connect_by_str(kcl: kf.KCLayout, LAYER: Layers) -> None:
     assert c.bbox() == kdb.DBox(50, 7.5, 80, 12.5)
 
 
-def test_vinstance_errors(kcl: kf.KCLayout, LAYER: Layers) -> None:
+def test_vinstance_errors(kcl: kf.KCLayout, layers: Layers) -> None:
     c = kcl.vkcell()
     straight_factory = kf.factories.straight.straight_dbu_factory(kcl)
     straight = straight_factory(
-        width=kcl.to_dbu(5), length=kcl.to_dbu(10), layer=LAYER.WG
+        width=kcl.to_dbu(5), length=kcl.to_dbu(10), layer=layers.WG
     )
     straight2 = straight_factory(
-        width=kcl.to_dbu(10), length=kcl.to_dbu(20), layer=LAYER.WG
+        width=kcl.to_dbu(10), length=kcl.to_dbu(20), layer=layers.WG
     )
     straight3 = straight_factory(
-        width=kcl.to_dbu(5), length=kcl.to_dbu(20), layer=LAYER.FILL1
+        width=kcl.to_dbu(5), length=kcl.to_dbu(20), layer=layers.FILL1
     )
     straight4 = straight_factory(
-        width=kcl.to_dbu(5), length=kcl.to_dbu(20), layer=LAYER.WG
+        width=kcl.to_dbu(5), length=kcl.to_dbu(20), layer=layers.WG
     ).dup()
     straight4.ports["o1"].port_type = "non-optical"
     ref = c << straight
@@ -556,11 +558,11 @@ def test_vinstance_errors(kcl: kf.KCLayout, LAYER: Layers) -> None:
     ref3 = c << straight3
     ref4 = c << straight4
     ref5 = c << straight.dup()
-    with pytest.raises(exceptions.PortWidthMismatch):
+    with pytest.raises(exceptions.PortWidthMismatchError):
         ref.connect("o1", ref2.ports["o2"])
-    with pytest.raises(exceptions.PortLayerMismatch):
+    with pytest.raises(exceptions.PortLayerMismatchError):
         ref.connect("o1", ref3.ports["o2"])
-    with pytest.raises(exceptions.PortTypeMismatch):
+    with pytest.raises(exceptions.PortTypeMismatchError):
         ref.connect("o1", ref4.ports["o1"])
     with pytest.raises(ValueError):
         ref.connect("o1", ref5)  # type: ignore

--- a/tests/test_instance_ports.py
+++ b/tests/test_instance_ports.py
@@ -4,9 +4,9 @@ from conftest import Layers
 import kfactory as kf
 
 
-def test_instance_ports(LAYER: Layers, kcl: kf.KCLayout) -> None:
+def test_instance_ports(layers: Layers, kcl: kf.KCLayout) -> None:
     c = kcl.kcell()
-    ref = c << kf.cells.straight.straight(width=0.5, length=1, layer=LAYER.WG)
+    ref = c << kf.cells.straight.straight(width=0.5, length=1, layer=layers.WG)
 
     instance_ports = ref.ports
 
@@ -35,13 +35,18 @@ def test_instance_ports(LAYER: Layers, kcl: kf.KCLayout) -> None:
 
 
 @pytest.fixture
-def dinstance_ports(LAYER: Layers, kcl: kf.KCLayout) -> kf.DInstance:
+def dinstance_ports(layers: Layers, kcl: kf.KCLayout) -> kf.DInstance:
     c = kcl.dkcell()
     straight = kf.factories.straight.straight_dbu_factory(kcl)(
-        width=5000, length=10000, layer=LAYER.WG
+        width=5000, length=10000, layer=layers.WG
     )
     ref = c.create_inst(
-        straight, trans=kf.kdb.ICplxTrans(mag=2), a=(10, 0), b=(0, 10), na=2, nb=2
+        straight,
+        trans=kf.kdb.DCplxTrans(mag=2),
+        a=kf.kdb.DVector(10, 0),
+        b=kf.kdb.DVector(0, 10),
+        na=2,
+        nb=2,
     )
     return ref
 
@@ -107,88 +112,88 @@ def test_dinstance_ports_iter(dinstance_ports: kf.DInstance) -> None:
     assert len(list(instance_ports)) == 8
 
 
-def test_single_instance_iter(kcl: kf.KCLayout, LAYER: Layers) -> None:
+def test_single_instance_iter(kcl: kf.KCLayout, layers: Layers) -> None:
     c = kcl.kcell()
     ref = c.create_inst(
-        kf.cells.straight.straight(width=0.5, length=1, layer=LAYER.WG),
+        kf.cells.straight.straight(width=0.5, length=1, layer=layers.WG),
         trans=kf.kdb.ICplxTrans(mag=2),
     )
     instance_ports = ref.ports
     assert len(list(instance_ports)) == 2
 
 
-def test_complex_array_iter(kcl: kf.KCLayout, LAYER: Layers) -> None:
-    c = kcl.kcell()
-    ref = c.create_inst(
-        kf.cells.straight.straight(width=0.5, length=1, layer=LAYER.WG),
-        trans=kf.kdb.ICplxTrans(mag=2),
-        a=(10, 0),
-        b=(0, 10),
-        na=2,
-        nb=2,
-    )
-    instance_ports = ref.ports
-    assert len(list(instance_ports)) == 8
-
-
-def test_regular_array_iter(kcl: kf.KCLayout, LAYER: Layers) -> None:
-    c = kcl.kcell()
-    ref = c.create_inst(
-        kf.cells.straight.straight(width=0.5, length=1, layer=LAYER.WG),
-        a=(10, 0),
-        b=(0, 10),
-        na=2,
-        nb=2,
-    )
-    instance_ports = ref.ports
-    assert len(list(instance_ports)) == 8
-
-
-def test_single_instance_each_by_array_coord(kcl: kf.KCLayout, LAYER: Layers) -> None:
-    c = kcl.kcell()
-    ref = c.create_inst(
-        kf.cells.straight.straight(width=0.5, length=1, layer=LAYER.WG),
-        trans=kf.kdb.ICplxTrans(mag=2),
-    )
-    instance_ports = ref.ports
-    assert [(i_a, i_b) for i_a, i_b, _ in instance_ports.each_by_array_coord()] == [
-        (0, 0),
-        (0, 0),
-    ]
-    instance_ports.copy()
-
-
-def test_complex_array_each_by_array_coord(kcl: kf.KCLayout, LAYER: Layers) -> None:
-    c = kcl.kcell()
-    ref = c.create_inst(
-        kf.cells.straight.straight(width=0.5, length=1, layer=LAYER.WG),
-        trans=kf.kdb.ICplxTrans(mag=2),
-        a=(10, 0),
-        b=(0, 10),
-        na=2,
-        nb=2,
-    )
-    instance_ports = ref.ports
-    assert [(i_a, i_b) for i_a, i_b, _ in instance_ports.each_by_array_coord()] == [
-        (0, 0),
-        (0, 0),
-        (0, 1),
-        (0, 1),
-        (1, 0),
-        (1, 0),
-        (1, 1),
-        (1, 1),
-    ]
-
-    instance_ports.copy()
-
-
-def test_regular_array_each_by_array_coord(kcl: kf.KCLayout, LAYER: Layers) -> None:
+def test_complex_array_iter(kcl: kf.KCLayout, layers: Layers) -> None:
     c = kcl.dkcell()
     ref = c.create_inst(
-        kf.cells.straight.straight(width=0.5, length=1, layer=LAYER.WG),
-        a=(10, 0),
-        b=(0, 10),
+        kf.cells.straight.straight(width=0.5, length=1, layer=layers.WG),
+        trans=kf.kdb.DCplxTrans(mag=2),
+        a=kf.kdb.DVector(10, 0),
+        b=kf.kdb.DVector(0, 10),
+        na=2,
+        nb=2,
+    )
+    instance_ports = ref.ports
+    assert len(list(instance_ports)) == 8
+
+
+def test_regular_array_iter(kcl: kf.KCLayout, layers: Layers) -> None:
+    c = kcl.dkcell()
+    ref = c.create_inst(
+        kf.cells.straight.straight(width=0.5, length=1, layer=layers.WG),
+        a=kf.kdb.DVector(10, 0),
+        b=kf.kdb.DVector(0, 10),
+        na=2,
+        nb=2,
+    )
+    instance_ports = ref.ports
+    assert len(list(instance_ports)) == 8
+
+
+def test_single_instance_each_by_array_coord(kcl: kf.KCLayout, layers: Layers) -> None:
+    c = kcl.kcell()
+    ref = c.create_inst(
+        kf.cells.straight.straight(width=0.5, length=1, layer=layers.WG),
+        trans=kf.kdb.ICplxTrans(mag=2),
+    )
+    instance_ports = ref.ports
+    assert [(i_a, i_b) for i_a, i_b, _ in instance_ports.each_by_array_coord()] == [
+        (0, 0),
+        (0, 0),
+    ]
+    instance_ports.copy()
+
+
+def test_complex_array_each_by_array_coord(kcl: kf.KCLayout, layers: Layers) -> None:
+    c = kcl.dkcell()
+    ref = c.create_inst(
+        kf.cells.straight.straight(width=0.5, length=1, layer=layers.WG),
+        trans=kf.kdb.DCplxTrans(mag=2),
+        a=kf.kdb.DVector(10, 0),
+        b=kf.kdb.DVector(0, 10),
+        na=2,
+        nb=2,
+    )
+    instance_ports = ref.ports
+    assert [(i_a, i_b) for i_a, i_b, _ in instance_ports.each_by_array_coord()] == [
+        (0, 0),
+        (0, 0),
+        (0, 1),
+        (0, 1),
+        (1, 0),
+        (1, 0),
+        (1, 1),
+        (1, 1),
+    ]
+
+    instance_ports.copy()
+
+
+def test_regular_array_each_by_array_coord(kcl: kf.KCLayout, layers: Layers) -> None:
+    c = kcl.dkcell()
+    ref = c.create_inst(
+        kf.cells.straight.straight(width=0.5, length=1, layer=layers.WG),
+        a=kf.kdb.DVector(10, 0),
+        b=kf.kdb.DVector(0, 10),
         na=2,
         nb=1,
     )
@@ -202,11 +207,11 @@ def test_regular_array_each_by_array_coord(kcl: kf.KCLayout, LAYER: Layers) -> N
     instance_ports.copy()
 
 
-def test_vinstance_ports_filter(kcl: kf.KCLayout, LAYER: Layers) -> None:
+def test_vinstance_ports_filter(kcl: kf.KCLayout, layers: Layers) -> None:
     c = kcl.vkcell()
     ref = c.create_inst(
         kf.factories.straight.straight_dbu_factory(kcl)(
-            width=5000, length=10000, layer=LAYER.WG
+            width=5000, length=10000, layer=layers.WG
         ),
         trans=kf.kdb.DCplxTrans(mag=2),
     )

--- a/tests/test_instances.py
+++ b/tests/test_instances.py
@@ -4,67 +4,67 @@ from conftest import Layers
 import kfactory as kf
 
 
-def test_vinstances_contains(kcl: kf.KCLayout, LAYER: Layers) -> None:
+def test_vinstances_contains(kcl: kf.KCLayout, layers: Layers) -> None:
     c = kcl.vkcell(name="test_vinstances_contains")
-    ref = c << kf.cells.straight.straight(width=0.5, length=1, layer=LAYER.WG)
+    ref = c << kf.cells.straight.straight(width=0.5, length=1, layer=layers.WG)
     assert ref in c.insts
 
 
-def test_instances_contains(kcl: kf.KCLayout, LAYER: Layers) -> None:
+def test_instances_contains(kcl: kf.KCLayout, layers: Layers) -> None:
     c = kcl.kcell(name="test_instances_contains")
-    ref = c << kf.cells.straight.straight(width=0.5, length=1, layer=LAYER.WG)
+    ref = c << kf.cells.straight.straight(width=0.5, length=1, layer=layers.WG)
     assert ref in c.insts
 
 
-def test_dinstances_contains(kcl: kf.KCLayout, LAYER: Layers) -> None:
+def test_dinstances_contains(kcl: kf.KCLayout, layers: Layers) -> None:
     c = kcl.dkcell(name="test_dinstances_contains")
-    ref = c << kf.cells.straight.straight(width=0.5, length=1, layer=LAYER.WG)
+    ref = c << kf.cells.straight.straight(width=0.5, length=1, layer=layers.WG)
     assert ref in c.insts
 
 
-def test_vinstances_contains_int(kcl: kf.KCLayout, LAYER: Layers) -> None:
+def test_vinstances_contains_int(kcl: kf.KCLayout, layers: Layers) -> None:
     c = kcl.vkcell(name="test_vinstances_contains_int")
-    _ = c << kf.cells.straight.straight(width=0.5, length=1, layer=LAYER.WG)
-    _ = c << kf.cells.straight.straight(width=0.5, length=1, layer=LAYER.WG)
+    _ = c << kf.cells.straight.straight(width=0.5, length=1, layer=layers.WG)
+    _ = c << kf.cells.straight.straight(width=0.5, length=1, layer=layers.WG)
     assert 0 in c.insts
     assert 1 in c.insts
 
 
-def test_instances_contains_int(kcl: kf.KCLayout, LAYER: Layers) -> None:
+def test_instances_contains_int(kcl: kf.KCLayout, layers: Layers) -> None:
     c = kcl.kcell(name="test_instances_contains_int")
-    _ = c << kf.cells.straight.straight(width=0.5, length=1, layer=LAYER.WG)
-    _ = c << kf.cells.straight.straight(width=0.5, length=1, layer=LAYER.WG)
+    _ = c << kf.cells.straight.straight(width=0.5, length=1, layer=layers.WG)
+    _ = c << kf.cells.straight.straight(width=0.5, length=1, layer=layers.WG)
     assert 0 in c.insts
     assert 1 in c.insts
 
 
-def test_dinstances_contains_int(kcl: kf.KCLayout, LAYER: Layers) -> None:
+def test_dinstances_contains_int(kcl: kf.KCLayout, layers: Layers) -> None:
     c = kcl.dkcell(name="test_dinstances_contains_int")
-    _ = c << kf.cells.straight.straight(width=0.5, length=1, layer=LAYER.WG)
-    _ = c << kf.cells.straight.straight(width=0.5, length=1, layer=LAYER.WG)
+    _ = c << kf.cells.straight.straight(width=0.5, length=1, layer=layers.WG)
+    _ = c << kf.cells.straight.straight(width=0.5, length=1, layer=layers.WG)
     assert 0 in c.insts
     assert 1 in c.insts
 
 
-def test_vinstances_contains_str(kcl: kf.KCLayout, LAYER: Layers) -> None:
+def test_vinstances_contains_str(kcl: kf.KCLayout, layers: Layers) -> None:
     c = kcl.vkcell(name="test_vinstances_contains_str")
-    ref = c << kf.cells.straight.straight(width=0.5, length=1, layer=LAYER.WG)
+    ref = c << kf.cells.straight.straight(width=0.5, length=1, layer=layers.WG)
     ref.name = "test_vinstances_contains_str_instance"
     assert ref.name is not None
     assert ref.name in c.insts
 
 
-def test_instances_contains_str(kcl: kf.KCLayout, LAYER: Layers) -> None:
+def test_instances_contains_str(kcl: kf.KCLayout, layers: Layers) -> None:
     c = kcl.kcell(name="test_instances_contains_str")
-    ref = c << kf.cells.straight.straight(width=0.5, length=1, layer=LAYER.WG)
+    ref = c << kf.cells.straight.straight(width=0.5, length=1, layer=layers.WG)
     ref.name = "test_instances_contains_str_instance"
     assert ref.name is not None
     assert ref.name in c.insts
 
 
-def test_dinstances_contains_str(kcl: kf.KCLayout, LAYER: Layers) -> None:
+def test_dinstances_contains_str(kcl: kf.KCLayout, layers: Layers) -> None:
     c = kcl.dkcell(name="test_dinstances_contains_str")
-    ref = c << kf.cells.straight.straight(width=0.5, length=1, layer=LAYER.WG)
+    ref = c << kf.cells.straight.straight(width=0.5, length=1, layer=layers.WG)
     ref.name = "test_dinstances_contains_str_instance"
     assert ref.name is not None
     assert ref.name in c.insts

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -49,36 +49,36 @@ def test_layer_infos_unnamed_layer() -> None:
     assert layer_info.layer1.name == "layer1"  # type: ignore[attr-defined]
 
 
-def test_layer_enum_creation(LAYER: Layers) -> None:
-    layer_enum = kf.layer.layerenum_from_dict(name="LAYER", layers=LAYER)
+def test_layer_enum_creation(layers: Layers) -> None:
+    layer_enum = kf.layer.layerenum_from_dict(name="LAYER", layers=layers)
     assert layer_enum.WG.layer == 1
     assert layer_enum.WG.datatype == 0
 
 
-def test_layer_enum_str(LAYER: Layers) -> None:
-    layer_enum = kf.layer.layerenum_from_dict(name="LAYER", layers=LAYER)
+def test_layer_enum_str(layers: Layers) -> None:
+    layer_enum = kf.layer.layerenum_from_dict(name="LAYER", layers=layers)
     assert str(layer_enum.WG) == "WG"
 
 
-def test_layer_enum_getitem(LAYER: Layers) -> None:
-    layer_enum = kf.layer.layerenum_from_dict(name="LAYER", layers=LAYER)
+def test_layer_enum_getitem(layers: Layers) -> None:
+    layer_enum = kf.layer.layerenum_from_dict(name="LAYER", layers=layers)
     assert layer_enum["WG"][0] == 1  # type: ignore[index]
     assert layer_enum["WG"][1] == 0  # type: ignore[index]
 
 
-def test_layer_enum_len(LAYER: Layers) -> None:
-    layer_enum = kf.layer.layerenum_from_dict(name="LAYER", layers=LAYER)
+def test_layer_enum_len(layers: Layers) -> None:
+    layer_enum = kf.layer.layerenum_from_dict(name="LAYER", layers=layers)
     assert len(layer_enum) == 7  # type: ignore[arg-type]
 
 
-def test_layer_enum_iter(LAYER: Layers) -> None:
-    layer_enum = kf.layer.layerenum_from_dict(name="LAYER", layers=LAYER)
+def test_layer_enum_iter(layers: Layers) -> None:
+    layer_enum = kf.layer.layerenum_from_dict(name="LAYER", layers=layers)
     values = list(layer_enum.WG)
     assert values == [1, 0]
 
 
-def test_layer_enum_invalid_index(LAYER: Layers) -> None:
-    layer_enum = kf.layer.layerenum_from_dict(name="LAYER", layers=LAYER)
+def test_layer_enum_invalid_index(layers: Layers) -> None:
+    layer_enum = kf.layer.layerenum_from_dict(name="LAYER", layers=layers)
     with pytest.raises(ValueError):
         layer_enum["WG"][2]  # type: ignore[index]
 

--- a/tests/test_layerstack.py
+++ b/tests/test_layerstack.py
@@ -27,9 +27,9 @@ def test_layerstack_layer_sidewall_angle(pdk: kf.KCLayout) -> None:
     assert isinstance(pdk.layer_stack.get_layer_to_sidewall_angle()[(1, 0)], float)
 
 
-def test_layerstack_layer_getattr(pdk: kf.KCLayout, LAYER: Layers) -> None:
+def test_layerstack_layer_getattr(pdk: kf.KCLayout, layers: Layers) -> None:
     assert pdk.layer_stack.wg == kf.layer.LayerLevel(
-        layer=LAYER.WG,
+        layer=layers.WG,
         thickness=0.22,
         zmin=0,
         material="si",
@@ -37,9 +37,9 @@ def test_layerstack_layer_getattr(pdk: kf.KCLayout, LAYER: Layers) -> None:
     )
 
 
-def test_layerstack_layer_getitem(pdk: kf.KCLayout, LAYER: Layers) -> None:
+def test_layerstack_layer_getitem(pdk: kf.KCLayout, layers: Layers) -> None:
     assert pdk.layer_stack["wg"] == kf.layer.LayerLevel(
-        layer=LAYER.WG,
+        layer=layers.WG,
         thickness=0.22,
         zmin=0,
         material="si",

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -154,17 +154,17 @@ def test_check_instances(kcl: kf.KCLayout) -> None:
         return parent_cell
 
     with pytest.raises(ValueError):
-        kcl.cell(check_instances=kf.kcell.CheckInstance.RAISE)(test_cell_with_rotation)(
-            "test_rase"
-        )
+        kcl.cell(check_instances=kf.kcell.CheckInstances.RAISE)(
+            test_cell_with_rotation
+        )("test_rase")
 
-    cell = kcl.cell(check_instances=kf.kcell.CheckInstance.FLATTEN)(
+    cell = kcl.cell(check_instances=kf.kcell.CheckInstances.FLATTEN)(
         test_cell_with_rotation
     )("test_flatten")
 
     assert len(cell.insts) == 0
 
-    cell2 = kcl.cell(check_instances=kf.kcell.CheckInstance.VINSTANCES)(
+    cell2 = kcl.cell(check_instances=kf.kcell.CheckInstances.VINSTANCES)(
         test_cell_with_rotation
     )("test_vinstances")
 
@@ -172,7 +172,7 @@ def test_check_instances(kcl: kf.KCLayout) -> None:
     assert len(cell2.vinsts) == 0
     assert len(cell2.insts) == 1
 
-    kcl.cell(check_instances=kf.kcell.CheckInstance.IGNORE)(test_cell_with_rotation)(
+    kcl.cell(check_instances=kf.kcell.CheckInstances.IGNORE)(test_cell_with_rotation)(
         "test_ignore"
     )
 

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -154,17 +154,17 @@ def test_check_instances(kcl: kf.KCLayout) -> None:
         return parent_cell
 
     with pytest.raises(ValueError):
-        kcl.cell(check_instances=kf.kcell.CHECK_INSTANCES.RAISE)(
-            test_cell_with_rotation
-        )("test_rase")
+        kcl.cell(check_instances=kf.kcell.CheckInstance.RAISE)(test_cell_with_rotation)(
+            "test_rase"
+        )
 
-    cell = kcl.cell(check_instances=kf.kcell.CHECK_INSTANCES.FLATTEN)(
+    cell = kcl.cell(check_instances=kf.kcell.CheckInstance.FLATTEN)(
         test_cell_with_rotation
     )("test_flatten")
 
     assert len(cell.insts) == 0
 
-    cell2 = kcl.cell(check_instances=kf.kcell.CHECK_INSTANCES.VINSTANCES)(
+    cell2 = kcl.cell(check_instances=kf.kcell.CheckInstance.VINSTANCES)(
         test_cell_with_rotation
     )("test_vinstances")
 
@@ -172,7 +172,7 @@ def test_check_instances(kcl: kf.KCLayout) -> None:
     assert len(cell2.vinsts) == 0
     assert len(cell2.insts) == 1
 
-    kcl.cell(check_instances=kf.kcell.CHECK_INSTANCES.IGNORE)(test_cell_with_rotation)(
+    kcl.cell(check_instances=kf.kcell.CheckInstance.IGNORE)(test_cell_with_rotation)(
         "test_ignore"
     )
 

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -7,7 +7,7 @@ from conftest import Layers
 import kfactory as kf
 
 
-def test_cell_decorator(kcl: kf.KCLayout, LAYER: Layers) -> None:
+def test_cell_decorator(kcl: kf.KCLayout, layers: Layers) -> None:
     rectangle_post_process = MagicMock()
 
     @kcl.cell(post_process=[rectangle_post_process])
@@ -16,9 +16,9 @@ def test_cell_decorator(kcl: kf.KCLayout, LAYER: Layers) -> None:
         c.shapes(layer).insert(kf.kdb.DBox(0, 0, width, height))
         return c
 
-    rectangle_cell = rectangle(10, 10, LAYER.WG)
-    rectangle_cell2 = rectangle(10, 10, LAYER.WG)
-    rectangle_cell3 = rectangle(10.1, 10.1, LAYER.WG)
+    rectangle_cell = rectangle(10, 10, layers.WG)
+    rectangle_cell2 = rectangle(10, 10, layers.WG)
+    rectangle_cell3 = rectangle(10.1, 10.1, layers.WG)
 
     assert rectangle_cell is rectangle_cell2
     assert rectangle_cell is not rectangle_cell3

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -93,7 +93,7 @@ def test_metainfo_set(straight: kf.KCell) -> None:
     straight.delete()
 
 
-def test_metainfo_read(LAYER: Layers, straight: kf.KCell) -> None:
+def test_metainfo_read(layers: Layers, straight: kf.KCell) -> None:
     """Test whether we can read written metadata to ports."""
     with NamedTemporaryFile("a", suffix=".oas") as t:
         save = kf.save_layout_options()

--- a/tests/test_netlist.py
+++ b/tests/test_netlist.py
@@ -3,11 +3,11 @@ from conftest import Layers
 import kfactory as kf
 
 
-def test_l2n(LAYER: Layers) -> None:
+def test_l2n(layers: Layers) -> None:
     c = kf.KCell(name="netlist_test")
 
-    b = kf.cells.circular.bend_circular(width=1, radius=10, layer=LAYER.WG)
-    s = kf.cells.straight.straight(width=1, length=20, layer=LAYER.WG)
+    b = kf.cells.circular.bend_circular(width=1, radius=10, layer=layers.WG)
+    s = kf.cells.straight.straight(width=1, length=20, layer=layers.WG)
 
     b1 = c << b
     b2 = c << b

--- a/tests/test_partial.py
+++ b/tests/test_partial.py
@@ -30,6 +30,6 @@ def partial_cell(partial: partial[kf.KCell]) -> kf.KCell:
     return c
 
 
-def test_partial(LAYER: Layers) -> None:
-    c = partial_cell(partial(to_be_partialled, width=1, length=10, layer=LAYER.WG))
+def test_partial(layers: Layers) -> None:
+    c = partial_cell(partial(to_be_partialled, width=1, length=10, layer=layers.WG))
     assert "<" not in c.name

--- a/tests/test_pdk.py
+++ b/tests/test_pdk.py
@@ -9,7 +9,7 @@ import kfactory as kf
 kf.config.max_cellname_length = 200
 
 
-def test_pdk(LAYER: Layers) -> None:
+def test_pdk(layers: Layers) -> None:
     pdk = kf.KCLayout("PDK")
 
     # class LAYER(kf.kcell.LayerEnum):
@@ -20,12 +20,12 @@ def test_pdk(LAYER: Layers) -> None:
         WG: kf.kdb.LayerInfo = kf.kdb.LayerInfo(1, 0)
         WGEX: kf.kdb.LayerInfo = kf.kdb.LayerInfo(1, 1)
 
-    pdk.infos = LAYER
-    for layer in LAYER.model_dump().values():
+    pdk.infos = layers
+    for layer in layers.model_dump().values():
         assert getattr(pdk.layers, layer.name).layer == layer.layer
 
 
-def test_clear(LAYER: Layers) -> None:
+def test_clear(layers: Layers) -> None:
     kcl = kf.KCLayout("CLEAR")
     kcl.layer(500, 0)
     kcl.infos = kf.LayerInfos(**{"WG": kf.kdb.LayerInfo(1, 0)})
@@ -38,16 +38,16 @@ def test_clear(LAYER: Layers) -> None:
     assert kcl.layers.WG == 0
 
 
-def test_kcell_delete(LAYER: Layers) -> None:
+def test_kcell_delete(layers: Layers) -> None:
     _kcl = kf.KCLayout("DELETE", infos=Layers)
 
-    _kcl.layers = _kcl.layerenum_from_dict(layers=LAYER)
+    _kcl.layers = _kcl.layerenum_from_dict(layers=layers)
 
     s = partial(
         kf.factories.straight.straight_dbu_factory(_kcl),
         width=1000,
         length=10_000,
-        layer=LAYER.WG,
+        layer=layers.WG,
     )
 
     s1 = s()
@@ -58,7 +58,7 @@ def test_kcell_delete(LAYER: Layers) -> None:
     assert s1._destroyed() is False
 
 
-def test_multi_pdk(LAYER: Layers) -> None:
+def test_multi_pdk(layers: Layers) -> None:
     base_pdk = kf.KCLayout("BASE", infos=Layers)
 
     doe_pdk1 = kf.KCLayout(name="DOE1", infos=Layers)
@@ -70,8 +70,8 @@ def test_multi_pdk(LAYER: Layers) -> None:
     bend90_pdk2 = kf.factories.euler.bend_euler_factory(doe_pdk2)
 
     doe1 = doe_pdk1.kcell("DOE1")
-    doe1_wg = doe1 << wg(width=1000, length=10_000, layer=LAYER.WG)
-    doe_b1 = doe1 << bend90_pdk1(width=1, radius=10, layer=LAYER.WG)
+    doe1_wg = doe1 << wg(width=1000, length=10_000, layer=layers.WG)
+    doe_b1 = doe1 << bend90_pdk1(width=1, radius=10, layer=layers.WG)
     doe_b1.connect("o1", doe1_wg, "o2")
 
     doe1.add_port(port=doe1_wg.ports["o1"], name="o1")
@@ -80,13 +80,13 @@ def test_multi_pdk(LAYER: Layers) -> None:
     doe2 = doe_pdk2.kcell("DOE2")
     enc2 = kf.LayerEnclosure(
         name="enc2",
-        sections=[(LAYER.WGCLAD, 0, 2000)],
-        main_layer=LAYER.WG,
+        sections=[(layers.WGCLAD, 0, 2000)],
+        main_layer=layers.WG,
     )
-    doe2_wg = doe2 << wg(width=1000, length=10_000, layer=LAYER.WG)
-    doe_b2 = doe2 << bend90_pdk2(width=1, radius=10, layer=LAYER.WG)
+    doe2_wg = doe2 << wg(width=1000, length=10_000, layer=layers.WG)
+    doe_b2 = doe2 << bend90_pdk2(width=1, radius=10, layer=layers.WG)
     doe_b2.connect("o1", doe2_wg, "o2")
-    doe_b3 = doe2 << bend90_pdk2(width=1, radius=10, layer=LAYER.WG, enclosure=enc2)
+    doe_b3 = doe2 << bend90_pdk2(width=1, radius=10, layer=layers.WG, enclosure=enc2)
 
     doe_b2.connect("o1", doe2_wg, "o2")
     doe_b3.connect("o1", doe_b2, "o2")
@@ -100,7 +100,7 @@ def test_multi_pdk(LAYER: Layers) -> None:
     d2.connect("o1", d1, "o2")
 
 
-def test_multi_pdk_convert(LAYER: Layers) -> None:
+def test_multi_pdk_convert(layers: Layers) -> None:
     with NamedTemporaryFile("a", suffix=".oas") as temp_file:
         base_pdk = kf.KCLayout("BASE", infos=Layers)
 
@@ -113,8 +113,8 @@ def test_multi_pdk_convert(LAYER: Layers) -> None:
         bend90_pdk2 = kf.factories.euler.bend_euler_factory(doe_pdk2)
 
         doe1 = doe_pdk1.kcell("DOE1")
-        doe1_wg = doe1 << wg(width=1000, length=10_000, layer=LAYER.WG)
-        doe_b1 = doe1 << bend90_pdk1(width=1, radius=10, layer=LAYER.WG)
+        doe1_wg = doe1 << wg(width=1000, length=10_000, layer=layers.WG)
+        doe_b1 = doe1 << bend90_pdk1(width=1, radius=10, layer=layers.WG)
         doe_b1.connect("o1", doe1_wg, "o2")
 
         doe1.add_port(port=doe1_wg.ports["o1"], name="o1")
@@ -123,13 +123,15 @@ def test_multi_pdk_convert(LAYER: Layers) -> None:
         doe2 = doe_pdk2.kcell("DOE2")
         enc2 = kf.LayerEnclosure(
             name="enc2",
-            sections=[(LAYER.WGCLAD, 0, 2000)],
-            main_layer=LAYER.WG,
+            sections=[(layers.WGCLAD, 0, 2000)],
+            main_layer=layers.WG,
         )
-        doe2_wg = doe2 << wg(width=1000, length=10_000, layer=LAYER.WG)
-        doe_b2 = doe2 << bend90_pdk2(width=1, radius=10, layer=LAYER.WG)
+        doe2_wg = doe2 << wg(width=1000, length=10_000, layer=layers.WG)
+        doe_b2 = doe2 << bend90_pdk2(width=1, radius=10, layer=layers.WG)
         doe_b2.connect("o1", doe2_wg, "o2")
-        doe_b3 = doe2 << bend90_pdk2(width=1, radius=10, layer=LAYER.WG, enclosure=enc2)
+        doe_b3 = doe2 << bend90_pdk2(
+            width=1, radius=10, layer=layers.WG, enclosure=enc2
+        )
 
         doe_b2.connect("o1", doe2_wg, "o2")
         doe_b3.connect("o1", doe_b2, "o2")
@@ -145,7 +147,7 @@ def test_multi_pdk_convert(LAYER: Layers) -> None:
         assembly.write(temp_file.name, convert_external_cells=True)
 
 
-def test_multi_pdk_read_write(LAYER: Layers) -> None:
+def test_multi_pdk_read_write(layers: Layers) -> None:
     base_pdk = kf.KCLayout("BASE", infos=Layers)
 
     doe_pdk1_write = kf.KCLayout(name="DOE1_WRITE", infos=Layers)
@@ -157,8 +159,8 @@ def test_multi_pdk_read_write(LAYER: Layers) -> None:
     bend90_pdk2 = kf.factories.euler.bend_euler_factory(doe_pdk2_write)
 
     doe1 = doe_pdk1_write.kcell("DOE1")
-    doe1_wg = doe1 << wg(width=1000, length=10_000, layer=LAYER.WG)
-    doe_b1 = doe1 << bend90_pdk1(width=1, radius=10, layer=LAYER.WG)
+    doe1_wg = doe1 << wg(width=1000, length=10_000, layer=layers.WG)
+    doe_b1 = doe1 << bend90_pdk1(width=1, radius=10, layer=layers.WG)
     doe_b1.connect("o1", doe1_wg, "o2")
 
     doe1.add_port(port=doe1_wg.ports["o1"], name="o1")
@@ -167,13 +169,13 @@ def test_multi_pdk_read_write(LAYER: Layers) -> None:
     doe2 = doe_pdk2_write.kcell("DOE2")
     enc2 = kf.LayerEnclosure(
         name="enc2",
-        sections=[(LAYER.WGCLAD, 0, 2000)],
-        main_layer=LAYER.WG,
+        sections=[(layers.WGCLAD, 0, 2000)],
+        main_layer=layers.WG,
     )
-    doe2_wg = doe2 << wg(width=1000, length=10_000, layer=LAYER.WG)
-    doe_b2 = doe2 << bend90_pdk2(width=1, radius=10, layer=LAYER.WG)
+    doe2_wg = doe2 << wg(width=1000, length=10_000, layer=layers.WG)
+    doe_b2 = doe2 << bend90_pdk2(width=1, radius=10, layer=layers.WG)
     doe_b2.connect("o1", doe2_wg, "o2")
-    doe_b3 = doe2 << bend90_pdk2(width=1, radius=10, layer=LAYER.WG, enclosure=enc2)
+    doe_b3 = doe2 << bend90_pdk2(width=1, radius=10, layer=layers.WG, enclosure=enc2)
 
     doe_b2.connect("o1", doe2_wg, "o2")
     doe_b3.connect("o1", doe_b2, "o2")
@@ -197,20 +199,20 @@ def test_multi_pdk_read_write(LAYER: Layers) -> None:
     d2.connect("o1", d1, "o2")
 
 
-def test_merge_read_shapes(LAYER: Layers) -> None:
+def test_merge_read_shapes(layers: Layers) -> None:
     with NamedTemporaryFile("w+b", suffix=".oas") as temp_file:
         with pytest.raises(kf.kcell.MergeError):
             kcl_1 = kf.KCLayout("MERGE_BASE_SHAPES", infos=Layers)
             s_base = kf.factories.straight.straight_dbu_factory(kcl_1)(
-                width=1000, length=10_000, layer=LAYER.WG
+                width=1000, length=10_000, layer=layers.WG
             )
             s_copy = s_base.dup()
             s_copy.name = "Straight"
 
             kcl_2 = kf.KCLayout("MERGE_READ_SHAPES", infos=Layers)
-            kcl_2.layers = kcl_2.layerenum_from_dict(layers=LAYER)
+            kcl_2.layers = kcl_2.layerenum_from_dict(layers=layers)
             s_base = kf.factories.straight.straight_dbu_factory(kcl_2)(
-                width=1100, length=10_000, layer=LAYER.WG
+                width=1100, length=10_000, layer=layers.WG
             )
             s_copy = s_base.dup()
             s_copy.name = "Straight"
@@ -222,24 +224,24 @@ def test_merge_read_shapes(LAYER: Layers) -> None:
             kf.config.logfilter.regex = None
 
 
-def test_merge_read_instances(LAYER: Layers) -> None:
+def test_merge_read_instances(layers: Layers) -> None:
     with NamedTemporaryFile("w+b", suffix=".oas") as temp_file:
         with pytest.raises(kf.kcell.MergeError):
             kcl_1 = kf.KCLayout("MERGE_BASE_INSTANCES", infos=Layers)
-            kcl_1.layers = kcl_1.layerenum_from_dict(layers=LAYER)
+            kcl_1.layers = kcl_1.layerenum_from_dict(layers=layers)
 
-            enc1 = kf.LayerEnclosure(sections=[(LAYER.WG, 0, 200)], name="CLAD")
+            enc1 = kf.LayerEnclosure(sections=[(layers.WG, 0, 200)], name="CLAD")
             s_base = kf.factories.straight.straight_dbu_factory(kcl_1)(
-                width=1000, length=10_000, layer=LAYER.WGEXCLUDE, enclosure=enc1
+                width=1000, length=10_000, layer=layers.WGEXCLUDE, enclosure=enc1
             )
             s_copy = kcl_1.kcell("Straight")
             s_copy << s_base
 
             kcl_2 = kf.KCLayout("MERGE_READ_INSTANCES", infos=Layers)
-            kcl_2.layers = kcl_2.layerenum_from_dict(layers=LAYER)
-            enc2 = kf.LayerEnclosure(sections=[(LAYER.WG, 0, 200)], name="CLAD")
+            kcl_2.layers = kcl_2.layerenum_from_dict(layers=layers)
+            enc2 = kf.LayerEnclosure(sections=[(layers.WG, 0, 200)], name="CLAD")
             s_base = kf.factories.straight.straight_dbu_factory(kcl_2)(
-                width=1000, length=10_000, layer=LAYER.WGEXCLUDE, enclosure=enc2
+                width=1000, length=10_000, layer=layers.WGEXCLUDE, enclosure=enc2
             )
             s_copy = kcl_2.kcell("Straight")
             copy = s_copy << s_base
@@ -273,7 +275,7 @@ def test_merge_properties() -> None:
             kf.config.logfilter.regex = regex
 
 
-def test_pdk_cell_infosettings(straight: kf.KCell, LAYER: Layers) -> None:
+def test_pdk_cell_infosettings(straight: kf.KCell, layers: Layers) -> None:
     kcl = kf.KCLayout("INFOSETTINGS", infos=Layers)
     c = kcl.kcell()
     _wg = c << straight

--- a/tests/test_ports.py
+++ b/tests/test_ports.py
@@ -30,13 +30,13 @@ def straight(width: int, length: int, layer: kf.kdb.LayerInfo) -> kf.KCell:
 
 
 @pytest.fixture()
-def wg(LAYER: Layers) -> kf.KCell:
-    return straight(1000, 20000, LAYER.WG)
+def wg(layers: Layers) -> kf.KCell:
+    return straight(1000, 20000, layers.WG)
 
 
 @pytest.fixture()
 @kf.cell
-def wg_floating_off_grid(LAYER: Layers) -> kf.KCell:
+def wg_floating_off_grid(layers: Layers) -> kf.KCell:
     with pytest.raises(AssertionError):
         c = kf.KCell()
         dbu = c.kcl.dbu
@@ -45,15 +45,15 @@ def wg_floating_off_grid(LAYER: Layers) -> kf.KCell:
             width=c.kcl.to_dbu(10 + dbu / 2),
             name="o1",
             dcplx_trans=kf.kdb.DCplxTrans(1, 180, False, dbu / 2, 0),
-            layer=c.kcl.find_layer(LAYER.WG),
+            layer=c.kcl.find_layer(layers.WG),
         )
         p2 = kf.Port(
             width=c.kcl.to_dbu(10 + dbu / 2),
             name="o2",
             dcplx_trans=kf.kdb.DCplxTrans(1, 0, False, 20 + dbu, 0),
-            layer=c.kcl.find_layer(LAYER.WG),
+            layer=c.kcl.find_layer(layers.WG),
         )
-        c.shapes(LAYER.WG).insert(kf.kdb.DBox(p1.x, -p1.width / 2, p2.x, p1.width / 2))
+        c.shapes(layers.WG).insert(kf.kdb.DBox(p1.x, -p1.width / 2, p2.x, p1.width / 2))
 
         c.add_port(port=p1)
         c.add_port(port=p2)
@@ -63,35 +63,35 @@ def wg_floating_off_grid(LAYER: Layers) -> kf.KCell:
     return c
 
 
-def test_straight(LAYER: Layers) -> None:
-    straight(1000, 20000, LAYER.WG)
+def test_straight(layers: Layers) -> None:
+    straight(1000, 20000, layers.WG)
 
 
-def test_settings(LAYER: Layers) -> None:
-    c = straight(1000, 20000, LAYER.WG)
+def test_settings(layers: Layers) -> None:
+    c = straight(1000, 20000, layers.WG)
 
     assert c.settings["length"] == 20000
     assert c.settings["width"] == 1000
     assert c.name == "straight_W1000_L20000_LWG"
 
 
-def test_connect_cplx_port(LAYER: Layers) -> None:
+def test_connect_cplx_port(layers: Layers) -> None:
     c = kf.KCell()
-    wg1 = c << straight(1000, 20000, LAYER.WG)
+    wg1 = c << straight(1000, 20000, layers.WG)
     port = kf.Port(
         width=c.kcl.to_dbu(1),
-        layer=c.kcl.find_layer(LAYER.WG),
+        layer=c.kcl.find_layer(layers.WG),
         name="cplxp1",
         dcplx_trans=kf.kdb.DCplxTrans(1, 30, False, 5, 10),
     )
     wg1.connect("o1", port)
 
 
-def test_connect_cplx_inst(LAYER: Layers) -> None:
+def test_connect_cplx_inst(layers: Layers) -> None:
     c = kf.KCell()
 
-    wg1 = c << straight(1000, 20000, LAYER.WG)
-    wg2 = c << straight(1000, 20000, LAYER.WG)
+    wg1 = c << straight(1000, 20000, layers.WG)
+    wg2 = c << straight(1000, 20000, layers.WG)
     wg1.transform(kf.kdb.DCplxTrans(1, 30, False, 5, 10))
     wg2.connect("o1", wg1, "o2")
     kf.config.logfilter.regex = (
@@ -117,12 +117,12 @@ def test_connect_integer(wg: kf.KCell) -> None:
     assert wg2.ports["o1"].trans == kf.kdb.Trans(0, False, 0, 0)
 
 
-def test_connect_port_width_mismatch(LAYER: Layers, wg: kf.KCell) -> None:
+def test_connect_port_width_mismatch(layers: Layers, wg: kf.KCell) -> None:
     c = kf.KCell()
-    wg1 = c << straight(1000, 20000, LAYER.WG)
+    wg1 = c << straight(1000, 20000, layers.WG)
     port = kf.Port(
         width=c.kcl.to_dbu(2),
-        layer=c.kcl.find_layer(LAYER.WG),
+        layer=c.kcl.find_layer(layers.WG),
         name="cplxp1",
         dcplx_trans=kf.kdb.DCplxTrans(1, 30, False, 5, 10),
     )
@@ -134,12 +134,12 @@ def test_connect_port_width_mismatch(LAYER: Layers, wg: kf.KCell) -> None:
     )
 
 
-def test_connect_instance_width_mismatch(LAYER: Layers, wg: kf.KCell) -> None:
+def test_connect_instance_width_mismatch(layers: Layers, wg: kf.KCell) -> None:
     c = kf.KCell()
-    wg1 = c << straight(1000, 20000, LAYER.WG)
+    wg1 = c << straight(1000, 20000, layers.WG)
     port = kf.Port(
         width=c.kcl.to_dbu(2),
-        layer=c.kcl.find_layer(LAYER.WG),
+        layer=c.kcl.find_layer(layers.WG),
         name="cplxp1",
         dcplx_trans=kf.kdb.DCplxTrans(1, 30, False, 5, 10),
     )
@@ -155,11 +155,11 @@ def test_connect_instance_width_mismatch(LAYER: Layers, wg: kf.KCell) -> None:
     )
 
 
-def test_keep_mirror(LAYER: Layers) -> None:
+def test_keep_mirror(layers: Layers) -> None:
     c = kf.KCell()
 
     p1 = kf.Port(
-        trans=kf.kdb.Trans.M90, width=1000, layer=c.kcl.find_layer(LAYER.WG), kcl=c.kcl
+        trans=kf.kdb.Trans.M90, width=1000, layer=c.kcl.find_layer(layers.WG), kcl=c.kcl
     )
 
     c.add_port(port=p1, name="o1")
@@ -169,14 +169,14 @@ def test_keep_mirror(LAYER: Layers) -> None:
     assert c["o2"].trans.is_mirror() is True
 
 
-def test_addports_keep_mirror(LAYER: Layers) -> None:
+def test_addports_keep_mirror(layers: Layers) -> None:
     c = kf.KCell()
 
     ports = [
         kf.Port(
             name=f"{i}",
             width=1000,
-            layer=c.kcl.find_layer(LAYER.WG),
+            layer=c.kcl.find_layer(layers.WG),
             trans=kf.kdb.Trans(i, True, 0, 0),
         )
         for i in range(4)
@@ -195,32 +195,32 @@ def test_addports_keep_mirror(LAYER: Layers) -> None:
         assert t1 == t2_mirr
 
 
-def test_contains(LAYER: Layers) -> None:
-    s = kf.cells.straight.straight(width=1, length=10, layer=LAYER.WG)
+def test_contains(layers: Layers) -> None:
+    s = kf.cells.straight.straight(width=1, length=10, layer=layers.WG)
     assert "o1" in s.ports
     assert s.ports["o1"] in s.ports
     assert s.ports["o1"].copy() in s.ports
 
 
-def test_ports_set_center(LAYER: Layers) -> None:
+def test_ports_set_center(layers: Layers) -> None:
     c = kf.KCell()
     p = c.create_port(
         name="o1",
         width=c.kcl.to_dbu(1),
         dcplx_trans=kf.kdb.DCplxTrans(1, 90, False, 0.0005, 0),
-        layer=c.kcl.find_layer(LAYER.WG),
+        layer=c.kcl.find_layer(layers.WG),
     )
     p.center = (0, 0)
     assert p.dcplx_trans.disp == kf.kdb.DVector(0, 0)
 
 
-def test_polar_copy(LAYER: Layers) -> None:
+def test_polar_copy(layers: Layers) -> None:
     c = kf.KCell()
     p = c.create_port(
         name="o1",
         width=1000,
         trans=kf.kdb.Trans(1, False, 0, 0),
-        layer=c.kcl.find_layer(LAYER.WG),
+        layer=c.kcl.find_layer(layers.WG),
     )
 
     p2 = p.copy_polar(500, 500, 2, True)
@@ -228,13 +228,13 @@ def test_polar_copy(LAYER: Layers) -> None:
     c.add_port(name="o2", port=p2)
 
 
-def test_polar_copy_complex(LAYER: Layers) -> None:
+def test_polar_copy_complex(layers: Layers) -> None:
     c = kf.KCell()
     p = c.create_port(
         name="o1",
         width=c.kcl.to_dbu(1),
         dcplx_trans=kf.kdb.DCplxTrans(1, 30, False, 0.755, 0),
-        layer=c.kcl.find_layer(LAYER.WG),
+        layer=c.kcl.find_layer(layers.WG),
     )
 
     p2 = p.copy_polar(500, 500, 2, True)
@@ -245,13 +245,13 @@ def test_polar_copy_complex(LAYER: Layers) -> None:
     )
 
 
-def test_dplx_port_dbu_port_conversion(LAYER: Layers, kcl: kf.KCLayout) -> None:
+def test_dplx_port_dbu_port_conversion(layers: Layers, kcl: kf.KCLayout) -> None:
     t1 = kf.kdb.DCplxTrans(1, 90, False, 10, 10)
     t2 = kf.kdb.Trans(1, False, 10_000, 10_000)
     p = kf.Port(
         width=kcl.to_dbu(1),
         dcplx_trans=t1,
-        layer=kcl.find_layer(LAYER.WG),
+        layer=kcl.find_layer(layers.WG),
         kcl=kcl,
     )
     assert p.trans == t2

--- a/tests/test_ports.py
+++ b/tests/test_ports.py
@@ -4,6 +4,7 @@ import pytest
 from conftest import Layers
 
 import kfactory as kf
+from kfactory.exceptions import PortWidthMismatchError
 
 
 @kf.cell
@@ -126,7 +127,7 @@ def test_connect_port_width_mismatch(layers: Layers, wg: kf.KCell) -> None:
         name="cplxp1",
         dcplx_trans=kf.kdb.DCplxTrans(1, 30, False, 5, 10),
     )
-    with pytest.raises(kf.exceptions.PortWidthMismatch) as excinfo:
+    with pytest.raises(PortWidthMismatchError) as excinfo:
         wg1.connect("o1", port)
     assert str(excinfo.value) == (
         f'Width mismatch between the ports {wg1.cell_name}["o1"] and Port "cplxp1" '
@@ -147,7 +148,7 @@ def test_connect_instance_width_mismatch(layers: Layers, wg: kf.KCell) -> None:
     c2.add_port(port=port, name="o2")
     wg1_instance = c << c2
 
-    with pytest.raises(kf.exceptions.PortWidthMismatch) as excinfo:
+    with pytest.raises(PortWidthMismatchError) as excinfo:
         wg1.connect("o1", wg1_instance, "o2")
     assert str(excinfo.value) == (
         f'Width mismatch between the ports {wg1.cell_name}["o1"] and '

--- a/tests/test_rename.py
+++ b/tests/test_rename.py
@@ -90,9 +90,9 @@ def test_rename_orientation() -> None:
     assert [p.name for p in port_list] == names
 
 
-def test_rename_setter(LAYER: Layers) -> None:
+def test_rename_setter(layers: Layers) -> None:
     kcl = kf.KCLayout("TEST_RENAME", infos=Layers)
-    kcl.layers = kcl.layerenum_from_dict(layers=LAYER)
+    kcl.layers = kcl.layerenum_from_dict(layers=layers)
 
     assert kcl.rename_function == kf.port.rename_clockwise_multi
 

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -31,7 +31,7 @@ def test_route_straight(
     x: int,
     bend90: kf.KCell,
     straight_factory_dbu: Callable[..., kf.KCell],
-    LAYER: Layers,
+    layers: Layers,
     optical_port: kf.Port,
 ) -> None:
     c = kf.KCell()
@@ -65,7 +65,7 @@ def test_route_straight(
 def test_route_bend90(
     bend90: kf.KCell,
     straight_factory_dbu: Callable[..., kf.KCell],
-    LAYER: Layers,
+    layers: Layers,
     optical_port: kf.Port,
     x: int,
     y: int,
@@ -108,7 +108,7 @@ def test_route_bend90(
 def test_route_bend90_invert(
     bend90: kf.KCell,
     straight_factory_dbu: Callable[..., kf.KCell],
-    LAYER: Layers,
+    layers: Layers,
     optical_port: kf.Port,
     x: int,
     y: int,
@@ -143,7 +143,7 @@ def test_route_bend90_invert(
 def test_route_bend90_euler(
     bend90_euler: kf.KCell,
     straight_factory_dbu: Callable[..., kf.KCell],
-    LAYER: Layers,
+    layers: Layers,
     optical_port: kf.Port,
     x: int,
     y: int,
@@ -167,7 +167,7 @@ def test_route_bend90_euler(
 
 
 def test_route_bundle(
-    LAYER: Layers,
+    layers: Layers,
     optical_port: kf.Port,
     bend90_euler: kf.KCell,
     straight_factory_dbu: Callable[..., kf.KCell],
@@ -218,7 +218,7 @@ def test_route_bundle(
 def test_route_length(
     bend90_euler: kf.KCell,
     straight_factory_dbu: Callable[..., kf.KCell],
-    LAYER: Layers,
+    layers: Layers,
     optical_port: kf.Port,
     taper: kf.KCell,
 ) -> None:
@@ -445,19 +445,19 @@ def test_smart_routing(
 
 
 def test_custom_router(
-    LAYER: Layers,
+    layers: Layers,
 ) -> None:
     kcl = kf.KCLayout("TEST_CUSTOM_ROUTER")
     c = kcl.kcell("CustomRouter")
-    bend90 = kf.cells.circular.bend_circular(width=1, radius=10, layer=LAYER.WG)
+    bend90 = kf.cells.circular.bend_circular(width=1, radius=10, layer=layers.WG)
     b90r = kf.routing.generic.get_radius(list(bend90.ports))
-    sf = partial(kf.cells.straight.straight_dbu, layer=LAYER.WG)
+    sf = partial(kf.cells.straight.straight_dbu, layer=layers.WG)
 
     start_ports = [
         kf.Port(
             name="in{i}",
             width=1000,
-            layer_info=LAYER.WG,
+            layer_info=layers.WG,
             trans=kf.kdb.Trans(1, False, -850_000 + i * 200_000, 0),
             kcl=c.kcl,
         )
@@ -467,7 +467,7 @@ def test_custom_router(
         kf.Port(
             name="in{i}",
             width=1000,
-            layer_info=LAYER.WG,
+            layer_info=layers.WG,
             trans=kf.kdb.Trans(3, False, -400_000 + i * 100_000, 200_000),
             kcl=c.kcl,
         )
@@ -498,7 +498,7 @@ def test_custom_router(
 def test_route_smart_waypoints_trans_sort(
     bend90_small: kf.KCell,
     straight_factory_dbu: Callable[..., kf.KCell],
-    LAYER: Layers,
+    layers: Layers,
 ) -> None:
     c = kf.KCell(name="TEST_SMART_ROUTE_WAYPOINTS_TRANS_SORT")
     _l = 15
@@ -506,13 +506,13 @@ def test_route_smart_waypoints_trans_sort(
         kf.kdb.Trans(1, False, -15_000 - i * 50_000, 15 * 50_000) for i in range(_l)
     ]
     start_ports = [
-        kf.Port(width=500, layer_info=LAYER.WG, kcl=c.kcl, trans=trans)
+        kf.Port(width=500, layer_info=layers.WG, kcl=c.kcl, trans=trans)
         for trans in transformations
     ]
     end_ports = [
         kf.Port(
             width=500,
-            layer_info=LAYER.WG,
+            layer_info=layers.WG,
             kcl=c.kcl,
             trans=kf.kdb.Trans(2, False, 500_000, 0) * trans,
         )
@@ -533,7 +533,7 @@ def test_route_smart_waypoints_trans_sort(
 def test_route_smart_waypoints_pts_sort(
     bend90_small: kf.KCell,
     straight_factory_dbu: Callable[..., kf.KCell],
-    LAYER: Layers,
+    layers: Layers,
 ) -> None:
     c = kf.KCell(name="TEST_SMART_ROUTE_WAYPOINTS_PTS_SORT")
     _l = 15
@@ -541,13 +541,13 @@ def test_route_smart_waypoints_pts_sort(
         kf.kdb.Trans(1, False, -15_000 - i * 50_000, 15 * 50_000) for i in range(_l)
     ]
     start_ports = [
-        kf.Port(width=500, layer_info=LAYER.WG, kcl=c.kcl, trans=trans)
+        kf.Port(width=500, layer_info=layers.WG, kcl=c.kcl, trans=trans)
         for trans in transformations
     ]
     end_ports = [
         kf.Port(
             width=500,
-            layer_info=LAYER.WG,
+            layer_info=layers.WG,
             kcl=c.kcl,
             trans=kf.kdb.Trans(2, False, 500_000, 0) * trans,
         )
@@ -568,7 +568,7 @@ def test_route_smart_waypoints_pts_sort(
 def test_route_smart_waypoints_trans(
     bend90_small: kf.KCell,
     straight_factory_dbu: Callable[..., kf.KCell],
-    LAYER: Layers,
+    layers: Layers,
 ) -> None:
     c = kf.KCell(name="TEST_SMART_ROUTE_WAYPOINTS_TRANS")
     _l = 15
@@ -576,14 +576,14 @@ def test_route_smart_waypoints_trans(
         kf.kdb.Trans(1, False, -15_000 - i * 50_000, 15 * 50_000) for i in range(_l)
     ]
     start_ports = [
-        kf.Port(width=500, layer_info=LAYER.WG, kcl=c.kcl, trans=trans)
+        kf.Port(width=500, layer_info=layers.WG, kcl=c.kcl, trans=trans)
         for trans in transformations
     ]
     start_ports.reverse()
     end_ports = [
         kf.Port(
             width=500,
-            layer_info=LAYER.WG,
+            layer_info=layers.WG,
             kcl=c.kcl,
             trans=kf.kdb.Trans(2, False, 500_000, 0) * trans,
         )
@@ -603,7 +603,7 @@ def test_route_smart_waypoints_trans(
 def test_route_smart_waypoints_pts(
     bend90_small: kf.KCell,
     straight_factory_dbu: Callable[..., kf.KCell],
-    LAYER: Layers,
+    layers: Layers,
 ) -> None:
     c = kf.KCell(name="TEST_SMART_ROUTE_WAYPOINTS_PTS")
     _l = 15
@@ -611,14 +611,14 @@ def test_route_smart_waypoints_pts(
         kf.kdb.Trans(1, False, -15_000 - i * 50_000, 15 * 50_000) for i in range(_l)
     ]
     start_ports = [
-        kf.Port(width=500, layer_info=LAYER.WG, kcl=c.kcl, trans=trans)
+        kf.Port(width=500, layer_info=layers.WG, kcl=c.kcl, trans=trans)
         for trans in transformations
     ]
     start_ports.reverse()
     end_ports = [
         kf.Port(
             width=500,
-            layer_info=LAYER.WG,
+            layer_info=layers.WG,
             kcl=c.kcl,
             trans=kf.kdb.Trans(2, False, 500_000, 0) * trans,
         )
@@ -636,7 +636,9 @@ def test_route_smart_waypoints_pts(
 
 
 def test_route_generic_reorient(
-    bend90_small: kf.KCell, straight_factory_dbu: Callable[..., kf.KCell], LAYER: Layers
+    bend90_small: kf.KCell,
+    straight_factory_dbu: Callable[..., kf.KCell],
+    layers: Layers,
 ) -> None:
     c = kf.KCell(name="test_route_generic_reorient")
 
@@ -678,33 +680,35 @@ def test_route_generic_reorient(
 
 
 def test_placer_error(
-    bend90_small: kf.KCell, straight_factory_dbu: Callable[..., kf.KCell], LAYER: Layers
+    bend90_small: kf.KCell,
+    straight_factory_dbu: Callable[..., kf.KCell],
+    layers: Layers,
 ) -> None:
     c = kf.KCell(name="test_placer_error")
 
-    ps = kf.Port(name="start", width=500, layer_info=LAYER.WG, trans=kf.kdb.Trans.R0)
+    ps = kf.Port(name="start", width=500, layer_info=layers.WG, trans=kf.kdb.Trans.R0)
     pe = kf.Port(
         name="end",
         width=500,
-        layer_info=LAYER.WG,
+        layer_info=layers.WG,
         trans=kf.kdb.Trans(2, False, 200_000, 0),
     )
     ps2 = kf.Port(
-        name="start2", width=500, layer_info=LAYER.WG, trans=kf.kdb.Trans(0, 5_000)
+        name="start2", width=500, layer_info=layers.WG, trans=kf.kdb.Trans(0, 5_000)
     )
     pe2 = kf.Port(
         name="end2",
         width=500,
-        layer_info=LAYER.WG,
+        layer_info=layers.WG,
         trans=kf.kdb.Trans(2, False, 200_000, 5_000),
     )
     ps3 = kf.Port(
-        name="start3", width=500, layer_info=LAYER.WG, trans=kf.kdb.Trans(0, 10_000)
+        name="start3", width=500, layer_info=layers.WG, trans=kf.kdb.Trans(0, 10_000)
     )
     pe3 = kf.Port(
         name="end3",
         width=500,
-        layer_info=LAYER.WG,
+        layer_info=layers.WG,
         trans=kf.kdb.Trans(2, False, 200_000, 10_000),
     )
 

--- a/tests/test_shapes.py
+++ b/tests/test_shapes.py
@@ -3,7 +3,7 @@ from conftest import Layers
 import kfactory as kf
 
 
-def test_shapes(LAYER: Layers) -> None:
+def test_shapes(layers: Layers) -> None:
     kc = kf.KCell()
 
-    kc.shapes(kc.kcl.find_layer(LAYER.WG)).insert(kf.kdb.Text())
+    kc.shapes(kc.kcl.find_layer(layers.WG)).insert(kf.kdb.Text())

--- a/tests/test_spiral.py
+++ b/tests/test_spiral.py
@@ -125,7 +125,7 @@ def dbend_circular(
     return c
 
 
-def test_spiral(LAYER: Layers) -> None:
+def test_spiral(layers: Layers) -> None:
     c = kf.KCell()
 
     r1 = 1000
@@ -135,19 +135,19 @@ def test_spiral(LAYER: Layers) -> None:
         name="start",
         trans=kf.kdb.Trans.R0,
         width=1000,
-        layer=c.kcl.find_layer(LAYER.WG),
+        layer=c.kcl.find_layer(layers.WG),
     )
 
     for _ in range(10):
         r = r1 + r2
         r2 = r1
         r1 = r
-        b = c << bend_circular(width=1000, radius=r2, layer=LAYER.WG)
+        b = c << bend_circular(width=1000, radius=r2, layer=layers.WG)
         b.connect("W0", p)
         p = b.ports["N0"]
 
 
-def test_dspiral(LAYER: Layers) -> None:
+def test_dspiral(layers: Layers) -> None:
     c = kf.KCell()
 
     r1 = 1
@@ -157,7 +157,7 @@ def test_dspiral(LAYER: Layers) -> None:
         name="start",
         dcplx_trans=kf.kdb.DCplxTrans.R0,
         width=c.kcl.to_dbu(1),
-        layer=c.kcl.find_layer(LAYER.WG),
+        layer=c.kcl.find_layer(layers.WG),
     )
 
     kf.config.logfilter.level = kf.conf.LogLevel.ERROR
@@ -166,6 +166,6 @@ def test_dspiral(LAYER: Layers) -> None:
         r = r1 + r2
         r2 = r1
         r1 = r
-        b = c << dbend_circular(width=1, radius=r2, layer=LAYER.WG)
+        b = c << dbend_circular(width=1, radius=r2, layer=layers.WG)
         b.connect("W0", p)
         p = b.ports["N0"]

--- a/tests/test_transformations.py
+++ b/tests/test_transformations.py
@@ -15,7 +15,7 @@ import kfactory as kf
     ],
 )
 def test_rotation(
-    center: kf.kdb.Point | None, straight: kf.KCell, LAYER: Layers
+    center: kf.kdb.Point | None, straight: kf.KCell, layers: Layers
 ) -> None:
     c = kf.KCell()
 
@@ -27,7 +27,7 @@ def test_rotation(
         wg2.rotate(2)
 
     if center:
-        c.shapes(c.kcl.find_layer(LAYER.WGCLAD)).insert(
+        c.shapes(c.kcl.find_layer(layers.WGCLAD)).insert(
             kf.kdb.Box(10).transformed(kf.kdb.Trans(center.to_v()))
         )
 
@@ -46,7 +46,7 @@ def test_rotation(
     ],
 )
 def test_drotation(
-    center: kf.kdb.DPoint | None, straight: kf.KCell, LAYER: Layers
+    center: kf.kdb.DPoint | None, straight: kf.KCell, layers: Layers
 ) -> None:
     c = kf.KCell()
 
@@ -59,7 +59,7 @@ def test_drotation(
         wg2.drotate(30)
 
     if center:
-        c.shapes(c.kcl.find_layer(LAYER.WGCLAD)).insert(
+        c.shapes(c.kcl.find_layer(layers.WGCLAD)).insert(
             kf.kdb.DBox(0.01).transformed(kf.kdb.DCplxTrans(center.to_v()))
         )
 

--- a/tests/test_violations.py
+++ b/tests/test_violations.py
@@ -3,29 +3,29 @@ from conftest import Layers
 import kfactory as kf
 
 
-def test_min_width_minkowski(straight: kf.KCell, LAYER: Layers) -> None:
+def test_min_width_minkowski(straight: kf.KCell, layers: Layers) -> None:
     kf.utils.violations.fix_width_minkowski_tiled(
-        c=straight, min_width=500, ref=LAYER.WG
+        c=straight, min_width=500, ref=layers.WG
     )
 
 
-def test_min_spacing_minkowski(straight: kf.KCell, LAYER: Layers) -> None:
+def test_min_spacing_minkowski(straight: kf.KCell, layers: Layers) -> None:
     kf.utils.violations.fix_spacing_minkowski_tiled(
-        c=straight, min_space=500, ref=LAYER.WG
+        c=straight, min_space=500, ref=layers.WG
     )
 
 
-def test_min_width_and_spacing_minkowski(straight: kf.KCell, LAYER: Layers) -> None:
+def test_min_width_and_spacing_minkowski(straight: kf.KCell, layers: Layers) -> None:
     kf.utils.violations.fix_width_and_spacing_minkowski_tiled(
-        c=straight, min_space=500, min_width=250, ref=LAYER.WG
+        c=straight, min_space=500, min_width=250, ref=layers.WG
     )
 
 
-def test_min_spacing_drc(straight: kf.KCell, LAYER: Layers) -> None:
-    kf.utils.violations.fix_spacing_tiled(c=straight, layer=LAYER.WG, min_space=500)
+def test_min_spacing_drc(straight: kf.KCell, layers: Layers) -> None:
+    kf.utils.violations.fix_spacing_tiled(c=straight, layer=layers.WG, min_space=500)
 
 
-def test_min_spacing_sizing(straight: kf.KCell, LAYER: Layers) -> None:
+def test_min_spacing_sizing(straight: kf.KCell, layers: Layers) -> None:
     kf.utils.violations.fix_spacing_sizing_tiled(
-        c=straight, min_space=500, layer=LAYER.WG
+        c=straight, min_space=500, layer=layers.WG
     )

--- a/tests/test_virtual.py
+++ b/tests/test_virtual.py
@@ -19,7 +19,7 @@ def test_virtual_inst(straight: kf.KCell) -> None:
 
 
 def test_virtual_cell_insert(
-    LAYER: Layers, straight: kf.KCell, wg_enc: kf.LayerEnclosure
+    layers: Layers, straight: kf.KCell, wg_enc: kf.LayerEnclosure
 ) -> None:
     c = kf.KCell()
 
@@ -28,7 +28,7 @@ def test_virtual_cell_insert(
     e_bend = kf.cells.virtual.euler.virtual_bend_euler(
         width=0.5,
         radius=10,
-        layer=LAYER.WG,
+        layer=layers.WG,
         angle=25,
         enclosure=wg_enc,
     )
@@ -37,7 +37,7 @@ def test_virtual_cell_insert(
     e3 = vc << e_bend
     e4 = vc << e_bend
     _s = kf.cells.virtual.straight.virtual_straight(
-        width=0.5, length=10, layer=LAYER.WG, enclosure=wg_enc
+        width=0.5, length=10, layer=layers.WG, enclosure=wg_enc
     )
     s = vc << _s
 
@@ -53,7 +53,7 @@ def test_virtual_cell_insert(
     vi.insert_into(c)
 
 
-def test_all_angle_route(LAYER: Layers, wg_enc: kf.LayerEnclosure) -> None:
+def test_all_angle_route(layers: Layers, wg_enc: kf.LayerEnclosure) -> None:
     bb = [kf.kdb.DPoint(x, y) for x, y in [(0, 0), (500, 0), (250, 200), (500, 250)]]
     vc = kf.VKCell(name="test_all_angle")
     kf.routing.aa.optical.route(
@@ -62,14 +62,14 @@ def test_all_angle_route(LAYER: Layers, wg_enc: kf.LayerEnclosure) -> None:
         backbone=bb,
         straight_factory=partial(
             kf.cells.virtual.straight.virtual_straight,
-            layer=LAYER.WG,
+            layer=layers.WG,
             enclosure=wg_enc,
         ),
         bend_factory=partial(
             kf.cells.virtual.euler.virtual_bend_euler,
             width=5,
             radius=20,
-            layer=LAYER.WG,
+            layer=layers.WG,
             enclosure=wg_enc,
         ),
     )


### PR DESCRIPTION
## Summary by Sourcery

Tests:
- Rename the "LAYER" fixture to "layers" for consistency.