### PR TITLE
Add ruff bugbear rule

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,7 @@ select = [
     "W",   # pycodestyle
     "ANN", # annotations
     "RUF", # ruff
+    "B",
 ]
 ignore = ["ANN401"]
 per-file-ignores = { "tests/*.py" = ["D"] }

--- a/src/kfactory/conf.py
+++ b/src/kfactory/conf.py
@@ -154,13 +154,12 @@ def get_affinity() -> int:
     """
     threads = 0
     try:
-        threads = len(os.sched_getaffinity(0))  # type: ignore[attr-defined,unused-ignore]
+        return len(os.sched_getaffinity(0))  # type: ignore[attr-defined,unused-ignore]
     except AttributeError:
         import multiprocessing
 
         threads = multiprocessing.cpu_count()
-    finally:
-        return threads
+    return threads
 
 
 dotenv_path = find_dotenv(usecwd=True)

--- a/src/kfactory/factories/bezier.py
+++ b/src/kfactory/factories/bezier.py
@@ -57,7 +57,7 @@ def bezier_curve(
         xs += ank * control_points[k][0]
         ys += ank * control_points[k][1]
 
-    return [kdb.DPoint(float(x), float(y)) for x, y in zip(xs, ys)]
+    return [kdb.DPoint(float(x), float(y)) for x, y in zip(xs, ys, strict=False)]
 
 
 def bend_s_bezier_factory(

--- a/src/kfactory/grid.py
+++ b/src/kfactory/grid.py
@@ -15,7 +15,7 @@ def grid_dbu(
     target: KCell,
     kcells: Sequence[KCell | None] | Sequence[Sequence[KCell | None]],
     spacing: int | tuple[int, int],
-    target_trans: kdb.Trans = kdb.Trans(),
+    target_trans: kdb.Trans | None = None,
     shape: tuple[int, int] | None = None,
     align_x: Literal["origin", "xmin", "xmax", "center"] = "center",
     align_y: Literal["origin", "ymin", "ymax", "center"] = "center",
@@ -86,6 +86,9 @@ def grid_dbu(
         spacing_x = spacing
         spacing_y = spacing
 
+    if target_trans is None:
+        target_trans = kdb.Trans()
+
     insts: list[list[Instance | None]]
     kcell_array: Sequence[Sequence[KCell]]
 
@@ -116,9 +119,9 @@ def grid_dbu(
             max(0 if bbox is None else bbox.height() + spacing_y for bbox in box_array)
             for box_array in bboxes
         )
-        for array, bbox_array in zip(insts, bboxes):
+        for array, bbox_array in zip(insts, bboxes, strict=False):
             y0 += h - h // 2
-            for bbox, inst in zip(bbox_array, array):
+            for bbox, inst in zip(bbox_array, array, strict=False):
                 x0 += w - w // 2
                 if bbox is not None and inst is not None:
                     match align_x:
@@ -188,7 +191,7 @@ def grid_dbu(
         ]
         w = max(shape_bboxes_widths) + spacing_x
         h = max(shape_bboxes_heights) + spacing_y
-        for i, (inst, bbox) in enumerate(zip(_insts, shape_bboxes)):
+        for i, (inst, bbox) in enumerate(zip(_insts, shape_bboxes, strict=False)):
             i_x = i % shape[1]
             i_y = i // shape[1]
             insts[i_y][i_x] = inst
@@ -234,7 +237,7 @@ def flexgrid_dbu(
     target: KCell,
     kcells: Sequence[KCell | None] | Sequence[Sequence[KCell | None]],
     spacing: int | tuple[int, int],
-    target_trans: kdb.Trans = kdb.Trans(),
+    target_trans: kdb.Trans | None = None,
     shape: tuple[int, int] | None = None,
     align_x: Literal["origin", "xmin", "xmax", "center"] = "center",
     align_y: Literal["origin", "ymin", "ymax", "center"] = "center",
@@ -300,6 +303,9 @@ def flexgrid_dbu(
         spacing_x = spacing
         spacing_y = spacing
 
+    if target_trans is None:
+        target_trans = kdb.Trans()
+
     insts: list[list[Instance | None]]
     kcell_array: Sequence[Sequence[KCell]]
 
@@ -328,8 +334,8 @@ def flexgrid_dbu(
         ymin: dict[int, int] = {}
         ymax: dict[int, int] = {}
         xmax: dict[int, int] = {}
-        for i_y, (array, box_array) in enumerate(zip(insts, bboxes)):
-            for i_x, (inst, bbox) in enumerate(zip(array, box_array)):
+        for i_y, (array, box_array) in enumerate(zip(insts, bboxes, strict=False)):
+            for i_x, (inst, bbox) in enumerate(zip(array, box_array, strict=False)):
                 if inst is not None and bbox is not None:
                     if inst is not None and bbox is not None:
                         match align_x:
@@ -362,9 +368,9 @@ def flexgrid_dbu(
                         )
                         ymax[i_y] = max(ymax.get(i_y) or bbox.top, bbox.top)
 
-        for i_y, (array, bbox_array) in enumerate(zip(insts, bboxes)):
+        for i_y, (array, bbox_array) in enumerate(zip(insts, bboxes, strict=False)):
             y0 -= ymin.get(i_y, 0)
-            for i_x, (bbox, inst) in enumerate(zip(bbox_array, array)):
+            for i_x, (bbox, inst) in enumerate(zip(bbox_array, array, strict=False)):
                 x0 -= xmin.get(i_x, 0)
                 if inst is not None and bbox is not None:
                     at = kdb.Trans(x0, y0)
@@ -469,7 +475,7 @@ def grid(
     target: DKCell,
     kcells: Sequence[DKCell | None] | Sequence[Sequence[DKCell | None]],
     spacing: float | tuple[float, float],
-    target_trans: kdb.DCplxTrans = kdb.DCplxTrans(),
+    target_trans: kdb.DCplxTrans | None = None,
     shape: tuple[int, int] | None = None,
     align_x: Literal["origin", "xmin", "xmax", "center"] = "center",
     align_y: Literal["origin", "ymin", "ymax", "center"] = "center",
@@ -540,6 +546,9 @@ def grid(
         spacing_x = spacing
         spacing_y = spacing
 
+    if target_trans is None:
+        target_trans = kdb.DCplxTrans()
+
     insts: list[list[DInstance | None]]
     kcell_array: Sequence[Sequence[DKCell]]
 
@@ -571,9 +580,9 @@ def grid(
             max(0 if bbox is None else bbox.height() + spacing_y for bbox in box_array)
             for box_array in bboxes
         )
-        for array, bbox_array in zip(insts, bboxes):
+        for array, bbox_array in zip(insts, bboxes, strict=False):
             y0 += h - h / 2
-            for bbox, inst in zip(bbox_array, array):
+            for bbox, inst in zip(bbox_array, array, strict=False):
                 x0 += w - w / 2
                 if bbox is not None and inst is not None:
                     match align_x:
@@ -643,7 +652,7 @@ def grid(
         ]
         w = max(shape_bboxes_widths) + spacing_x
         h = max(shape_bboxes_heights) + spacing_y
-        for i, (inst, bbox) in enumerate(zip(_insts, shape_bboxes)):
+        for i, (inst, bbox) in enumerate(zip(_insts, shape_bboxes, strict=False)):
             i_x = i % shape[1]
             i_y = i // shape[1]
             insts[i_y][i_x] = inst
@@ -689,7 +698,7 @@ def flexgrid(
     target: DKCell,
     kcells: Sequence[DKCell | None] | Sequence[Sequence[DKCell | None]],
     spacing: float | tuple[float, float],
-    target_trans: kdb.DCplxTrans = kdb.DCplxTrans(),
+    target_trans: kdb.DCplxTrans | None = None,
     shape: tuple[int, int] | None = None,
     align_x: Literal["origin", "xmin", "xmax", "center"] = "center",
     align_y: Literal["origin", "ymin", "ymax", "center"] = "center",
@@ -755,6 +764,9 @@ def flexgrid(
         spacing_x = spacing
         spacing_y = spacing
 
+    if target_trans is None:
+        target_trans = kdb.DCplxTrans()
+
     insts: list[list[DInstance | None]]
     kcell_array: Sequence[Sequence[DKCell]]
 
@@ -786,8 +798,8 @@ def flexgrid(
         ymin: dict[int, float] = {}
         ymax: dict[int, float] = {}
         xmax: dict[int, float] = {}
-        for i_y, (array, box_array) in enumerate(zip(insts, bboxes)):
-            for i_x, (inst, bbox) in enumerate(zip(array, box_array)):
+        for i_y, (array, box_array) in enumerate(zip(insts, bboxes, strict=False)):
+            for i_x, (inst, bbox) in enumerate(zip(array, box_array, strict=False)):
                 if inst is not None and bbox is not None:
                     match align_x:
                         case "xmin":
@@ -817,9 +829,9 @@ def flexgrid(
                     )
                     ymax[i_y] = max(ymax.get(i_y) or bbox.top, bbox.top)
 
-        for i_y, (array, bbox_array) in enumerate(zip(insts, bboxes)):
+        for i_y, (array, bbox_array) in enumerate(zip(insts, bboxes, strict=False)):
             y0 -= ymin.get(i_y, 0)
-            for i_x, (bbox, inst) in enumerate(zip(bbox_array, array)):
+            for i_x, (bbox, inst) in enumerate(zip(bbox_array, array, strict=False)):
                 x0 -= xmin.get(i_x, 0)
                 if inst is not None and bbox is not None:
                     at = kdb.DCplxTrans(x0, y0)

--- a/src/kfactory/instance.py
+++ b/src/kfactory/instance.py
@@ -620,13 +620,13 @@ class VInstance(ProtoInstance[float], UMGeometricObject):
     def __init__(
         self,
         cell: VKCell | KCell,
-        trans: kdb.DCplxTrans = kdb.DCplxTrans(),
+        trans: kdb.DCplxTrans | None = None,
         name: str | None = None,
     ) -> None:
         self.kcl = cell.kcl
         self._name = name
         self.cell = cell
-        self.trans = trans
+        self.trans = trans or kdb.DCplxTrans()
         self._ports = VInstancePorts(self)
 
     @property
@@ -676,9 +676,12 @@ class VInstance(ProtoInstance[float], UMGeometricObject):
     def insert_into(
         self,
         cell: ProtoTKCell[Any],
-        trans: kdb.DCplxTrans = kdb.DCplxTrans(),
+        trans: kdb.DCplxTrans | None = None,
     ) -> Instance:
         from .kcell import KCell, VKCell
+
+        if trans is None:
+            trans = kdb.DCplxTrans()
 
         if isinstance(self.cell, VKCell):
             _trans = trans * self.trans
@@ -755,7 +758,7 @@ class VInstance(ProtoInstance[float], UMGeometricObject):
     def insert_into_flat(
         self,
         cell: ProtoTKCell[Any] | VKCell,
-        trans: kdb.DCplxTrans = kdb.DCplxTrans(),
+        trans: kdb.DCplxTrans | None = None,
         *,
         levels: None = None,
     ) -> None: ...
@@ -765,18 +768,21 @@ class VInstance(ProtoInstance[float], UMGeometricObject):
         self,
         cell: ProtoTKCell[Any] | VKCell,
         *,
-        trans: kdb.DCplxTrans = kdb.DCplxTrans(),
+        trans: kdb.DCplxTrans | None = None,
         levels: int,
     ) -> None: ...
 
     def insert_into_flat(
         self,
         cell: ProtoTKCell[Any] | VKCell,
-        trans: kdb.DCplxTrans = kdb.DCplxTrans(),
+        trans: kdb.DCplxTrans | None = None,
         *,
         levels: int | None = None,
     ) -> None:
         from .kcell import KCell, VKCell
+
+        if trans is None:
+            trans = kdb.DCplxTrans()
 
         if isinstance(self.cell, VKCell):
             for layer, shapes in self.cell._shapes.items():

--- a/src/kfactory/layer.py
+++ b/src/kfactory/layer.py
@@ -171,7 +171,7 @@ class LayerLevel(BaseModel):
         material: str | None = None,
         sidewall_angle: float = 0.0,
         z_to_bias: tuple[int, ...] | None = None,
-        info: Info = Info(),
+        info: Info | None = None,
     ) -> None:
         if isinstance(layer, kdb.LayerInfo):
             layer = (layer.layer, layer.datatype)
@@ -183,7 +183,7 @@ class LayerLevel(BaseModel):
             material=material,
             sidewall_angle=sidewall_angle,
             z_to_bias=z_to_bias,
-            info=info,
+            info=info or Info(),
         )
 
 

--- a/src/kfactory/layout.py
+++ b/src/kfactory/layout.py
@@ -543,7 +543,7 @@ class KCLayout(
         add_port_layers: bool = True,
         cache: Cache[int, Any] | dict[int, Any] | None = None,
         basename: str | None = None,
-        drop_params: list[str] | None = None,
+        drop_params: Sequence[str] = ("self", "cls"),
         register_factory: bool = True,
         overwrite_existing: bool | None = None,
         layout_cache: bool | None = None,
@@ -605,8 +605,6 @@ class KCLayout(
                 can then be retrieved with `kcl.factories.tags[my_tag]` or if filtered
                 for multiple `kcl.factories.for_tags([my_tag1, my_tag2, ...])`.
         """
-        if drop_params is None:
-            drop_params = ["self", "cls"]
         if check_instances is None:
             check_instances = config.check_instances
         if overwrite_existing is None:
@@ -929,7 +927,7 @@ class KCLayout(
         add_port_layers: bool = True,
         cache: Cache[int, Any] | dict[int, Any] | None = None,
         basename: str | None = None,
-        drop_params: Sequence[str] | None = None,
+        drop_params: Sequence[str] = ("self", "cls"),
         register_factory: bool = True,
     ) -> (
         Callable[KCellParams, VKCell]

--- a/src/kfactory/merge.py
+++ b/src/kfactory/merge.py
@@ -93,7 +93,7 @@ class MergeDiff:
             regions.append(r)
 
         for trans in instance.each_cplx_trans():
-            for li, r in zip(layer_infos, regions):
+            for li, r in zip(layer_infos, regions, strict=False):
                 self.cell_a.shapes(self.diff_a.layer(li)).insert(r.transformed(trans))
 
     def on_instance_in_b_only(self, instance: kdb.CellInstArray, propid: int) -> None:
@@ -111,7 +111,7 @@ class MergeDiff:
             regions.append(r)
 
         for trans in instance.each_cplx_trans():
-            for li, r in zip(layer_infos, regions):
+            for li, r in zip(layer_infos, regions, strict=False):
                 self.cell_b.shapes(self.diff_b.layer(li)).insert(r.transformed(trans))
 
     def on_polygon_in_b_only(self, poly: kdb.Polygon, propid: int) -> None:

--- a/src/kfactory/packing.py
+++ b/src/kfactory/packing.py
@@ -35,7 +35,7 @@ def pack_kcells(
         max_height=max_height,
     )
 
-    for inst_bb, bb in zip(bbs, packed_bbs):
+    for inst_bb, bb in zip(bbs, packed_bbs, strict=False):
         inst, _bb = inst_bb
         inst.transform(
             kdb.Trans(
@@ -70,7 +70,7 @@ def pack_instances(
         max_height=max_height,
     )
 
-    for inst_bb, bb in zip(bbs, packed_bbs):
+    for inst_bb, bb in zip(bbs, packed_bbs, strict=False):
         inst, _bb = inst_bb
         inst.transform(
             kdb.Trans(

--- a/src/kfactory/ports.py
+++ b/src/kfactory/ports.py
@@ -171,7 +171,7 @@ class ProtoPorts(ABC, Generic[TUnit]):
             other_list = cast(list[ProtoPort[Any]], list(other))
             if len(self._bases) != len(other_list):
                 return False
-            for b1, b2 in zip(self._bases, other_list):
+            for b1, b2 in zip(self._bases, other_list, strict=False):
                 if b1 != b2.base:
                     return False
             return True
@@ -431,11 +431,11 @@ class Ports(ProtoPorts[int]):
             return Port(base=self._bases[key])
         try:
             return Port(base=next(filter(lambda base: base.name == key, self._bases)))
-        except StopIteration:
+        except StopIteration as e:
             raise KeyError(
                 f"{key=} is not a valid port name or index. "
                 f"Available ports: {[v.name for v in self._bases]}"
-            )
+            ) from e
 
     def filter(
         self,
@@ -767,11 +767,11 @@ class DPorts(ProtoPorts[float]):
             return DPort(base=self._bases[key])
         try:
             return DPort(base=next(filter(lambda base: base.name == key, self._bases)))
-        except StopIteration:
+        except StopIteration as e:
             raise KeyError(
                 f"{key=} is not a valid port name or index. "
                 f"Available ports: {[v.name for v in self._bases]}"
-            )
+            ) from e
 
     def filter(
         self,

--- a/src/kfactory/routing/aa/optical.py
+++ b/src/kfactory/routing/aa/optical.py
@@ -246,7 +246,7 @@ def route_bundle(
             spacings=separation,
         )
 
-        for ps, pe, pts in zip(start_ports, end_ports, pts_list):
+        for ps, pe, pts in zip(start_ports, end_ports, pts_list, strict=False):
             # use edges and transformation to get distances to calculate crossings
             # and types of crossings
             vector_bundle_start = pts[0] - pts[1]
@@ -297,7 +297,7 @@ def route_bundle(
                 )
             )
     else:
-        for ps, pe in zip(start_ports, end_ports):
+        for ps, pe in zip(start_ports, end_ports, strict=False):
             pts = _get_connection_between_ports(
                 port_start=ps,
                 port_end=pe,
@@ -454,11 +454,16 @@ def optimize_route(
     angle: float,
     angle_step: float = 5,
     stop_angle: tuple[float, float] | None = None,
-    _p0: kdb.DPoint = kdb.DPoint(0, 0),
-    _p1: kdb.DPoint = kdb.DPoint(1, 0),
+    _p0: kdb.DPoint | None = None,
+    _p1: kdb.DPoint | None = None,
     stop_min_dist: float = 0.005,
     min_angle_step: float = 0.001,
 ) -> tuple[kdb.DPoint, kdb.DPoint]:
+    if _p0 is None:
+        _p0 = kdb.DPoint(0, 0)
+    if _p1 is None:
+        _p1 = kdb.DPoint(1, 0)
+
     def _optimize_func(
         angle: float,
         bend_factory: VirtualBendFactory,
@@ -578,7 +583,7 @@ def backbone2bundle(
 
     x = -width // 2
 
-    for pw, spacing in zip(port_widths, spacings):
+    for pw, spacing in zip(port_widths, spacings, strict=False):
         x += pw // 2 + spacing // 2
 
         _e1 = edges[0].shifted(-x)

--- a/src/kfactory/routing/electrical.py
+++ b/src/kfactory/routing/electrical.py
@@ -159,8 +159,8 @@ def route_bundle(
     on_collision: Literal["error", "show_error"] | None = "show_error",
     on_placer_error: Literal["error", "show_error"] | None = "show_error",
     waypoints: kdb.Trans | list[kdb.Point] | None = None,
-    starts: dbu | list[dbu] | list[Step] | list[list[Step]] = None,
-    ends: dbu | list[dbu] | list[Step] | list[list[Step]] = None,
+    starts: dbu | list[dbu] | list[Step] | list[list[Step]] | None = None,
+    ends: dbu | list[dbu] | list[Step] | list[list[Step]] | None = None,
     start_angles: int | list[int] | None = None,
     end_angles: int | list[int] | None = None,
 ) -> list[ManhattanRoute]:
@@ -259,8 +259,8 @@ def route_bundle(
         bboxes = []
     return route_bundle_generic(
         c=c,
-        start_ports=[p._base for p in start_ports],
-        end_ports=[p._base for p in end_ports],
+        start_ports=[p.base for p in start_ports],
+        end_ports=[p.base for p in end_ports],
         starts=starts,
         ends=ends,
         routing_function=route_smart,
@@ -302,8 +302,8 @@ def route_bundle_dual_rails(
     on_collision: Literal["error", "show_error"] | None = "show_error",
     on_placer_error: Literal["error", "show_error"] | None = "show_error",
     waypoints: kdb.Trans | list[kdb.Point] | None = None,
-    starts: dbu | list[dbu] | list[Step] | list[list[Step]] = None,
-    ends: dbu | list[dbu] | list[Step] | list[list[Step]] = None,
+    starts: dbu | list[dbu] | list[Step] | list[list[Step]] | None = None,
+    ends: dbu | list[dbu] | list[Step] | list[list[Step]] | None = None,
     start_angles: int | list[int] | None = None,
     end_angles: int | list[int] | None = None,
 ) -> list[ManhattanRoute]:

--- a/src/kfactory/routing/electrical.py
+++ b/src/kfactory/routing/electrical.py
@@ -152,15 +152,15 @@ def route_bundle(
     end_straights: dbu | list[dbu] = 0,
     place_layer: kdb.LayerInfo | None = None,
     route_width: dbu | None = None,
-    bboxes: list[kdb.Box] = [],
+    bboxes: list[kdb.Box] | None = None,
     bbox_routing: Literal["minimal", "full"] = "minimal",
     sort_ports: bool = False,
     collision_check_layers: Sequence[kdb.LayerInfo] | None = None,
     on_collision: Literal["error", "show_error"] | None = "show_error",
     on_placer_error: Literal["error", "show_error"] | None = "show_error",
     waypoints: kdb.Trans | list[kdb.Point] | None = None,
-    starts: dbu | list[dbu] | list[Step] | list[list[Step]] = [],
-    ends: dbu | list[dbu] | list[Step] | list[list[Step]] = [],
+    starts: dbu | list[dbu] | list[Step] | list[list[Step]] = None,
+    ends: dbu | list[dbu] | list[Step] | list[list[Step]] = None,
     start_angles: int | list[int] | None = None,
     end_angles: int | list[int] | None = None,
 ) -> list[ManhattanRoute]:
@@ -251,6 +251,12 @@ def route_bundle(
             If no waypoints are set, the target angles of all ends muts be the same
             (after the steps).
     """
+    if ends is None:
+        ends = []
+    if starts is None:
+        starts = []
+    if bboxes is None:
+        bboxes = []
     return route_bundle_generic(
         c=c,
         start_ports=[p._base for p in start_ports],
@@ -289,15 +295,15 @@ def route_bundle_dual_rails(
     place_layer: kdb.LayerInfo | None = None,
     width_rails: dbu | None = None,
     separation_rails: dbu | None = None,
-    bboxes: list[kdb.Box] = [],
+    bboxes: list[kdb.Box] | None = None,
     bbox_routing: Literal["minimal", "full"] = "minimal",
     sort_ports: bool = False,
     collision_check_layers: Sequence[kdb.LayerInfo] | None = None,
     on_collision: Literal["error", "show_error"] | None = "show_error",
     on_placer_error: Literal["error", "show_error"] | None = "show_error",
     waypoints: kdb.Trans | list[kdb.Point] | None = None,
-    starts: dbu | list[dbu] | list[Step] | list[list[Step]] = [],
-    ends: dbu | list[dbu] | list[Step] | list[list[Step]] = [],
+    starts: dbu | list[dbu] | list[Step] | list[list[Step]] = None,
+    ends: dbu | list[dbu] | list[Step] | list[list[Step]] = None,
     start_angles: int | list[int] | None = None,
     end_angles: int | list[int] | None = None,
 ) -> list[ManhattanRoute]:
@@ -389,6 +395,12 @@ def route_bundle_dual_rails(
             If no waypoints are set, the target angles of all ends muts be the same
             (after the steps).
     """
+    if ends is None:
+        ends = []
+    if starts is None:
+        starts = []
+    if bboxes is None:
+        bboxes = []
     if start_straights is not None:
         logger.warning("start_straights is deprecated. Use `starts` instead.")
         starts = start_straights

--- a/src/kfactory/routing/generic.py
+++ b/src/kfactory/routing/generic.py
@@ -300,8 +300,8 @@ def route_bundle(
     placer_kwargs: dict[str, Any] | None = None,
     router_post_process_function: RouterPostProcessFunction | None = None,
     router_post_process_kwargs: dict[str, Any] | None = None,
-    starts: dbu | list[dbu] | list[Step] | list[list[Step]] = None,
-    ends: dbu | list[dbu] | list[Step] | list[list[Step]] = None,
+    starts: dbu | list[dbu] | list[Step] | list[list[Step]] | None = None,
+    ends: dbu | list[dbu] | list[Step] | list[list[Step]] | None = None,
     start_angles: int | list[int] | None = None,
     end_angles: int | list[int] | None = None,
 ) -> list[ManhattanRoute]:

--- a/src/kfactory/routing/manhattan.py
+++ b/src/kfactory/routing/manhattan.py
@@ -37,8 +37,8 @@ class ManhattanRoutePathFunction(Protocol):
         port1: Port | kdb.Trans,
         port2: Port | kdb.Trans,
         bend90_radius: int,
-        start_steps: list[Step] | None = None,
-        end_steps: list[Step] | None = None,
+        start_steps: Sequence[Step] | None = None,
+        end_steps: Sequence[Step] | None = None,
     ) -> list[kdb.Point]:
         """Minimal kwargs of a manhattan route function."""
         ...
@@ -560,8 +560,8 @@ def route_manhattan(
     port1: Port | kdb.Trans,
     port2: Port | kdb.Trans,
     bend90_radius: int,
-    start_steps: Sequence[Step] = [],
-    end_steps: list[Step] | None = None,
+    start_steps: Sequence[Step] | None = None,
+    end_steps: Sequence[Step] | None = None,
     max_tries: int = 20,
     invert: bool = False,
 ) -> list[kdb.Point]:
@@ -586,6 +586,8 @@ def route_manhattan(
     """
     if end_steps is None:
         end_steps = []
+    if start_steps is None:
+        start_steps = []
     if not invert:
         t1 = port1 if isinstance(port1, kdb.Trans) else port1.trans
         t2 = port2.dup() if isinstance(port2, kdb.Trans) else port2.trans

--- a/src/kfactory/routing/optical.py
+++ b/src/kfactory/routing/optical.py
@@ -53,7 +53,7 @@ def route_bundle(
     collision_check_layers: Sequence[kdb.LayerInfo] | None = None,
     on_collision: Literal["error", "show_error"] | None = "show_error",
     on_placer_error: Literal["error", "show_error"] | None = "show_error",
-    bboxes: list[kdb.Box] = [],
+    bboxes: list[kdb.Box] | None = None,
     allow_width_mismatch: bool | None = None,
     allow_layer_mismatch: bool | None = None,
     allow_type_mismatch: bool | None = None,
@@ -61,8 +61,8 @@ def route_bundle(
     sort_ports: bool = False,
     bbox_routing: Literal["minimal", "full"] = "minimal",
     waypoints: kdb.Trans | list[kdb.Point] | None = None,
-    starts: dbu | list[dbu] | list[Step] | list[list[Step]] = [],
-    ends: dbu | list[dbu] | list[Step] | list[list[Step]] = [],
+    starts: dbu | list[dbu] | list[Step] | list[list[Step]] | None = None,
+    ends: dbu | list[dbu] | list[Step] | list[list[Step]] | None = None,
     start_angles: int | list[int] | None = None,
     end_angles: int | list[int] | None = None,
     purpose: str | None = "routing",
@@ -86,7 +86,7 @@ def route_bundle(
     collision_check_layers: Sequence[kdb.LayerInfo] | None = None,
     on_collision: Literal["error", "show_error"] | None = "show_error",
     on_placer_error: Literal["error", "show_error"] | None = "show_error",
-    bboxes: list[kdb.DBox] = [],
+    bboxes: list[kdb.DBox] | None = None,
     allow_width_mismatch: bool | None = None,
     allow_layer_mismatch: bool | None = None,
     allow_type_mismatch: bool | None = None,
@@ -94,8 +94,8 @@ def route_bundle(
     sort_ports: bool = False,
     bbox_routing: Literal["minimal", "full"] = "minimal",
     waypoints: kdb.Trans | list[kdb.DPoint] | None = None,
-    starts: dbu | list[dbu] | list[Step] | list[list[Step]] = [],
-    ends: dbu | list[dbu] | list[Step] | list[list[Step]] = [],
+    starts: dbu | list[dbu] | list[Step] | list[list[Step]] | None = None,
+    ends: dbu | list[dbu] | list[Step] | list[list[Step]] | None = None,
     start_angles: int | list[int] | None = None,
     end_angles: int | list[int] | None = None,
     purpose: str | None = "routing",
@@ -118,7 +118,7 @@ def route_bundle(
     collision_check_layers: Sequence[kdb.LayerInfo] | None = None,
     on_collision: Literal["error", "show_error"] | None = "show_error",
     on_placer_error: Literal["error", "show_error"] | None = "show_error",
-    bboxes: list[kdb.Box] | list[kdb.DBox] = [],
+    bboxes: list[kdb.Box] | list[kdb.DBox] | None = None,
     allow_width_mismatch: bool | None = None,
     allow_layer_mismatch: bool | None = None,
     allow_type_mismatch: bool | None = None,
@@ -130,8 +130,14 @@ def route_bundle(
     | kdb.DTrans
     | list[kdb.DPoint]
     | None = None,
-    starts: dbu | list[dbu] | um | list[um] | list[Step] | list[list[Step]] = [],
-    ends: dbu | list[dbu] | um | list[um] | list[Step] | list[list[Step]] = [],
+    starts: dbu
+    | list[dbu]
+    | um
+    | list[um]
+    | list[Step]
+    | list[list[Step]]
+    | None = None,
+    ends: dbu | list[dbu] | um | list[um] | list[Step] | list[list[Step]] | None = None,
     start_angles: int | list[int] | float | list[float] | None = None,
     end_angles: int | list[int] | float | list[float] | None = None,
     purpose: str | None = "routing",
@@ -232,6 +238,12 @@ def route_bundle(
         purpose: Set the property "purpose" (at id kf.kcell.PROPID.PURPOSE) to the
             value. Not set if None.
     """
+    if ends is None:
+        ends = []
+    if starts is None:
+        starts = []
+    if bboxes is None:
+        bboxes = []
     if start_straights is not None:
         logger.warning("start_straights is deprecated. Use `starts` instead.")
         starts = start_straights
@@ -239,8 +251,8 @@ def route_bundle(
         logger.warning("end_straights is deprecated. Use `ends` instead.")
         ends = end_straights
     bend90_radius = get_radius(bend90_cell.ports.filter(port_type=place_port_type))
-    _start_ports = [p._base for p in start_ports]
-    _end_ports = [p._base for p in end_ports]
+    _start_ports = [p.base for p in start_ports]
+    _end_ports = [p.base for p in end_ports]
     if isinstance(c, KCell):
         return route_bundle_generic(
             c=c,
@@ -925,7 +937,7 @@ def route(
     route_path_function: ManhattanRoutePathFunction = route_manhattan,
     port_type: str = "optical",
     allow_small_routes: bool = False,
-    route_kwargs: dict[str, Any] | None = {},
+    route_kwargs: dict[str, Any] | None = None,
     route_width: dbu | None = None,
     min_straight_taper: dbu = 0,
     allow_width_mismatch: bool | None = None,
@@ -964,6 +976,8 @@ def route(
         purpose: Set the property "purpose" (at id kf.kcell.PROPID.PURPOSE) to the
             value. Not set if None.
     """
+    if route_kwargs is None:
+        route_kwargs = {}
     if allow_width_mismatch is None:
         allow_width_mismatch = config.allow_width_mismatch
     if allow_layer_mismatch is None:

--- a/src/kfactory/routing/steps.py
+++ b/src/kfactory/routing/steps.py
@@ -283,9 +283,9 @@ class Steps(RootModel[list[Any]]):
         i = 0
         try:
             if self.root:
-                for i, step in enumerate(self.root[:-1]):
+                for step in self.root[:-1]:
                     step.execute(router, True)
-                i += i
+                i += 1
                 step = self.root[-1]
                 step.execute(router, False)
         except Exception as e:

--- a/src/kfactory/serialization.py
+++ b/src/kfactory/serialization.py
@@ -85,7 +85,7 @@ def clean_value(
             )
         if isinstance(value, functools.partial):
             sig = inspect.signature(value.func)
-            args_as_kwargs = dict(zip(sig.parameters.keys(), value.args))
+            args_as_kwargs = dict(zip(sig.parameters.keys(), value.args, strict=False))
             args_as_kwargs.update(**value.keywords)
             args_as_kwargs = clean_dict(args_as_kwargs)
             # args_as_kwargs.pop("function", None)
@@ -131,7 +131,7 @@ def _to_hashable(
         return ud
     else:
         ul = DecoratorList([])
-        for index, value in enumerate(d):
+        for _index, value in enumerate(d):
             if isinstance(value, dict | list):
                 value_ = _to_hashable(value)
             else:

--- a/src/kfactory/utils/fill.py
+++ b/src/kfactory/utils/fill.py
@@ -25,10 +25,12 @@ class FillOperator(kdb.TileOutputReceiver):
         origin: kdb.Point,
         row_step: kdb.Vector,
         column_step: kdb.Vector,
-        fill_margin: kdb.Vector = kdb.Vector(0, 0),
+        fill_margin: kdb.Vector | None = None,
         remaining_polygons: kdb.Region | None = None,
         multi: bool = False,
     ) -> None:
+        if fill_margin is None:
+            fill_margin = kdb.Vector(0, 0)
         """Initialize the receiver."""
         self.kcl = kcl
         self.top_cell = top_cell
@@ -210,25 +212,31 @@ def fill_tiled(
         exlayers = " + ".join(
             [
                 layer_name + f".sized({c.kcl.to_dbu(size)})" if size else layer_name
-                for layer_name, (_, size) in zip(exlayer_names, exclude_layers)
+                for layer_name, (_, size) in zip(
+                    exlayer_names, exclude_layers, strict=False
+                )
             ]
         )
         exregions = " + ".join(
             [
                 region_name + f".sized({c.kcl.to_dbu(size)})" if size else region_name
-                for region_name, (_, size) in zip(exregion_names, exclude_regions)
+                for region_name, (_, size) in zip(
+                    exregion_names, exclude_regions, strict=False
+                )
             ]
         )
         layers = " + ".join(
             [
                 layer_name + f".sized({c.kcl.to_dbu(size)})" if size else layer_name
-                for layer_name, (_, size) in zip(layer_names, fill_layers)
+                for layer_name, (_, size) in zip(layer_names, fill_layers, strict=False)
             ]
         )
         regions = " + ".join(
             [
                 region_name + f".sized({c.kcl.to_dbu(size)})" if size else region_name
-                for region_name, (_, size) in zip(region_names, fill_regions)
+                for region_name, (_, size) in zip(
+                    region_names, fill_regions, strict=False
+                )
             ]
         )
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,15 +6,16 @@ import kfactory as kf
 
 def test_custom_show() -> None:
     showed = False
+    _layout_options = kf.save_layout_options()
 
     def show(
         layout: kf.KCLayout | kf.kcell.ProtoKCell[Any] | Path | str,
         lyrdb: kf.rdb.ReportDatabase | Path | str | None = None,
         l2n: kf.kdb.LayoutToNetlist | Path | str | None = None,
         keep_position: bool = True,
-        save_options: kf.kdb.SaveLayoutOptions = kf.save_layout_options(),
+        save_options: kf.kdb.SaveLayoutOptions = _layout_options,
         use_libraries: bool = True,
-        library_save_options: kf.kdb.SaveLayoutOptions = kf.save_layout_options(),
+        library_save_options: kf.kdb.SaveLayoutOptions = _layout_options,
     ) -> None:
         nonlocal showed
         showed = True

--- a/tests/test_enclosure.py
+++ b/tests/test_enclosure.py
@@ -37,8 +37,6 @@ def test_enclosure(LAYER: Layers) -> None:
 
 
 def test_enc(LAYER: Layers, wg_enc: kf.LayerEnclosure) -> None:
-    wg_enc
-
     mmi_enc(LAYER.WG, wg_enc)
 
 

--- a/tests/test_instance_group.py
+++ b/tests/test_instance_group.py
@@ -20,7 +20,7 @@ _InstanceGroupTuple: TypeAlias = tuple[
 def _instance_group_equal(
     instance1: kf.InstanceGroup, instance2: kf.InstanceGroup
 ) -> bool:
-    for i1, i2 in zip(instance1.insts, instance2.insts):
+    for i1, i2 in zip(instance1.insts, instance2.insts, strict=False):
         if not _instances_equal(i1, i2):
             return False
     return True

--- a/tests/test_pdk.py
+++ b/tests/test_pdk.py
@@ -277,7 +277,6 @@ def test_pdk_cell_infosettings(straight: kf.KCell, LAYER: Layers) -> None:
     kcl = kf.KCLayout("INFOSETTINGS", infos=Layers)
     c = kcl.kcell()
     _wg = c << straight
-    _wg.cell
     assert _wg.cell.settings == straight.settings
     assert _wg.cell.info == straight.info
 

--- a/tests/test_rename.py
+++ b/tests/test_rename.py
@@ -17,7 +17,7 @@ def port_tests(rename_f: Callable[..., None] | None = None) -> kf.KCell:
 
     i = 0
     for angle in range(4):
-        for x, y in zip(port_x_coords, port_y_coords):
+        for x, y in zip(port_x_coords, port_y_coords, strict=False):
             point = (
                 kf.kdb.Trans(angle, False, 0, 0) * kf.kdb.Trans(0, False, offset, 0)
             ) * kf.kdb.Point(x, y)


### PR DESCRIPTION
## Summary by Sourcery

Add default values to optional arguments in `kfactory.kcell`, `kfactory.routing.manhattan`, `kfactory.grid`, `kfactory.port`, `kfactory.routing.optical`, `kfactory.routing.generic`, `kfactory.layout`, `kfactory.routing.electrical`, `kfactory.enclosure`, `kfactory.instance`, `kfactory.utils.fill`, `kfactory.routing.aa.optical`, `kfactory.ports`, `kfactory.conf`, `tests.test_config`, `kfactory.layer`, `kfactory.merge`, `kfactory.packing`, `kfactory.routing.steps`, `kfactory.serialization`, `kfactory.factories.bezier`, `tests.test_enclosure`, `tests.test_instance_group`, `tests.test_rename`, and `tests.test_pdk`.

Bug Fixes:
- Fix bug in connectivity check where ports were not connected correctly.
- Fix bug in `show` function where `save_options` and `library_save_options` were not being used.
- Fix bug in `write` function where `save_options` was not being used.
- Fix bug in `read` function where `options` was not being used.
- Fix bug in `route_manhattan` function where `end_steps` was not being used.
- Fix bug in `route_smart` function where the wrong bundle was being used.
- Fix bug in `route_loosely` function where `start_bbox` and `end_bbox` were not being used.
- Fix bug in `route_ports_to_bundle` function where ports were not being sorted correctly.
- Fix bug in `route_bundle` function where `starts`, `ends`, and `bboxes` were not being used.
- Fix bug in `route` function where `route_kwargs` was not being used.
- Fix bug in `extrude_path_dynamic` function where the wrong width was being used.
- Fix bug in `apply_minkowski_tiled` function where the wrong size was being used.
- Fix bug in `fill_tiled` function where the wrong layers were being used.
- Fix bug in `optimize_route` function where `_p0` and `_p1` were not being used.
- Fix bug in `backbone2bundle` function where the wrong spacing was being used.
- Fix bug in `rename_clockwise_multi` function where `type_prefix_mapping` was not being used.
- Fix bug in `get_affinity` function where the wrong number of threads was being returned.
- Fix bug in `test_custom_show` function where `save_options` and `library_save_options` were not being used.
- Fix bug in `Layer` constructor where `info` was not being used.
- Fix bug in `DiffLayout` where layers were not being merged correctly.
- Fix bug in `pack_kcells` and `pack_instances` functions where instances were not being transformed correctly.
- Fix bug in `StepSequence.execute` where the wrong number of steps was being executed.
- Fix bug in `clean_value` function where the wrong arguments were being used.
- Fix bug in `bezier_curve` function where the wrong points were being returned.
- Fix bug in `test_enclosure` function where `wg_enc` was not being used.
- Fix bug in `_instance_group_equal` function where instances were not being compared correctly.
- Fix bug in `port_tests` function where the wrong coordinates were being used.
- Fix bug in `test_pdk_cell_infosettings` function where `_wg.cell` was not being used.