### PR TITLE
Add ports tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ cov:
 	uv run pytest -n logical -s --cov=kfactory --cov-branch --cov-report=xml
 
 dev-cov:
-	uv run pytest -n logical -s --cov=kfactory --cov-report=term-missing:skip-covered --durations=10
+	uv run pytest -n logical -s --cov=kfactory --cov-report=term-missing:skip-covered
 
 venv:
 	uv venv -p 3.13

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,10 @@ venv:
 	uv venv -p 3.13
 
 lint:
-	flake8 .
+	uv run ruff check .
+
+mypy:
+	uv run dmypy run src/kfactory
 
 pylint:
 	pylint kfactory

--- a/src/kfactory/cross_section.py
+++ b/src/kfactory/cross_section.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from functools import cached_property
-from typing import TYPE_CHECKING, ClassVar, NotRequired, Self, TypedDict, cast
+from typing import TYPE_CHECKING, NotRequired, Self, TypedDict, cast
 
 from pydantic import BaseModel, Field, model_validator
 
@@ -16,8 +16,6 @@ if TYPE_CHECKING:
 
 class SymmetricalCrossSection(BaseModel, frozen=True):
     """CrossSection which is symmetrical to its main_layer/width."""
-
-    yaml_tag: ClassVar[str] = "!SymmetricalCrossSection"
 
     width: int
     enclosure: LayerEnclosure

--- a/src/kfactory/cross_section.py
+++ b/src/kfactory/cross_section.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from functools import cached_property
-from typing import TYPE_CHECKING, NotRequired, Self, TypedDict, cast
+from typing import TYPE_CHECKING, ClassVar, NotRequired, Self, TypedDict, cast
 
 from pydantic import BaseModel, Field, model_validator
 
@@ -16,6 +16,8 @@ if TYPE_CHECKING:
 
 class SymmetricalCrossSection(BaseModel, frozen=True):
     """CrossSection which is symmetrical to its main_layer/width."""
+
+    yaml_tag: ClassVar[str] = "!SymmetricalCrossSection"
 
     width: int
     enclosure: LayerEnclosure

--- a/src/kfactory/cross_section.py
+++ b/src/kfactory/cross_section.py
@@ -43,6 +43,12 @@ class SymmetricalCrossSection(BaseModel, frozen=True):
             )
         return self
 
+    @model_validator(mode="after")
+    def _validate_width(self) -> Self:
+        if self.width <= 0:
+            raise ValueError("Width must be greater than 0.")
+        return self
+
     @cached_property
     def main_layer(self) -> kdb.LayerInfo:
         """Main Layer of the enclosure and cross section."""
@@ -63,6 +69,12 @@ class DSymmetricalCrossSection(BaseModel):
     width: float
     enclosure: DLayerEnclosure
     name: str | None = None
+
+    @model_validator(mode="after")
+    def _validate_width(self) -> Self:
+        if self.width <= 0:
+            raise ValueError("Width must be greater than 0.")
+        return self
 
     def to_itype(self, kcl: KCLayout) -> SymmetricalCrossSection:
         """Convert to a dbu based CrossSection."""

--- a/src/kfactory/enclosure.py
+++ b/src/kfactory/enclosure.py
@@ -35,7 +35,6 @@ from pydantic import (
     field_validator,
     model_serializer,
 )
-from ruamel.yaml.representer import BaseRepresenter, MappingNode
 from typing_extensions import TypedDict
 
 from . import kdb
@@ -475,7 +474,7 @@ class LayerSection(BaseModel):
     touching or overlapping sections.
     """
 
-    sections: list[Section] = Field(default=[])
+    sections: list[Section] = Field(default_factory=list)
 
     def add_section(self, sec: Section) -> int:
         """Add a new section.
@@ -541,7 +540,6 @@ class LayerEnclosure(BaseModel, validate_assignment=True, arbitrary_types_allowe
     layer_sections: dict[kdb.LayerInfo, LayerSection]
     _name: str | None = PrivateAttr()
     main_layer: kdb.LayerInfo | None
-    yaml_tag: str = "!Enclosure"
 
     def __init__(
         self,
@@ -1041,12 +1039,6 @@ class LayerEnclosure(BaseModel, validate_assignment=True, arbitrary_types_allowe
             return reg_max - reg_min
 
         self.apply_custom(c, bbox_reg)
-
-    @classmethod
-    def to_yaml(cls, representer: BaseRepresenter, node: Any) -> MappingNode:
-        """Get YAML representation of the enclosure."""
-        d = dict(node.enclosures)
-        return representer.represent_mapping(cls.yaml_tag, d)
 
     def __str__(self) -> str:
         """String representation of an enclosure.

--- a/src/kfactory/instance_ports.py
+++ b/src/kfactory/instance_ports.py
@@ -437,10 +437,7 @@ class VInstancePorts(ProtoInstancePorts[float, VInstance]):
         if isinstance(port, ProtoPort):
             return port.base in [p.base for p in self.instance.ports]
         else:
-            for _port in self.instance.ports:
-                if _port.name == port:
-                    return True
-            return False
+            return any(_port.name == port for _port in self.instance.ports)
 
     def __repr__(self) -> str:
         """String representation.

--- a/src/kfactory/instance_ports.py
+++ b/src/kfactory/instance_ports.py
@@ -41,6 +41,24 @@ class HasCellPorts(Generic[TUnit], ABC):
 class ProtoInstancePorts(HasCellPorts[TUnit], Generic[TUnit, TInstance], ABC):
     instance: TInstance
 
+    @abstractmethod
+    def __len__(self) -> int: ...
+
+    @abstractmethod
+    def __contains__(self, port: str | ProtoPort[Any]) -> bool: ...
+
+    @abstractmethod
+    def __getitem__(self, key: int | str | None) -> ProtoPort[TUnit]: ...
+
+    @abstractmethod
+    def __iter__(self) -> Iterator[ProtoPort[TUnit]]: ...
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}(n={len(self)})"
+
+    def __str__(self) -> str:
+        return f"{self.__class__.__name__}(ports={list(self)})"
+
 
 class ProtoTInstancePorts(
     ProtoInstancePorts[TUnit, ProtoTInstance[TUnit]], Generic[TUnit], ABC
@@ -413,6 +431,16 @@ class VInstancePorts(ProtoInstancePorts[float, VInstance]):
     def __iter__(self) -> Iterator[DPort]:
         """Create a copy of the ports to iterate through."""
         yield from (p.copy(self.instance.trans) for p in self.cell_ports)
+
+    def __contains__(self, port: str | ProtoPort[Any]) -> bool:
+        """Check if a port is in the instance."""
+        if isinstance(port, ProtoPort):
+            return port.base in [p.base for p in self.instance.ports]
+        else:
+            for _port in self.instance.ports:
+                if _port.name == port:
+                    return True
+            return False
 
     def __repr__(self) -> str:
         """String representation.

--- a/src/kfactory/instances.py
+++ b/src/kfactory/instances.py
@@ -47,6 +47,17 @@ class ProtoInstances(Generic[TUnit, TInstance], ABC):
     @abstractmethod
     def clear(self) -> None: ...
 
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}(n={len(self)})"
+
+    def __str__(self) -> str:
+        return f"{self.__class__.__name__}(insts={list(self)})"
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, ProtoInstances):
+            return False
+        return list(self) == list(other)
+
 
 class ProtoTInstances(ProtoInstances[TUnit, ProtoTInstance[TUnit]], ABC):
     _tkcell: TKCell

--- a/src/kfactory/kcell.py
+++ b/src/kfactory/kcell.py
@@ -2469,7 +2469,6 @@ class KCell(ProtoTKCell[int], DBUGeometricObject):
                     port_type=_d["port_type"],
                 )
             else:
-                print(kdb.LayerInfo.from_string(layer_as_string))
                 cell.create_port(
                     name=str(_d["name"]),
                     trans=kdb.Trans.from_s(_d["trans"]),

--- a/src/kfactory/layer.py
+++ b/src/kfactory/layer.py
@@ -249,7 +249,7 @@ class LayerStack(BaseModel):
         """Access layer stack elements."""
         if key not in self.layers:
             layers = list(self.layers.keys())
-            raise ValueError(f"{key!r} not in {layers}")
+            raise KeyError(f"{key!r} not in {layers}")
 
         return self.layers[key]
 

--- a/src/kfactory/layout.py
+++ b/src/kfactory/layout.py
@@ -1589,6 +1589,9 @@ class KCLayout(
         """Get a cross section by name or specification."""
         return self.cross_sections.get_cross_section(cross_section)
 
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}({self.name}, n={len(self.kcells)})"
+
 
 KCLayout.model_rebuild()
 TVCell.model_rebuild()

--- a/src/kfactory/port.py
+++ b/src/kfactory/port.py
@@ -851,19 +851,6 @@ class Port(ProtoPort[int]):
             self._base.dcplx_trans = self.dcplx_trans
             self._base.dcplx_trans.angle = value
 
-    @property
-    def mirror(self) -> bool:
-        """Returns `True`/`False` depending on the mirror flag on the transformation."""
-        return self.trans.is_mirror()
-
-    @mirror.setter
-    def mirror(self, value: bool) -> None:
-        """Setter for mirror flag on trans."""
-        if self._base.trans:
-            self._base.trans.mirror = value
-        else:
-            self._base.dcplx_trans.mirror = value  # type: ignore[union-attr]
-
     def __repr__(self) -> str:
         """String representation of port."""
         return (
@@ -1096,15 +1083,6 @@ class DPort(ProtoPort[float]):
     def width(self) -> float:
         """Width of the port in um."""
         return self.kcl.to_um(self._base.cross_section.width)
-
-    @property
-    def mirror(self) -> bool:
-        """Mirror flag of the port."""
-        return self.mirror
-
-    @mirror.setter
-    def mirror(self, value: bool) -> None:
-        self.mirror = value
 
 
 class DIRECTION(IntEnum):

--- a/src/kfactory/port.py
+++ b/src/kfactory/port.py
@@ -150,6 +150,7 @@ class BasePort(BaseModel, arbitrary_types_allowed=True):
             and isinstance(post_trans, kdb.Trans)
         ):
             base.trans = trans * base.trans * post_trans
+            base.dcplx_trans = None
             return base
         if isinstance(trans, kdb.Trans):
             trans = kdb.DCplxTrans(trans.to_dtype(self.kcl.dbu))

--- a/src/kfactory/ports.py
+++ b/src/kfactory/ports.py
@@ -225,10 +225,7 @@ class ProtoPorts(ABC, Generic[TUnit]):
         if isinstance(other, Iterable):
             if len(self._bases) != len(other):
                 return False
-            for b1, b2 in zip(iter(self), other, strict=False):
-                if b1 != b2:
-                    return False
-            return True
+            return all(b1 == b2 for b1, b2 in zip(iter(self), other, strict=False))
         return False
 
 

--- a/src/kfactory/ports.py
+++ b/src/kfactory/ports.py
@@ -33,7 +33,7 @@ from .port import (
     filter_port_type,
     filter_regex,
 )
-from .typings import TPort, TUnit
+from .typings import Angle, TPort, TUnit
 from .utilities import pprint_ports
 
 if TYPE_CHECKING:
@@ -45,7 +45,7 @@ __all__ = ["DPorts", "Ports", "ProtoPorts"]
 
 def _filter_ports(
     ports: Iterable[TPort],
-    angle: int | None = None,
+    angle: Angle | None = None,
     orientation: float | None = None,
     layer: LayerEnum | int | None = None,
     port_type: str | None = None,
@@ -187,7 +187,7 @@ class ProtoPorts(ABC, Generic[TUnit]):
     @abstractmethod
     def filter(
         self,
-        angle: int | None = None,
+        angle: Angle | None = None,
         orientation: float | None = None,
         layer: LayerEnum | int | None = None,
         port_type: str | None = None,
@@ -314,7 +314,7 @@ class Ports(ProtoPorts[int]):
         width: int,
         layer: LayerEnum | int,
         center: tuple[int, int],
-        angle: Literal[0, 1, 2, 3],
+        angle: Angle,
         name: str | None = None,
         port_type: str = "optical",
     ) -> Port: ...
@@ -337,7 +337,7 @@ class Ports(ProtoPorts[int]):
         width: int,
         layer_info: kdb.LayerInfo,
         center: tuple[int, int],
-        angle: Literal[0, 1, 2, 3],
+        angle: Angle,
         name: str | None = None,
         port_type: str = "optical",
     ) -> Port: ...
@@ -353,7 +353,7 @@ class Ports(ProtoPorts[int]):
         trans: kdb.Trans | None = None,
         dcplx_trans: kdb.DCplxTrans | None = None,
         center: tuple[int, int] | None = None,
-        angle: Literal[0, 1, 2, 3] | None = None,
+        angle: Angle | None = None,
         mirror_x: bool = False,
         cross_section: SymmetricalCrossSection | None = None,
     ) -> Port:
@@ -455,7 +455,7 @@ class Ports(ProtoPorts[int]):
 
     def filter(
         self,
-        angle: int | None = None,
+        angle: Angle | None = None,
         orientation: float | None = None,
         layer: LayerEnum | int | None = None,
         port_type: str | None = None,
@@ -579,7 +579,7 @@ class DPorts(ProtoPorts[float]):
         width: float,
         layer: LayerEnum | int,
         center: tuple[float, float],
-        angle: float,
+        orientation: float,
         name: str | None = None,
         port_type: str = "optical",
     ) -> DPort: ...
@@ -613,7 +613,7 @@ class DPorts(ProtoPorts[float]):
         width: float,
         layer_info: kdb.LayerInfo,
         center: tuple[float, float],
-        angle: float,
+        orientation: float,
         name: str | None = None,
         port_type: str = "optical",
     ) -> DPort: ...
@@ -629,7 +629,7 @@ class DPorts(ProtoPorts[float]):
         trans: kdb.Trans | None = None,
         dcplx_trans: kdb.DCplxTrans | None = None,
         center: tuple[float, float] | None = None,
-        angle: float | None = None,
+        orientation: float | None = None,
         mirror_x: bool = False,
         cross_section: SymmetricalCrossSection | None = None,
     ) -> DPort:
@@ -646,10 +646,9 @@ class DPorts(ProtoPorts[float]):
             dcplx_trans: Complex transformation for the port.
                 Use if a non-90° port is necessary.
             center: Tuple of the center. [dbu]
-            angle: Angle in 90° increments. Used for simple/dbu transformations.
+            orientation: Angle in degrees.
             mirror_x: Mirror the transformation of the port.
             cross_section: Cross section of the port. If set, overwrites width and layer
-                (info).
         """
         if cross_section is None:
             if width is None:
@@ -694,19 +693,19 @@ class DPorts(ProtoPorts[float]):
                 cross_section=cross_section,
                 kcl=self.kcl,
             )
-        elif angle is not None and center is not None:
+        elif orientation is not None and center is not None:
             port = DPort(
                 name=name,
                 port_type=port_type,
                 cross_section=cross_section,
-                angle=angle,
+                orientation=orientation,
                 center=center,
                 mirror_x=mirror_x,
                 kcl=self.kcl,
             )
         else:
             raise ValueError(
-                f"You need to define width {width} and trans {trans} or angle {angle}"
+                f"You need to define width {width} and trans {trans} or orientation {orientation}"
                 f" and center {center} or dcplx_trans {dcplx_trans}"
             )
 
@@ -740,7 +739,7 @@ class DPorts(ProtoPorts[float]):
 
     def filter(
         self,
-        angle: int | None = None,
+        angle: Angle | None = None,
         orientation: float | None = None,
         layer: LayerEnum | int | None = None,
         port_type: str | None = None,

--- a/src/kfactory/ports.py
+++ b/src/kfactory/ports.py
@@ -222,8 +222,8 @@ class ProtoPorts(ABC, Generic[TUnit]):
 
     def __eq__(self, other: object) -> bool:
         """Support for `ports1 == ports2` comparisons."""
-        if isinstance(other, Sequence):
-            if len(self._bases) != len(other):
+        if isinstance(other, Iterable):
+            if len(self._bases) != len(list(other)):
                 return False
             return all(b1 == b2 for b1, b2 in zip(iter(self), other, strict=False))
         return False

--- a/src/kfactory/ports.py
+++ b/src/kfactory/ports.py
@@ -398,8 +398,6 @@ class Ports(ProtoPorts[int]):
                     )
                 layer_info = self.kcl.layout.get_info(layer)
             assert layer_info is not None
-            if width <= 0:
-                raise ValueError("width needs to be set and be >0")
             cross_section = self.kcl.get_cross_section(
                 CrossSectionSpec(main_layer=layer_info, width=width)
             )
@@ -663,8 +661,6 @@ class DPorts(ProtoPorts[float]):
                     )
                 layer_info = self.kcl.layout.get_info(layer)
             assert layer_info is not None
-            if width <= 0:
-                raise ValueError("width needs to be set and be >0")
             width_ = self.kcl.to_dbu(width)
             if width_ % 2:
                 raise ValueError(

--- a/src/kfactory/ports.py
+++ b/src/kfactory/ports.py
@@ -705,8 +705,8 @@ class DPorts(ProtoPorts[float]):
             )
         else:
             raise ValueError(
-                f"You need to define width {width} and trans {trans} or orientation {orientation}"
-                f" and center {center} or dcplx_trans {dcplx_trans}"
+                f"You need to define width {width} and trans {trans} or orientation"
+                f" {orientation} and center {center} or dcplx_trans {dcplx_trans}"
             )
 
         self._bases.append(port.base)

--- a/src/kfactory/ports.py
+++ b/src/kfactory/ports.py
@@ -222,7 +222,7 @@ class ProtoPorts(ABC, Generic[TUnit]):
 
     def __eq__(self, other: object) -> bool:
         """Support for `ports1 == ports2` comparisons."""
-        if isinstance(other, Iterable):
+        if isinstance(other, Sequence):
             if len(self._bases) != len(other):
                 return False
             return all(b1 == b2 for b1, b2 in zip(iter(self), other, strict=False))

--- a/src/kfactory/ports.py
+++ b/src/kfactory/ports.py
@@ -228,6 +228,16 @@ class ProtoPorts(ABC, Generic[TUnit]):
             return all(b1 == b2 for b1, b2 in zip(iter(self), other, strict=False))
         return False
 
+    def print(self, unit: Literal["dbu", "um", None] = None) -> None:
+        """Pretty print ports."""
+        config.console.print(pprint_ports(self, unit=unit))
+
+    def pformat(self, unit: Literal["dbu", "um", None] = None) -> str:
+        """Pretty print ports."""
+        with config.console.capture() as capture:
+            config.console.print(pprint_ports(self, unit=unit))
+        return capture.get()
+
 
 class Ports(ProtoPorts[int]):
     """A collection of dbu ports.
@@ -448,7 +458,7 @@ class Ports(ProtoPorts[int]):
         self, rename_function: Callable[[Sequence[Port]], None] | None = None
     ) -> Self:
         """Get a copy of each port."""
-        bases = [b.model_copy() for b in self._bases]
+        bases = [b.__copy__() for b in self._bases]
         if rename_function is not None:
             rename_function([Port(base=b) for b in bases])
         return self.__class__(bases=bases, kcl=self.kcl)
@@ -482,16 +492,6 @@ class Ports(ProtoPorts[int]):
     def __repr__(self) -> str:
         """Representation of the Ports as strings."""
         return repr([repr(DPort(base=b)) for b in self._bases])
-
-    def print(self, unit: Literal["dbu", "um", None] = None) -> None:
-        """Pretty print ports."""
-        config.console.print(pprint_ports(self, unit=unit))
-
-    def pformat(self, unit: Literal["dbu", "um", None] = None) -> str:
-        """Pretty print ports."""
-        with config.console.capture() as capture:
-            config.console.print(pprint_ports(self, unit=unit))
-        return capture.get()
 
 
 class DPorts(ProtoPorts[float]):
@@ -732,7 +732,7 @@ class DPorts(ProtoPorts[float]):
         self, rename_function: Callable[[Sequence[DPort]], None] | None = None
     ) -> Self:
         """Get a copy of each port."""
-        bases = [b.model_copy() for b in self._bases]
+        bases = [b.__copy__() for b in self._bases]
         if rename_function is not None:
             rename_function([DPort(base=b) for b in bases])
         return self.__class__(bases=bases, kcl=self.kcl)
@@ -766,13 +766,3 @@ class DPorts(ProtoPorts[float]):
     def __repr__(self) -> str:
         """Representation of the Ports as strings."""
         return repr([repr(Port(base=b)) for b in self._bases])
-
-    def print(self, unit: Literal["dbu", "um", None] = None) -> None:
-        """Pretty print ports."""
-        config.console.print(pprint_ports(self, unit=unit))
-
-    def pformat(self, unit: Literal["dbu", "um", None] = None) -> str:
-        """Pretty print ports."""
-        with config.console.capture() as capture:
-            config.console.print(pprint_ports(self, unit=unit))
-        return capture.get()

--- a/src/kfactory/typings.py
+++ b/src/kfactory/typings.py
@@ -104,3 +104,5 @@ layer = Annotated["int | LayerEnum", "layer"]
 layer_info = Annotated[kdb.LayerInfo, "layer info"]
 unit: TypeAlias = int | float
 """Database unit or micrometer."""
+Angle: TypeAlias = int
+"""Integer in the range of `[0,1,2,3]` which are increments in 90°."""

--- a/tests/test_cell.py
+++ b/tests/test_cell.py
@@ -439,23 +439,22 @@ def test_to_itype(kcl: kf.KCLayout) -> None:
 
 
 def test_cell_yaml(kcl: kf.KCLayout, layers: Layers) -> None:
-    with tempfile.NamedTemporaryFile(suffix=".yaml") as tmpfile:
-        from ruamel.yaml import YAML
+    from ruamel.yaml import YAML
 
-        yaml = YAML()
-        yaml.register_class(kf.KCell)
-        c = kf.factories.straight.straight_dbu_factory(kf.kcl)(
-            width=5000, length=10000, layer=layers.WG
-        ).dup()
+    yaml = YAML()
+    yaml.register_class(kf.KCell)
+    c = kf.factories.straight.straight_dbu_factory(kf.kcl)(
+        width=5000, length=10000, layer=layers.WG
+    ).dup()
 
-        with open(tmpfile.name, "w") as file:
-            yaml.dump(c, file)
+    with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False) as tmpfile:
+        yaml.dump(c, tmpfile)
 
-        c.name += "test"
+    c.name += "test"
 
-        with open(tmpfile.name) as file:
-            cell = yaml.load(file)
-            assert isinstance(cell, kf.KCell)
+    with open(tmpfile.name) as file:
+        cell = yaml.load(file)
+        assert isinstance(cell, kf.KCell)
 
         c.name = c.name.replace("test", "")
 

--- a/tests/test_cell.py
+++ b/tests/test_cell.py
@@ -476,6 +476,9 @@ def test_cell_yaml(kcl: kf.KCLayout, layers: Layers) -> None:
 
         assert compare_kcell_fields(c_base_kcell, cell_base_kcell)
 
+        c.delete()
+        cell.delete()
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/test_cell.py
+++ b/tests/test_cell.py
@@ -201,7 +201,6 @@ def test_overwrite(layers: Layers) -> None:
 
     @kcl.cell
     def test_overwrite_cell() -> kf.KCell:
-        print("overwrite1")
         c = kcl.kcell()
         return c
 
@@ -209,7 +208,6 @@ def test_overwrite(layers: Layers) -> None:
 
     @kcl.cell(overwrite_existing=True)  # type: ignore[no-redef]
     def test_overwrite_cell() -> kf.KCell:
-        print("overwrite2")
         c = kcl.kcell()
         return c
 
@@ -453,18 +451,20 @@ def test_cell_yaml(layers: Layers) -> None:
         width=5000, length=10000, layer=layers.WG
     ).dup()
 
-    c.name = "kf.factories.straight.straight_dbu_factory.random_cell"
+    _temp_cell_name = "kf.factories.straight.straight_dbu_factory.random_cell"
+
+    c.name = _temp_cell_name
 
     with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False) as tmpfile:
         yaml.dump(c, tmpfile)
 
-    c.name = "kf.factories.straight.straight_dbu_factory.random_cell_old"
+    c.name = _temp_cell_name + "_old"
 
     with open(tmpfile.name) as file:
         cell = yaml.load(file)
         assert isinstance(cell, kf.KCell)
 
-        c.name = "kf.factories.straight.straight_dbu_factory.random_cell"
+        c.name = _temp_cell_name
 
         c_base_kcell = c.base_kcell
         cell_base_kcell = cell.base_kcell
@@ -488,4 +488,4 @@ def test_cell_yaml(layers: Layers) -> None:
 
 
 if __name__ == "__main__":
-    pytest.main([__file__, "-v"])
+    pytest.main([__file__, "-v", "-s"])

--- a/tests/test_cells.py
+++ b/tests/test_cells.py
@@ -121,10 +121,12 @@ def test_cells(cell_name: str, layers: Layers) -> None:
             )
 
 
-def test_additional_info(layers: Layers, wg_enc: kf.LayerEnclosure) -> None:
+def test_additional_info(
+    kcl: kf.KCLayout, layers: Layers, wg_enc: kf.LayerEnclosure
+) -> None:
     test_bend_euler = partial(
         kf.factories.euler.bend_euler_factory(
-            kcl=kf.kcl,
+            kcl=kcl,
             additional_info={"creation_time": "2023-02-12Z23:00:00"},
             overwrite_existing=True,
         ),

--- a/tests/test_dkcell.py
+++ b/tests/test_dkcell.py
@@ -38,7 +38,7 @@ def test_dkcell_ports() -> None:
     c = kcl.dkcell("test_dkcell_ports")
     assert isinstance(c.ports, kf.DPorts)
     assert list(c.ports) == []
-    p = c.create_port(width=1, layer=1, center=(0, 0), angle=90)
+    p = c.create_port(width=1, layer=1, center=(0, 0), orientation=90)
     assert p in c.ports
     assert c.ports == [p]
 
@@ -53,7 +53,7 @@ def test_dkcell_locked() -> None:
         c.ports = []
 
     with pytest.raises(kf.kcell.LockedError):
-        c.create_port(width=1, layer=1, center=(0, 0), angle=90)
+        c.create_port(width=1, layer=1, center=(0, 0), orientation=90)
 
 
 def test_dkcell_attributes() -> None:

--- a/tests/test_instance_ports.py
+++ b/tests/test_instance_ports.py
@@ -244,6 +244,19 @@ def test_vinstance_ports_filter(kcl: kf.KCLayout, layers: Layers) -> None:
 
     assert instance_ports["o2"] == ref.ports["o2"]
 
+    str(instance_ports)
+
+
+def test_vinstance_ports_contains(kcl: kf.KCLayout, layers: Layers) -> None:
+    c = kcl.vkcell()
+    ref = c.create_inst(
+        kf.factories.straight.straight_dbu_factory(kcl)(
+            width=5000, length=10000, layer=layers.WG
+        ),
+        trans=kf.kdb.DCplxTrans(mag=2),
+    )
+    assert ref.ports[0] in ref.ports
+
 
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -83,5 +83,11 @@ def test_layer_enum_invalid_index(layers: Layers) -> None:
         layer_enum["WG"][2]  # type: ignore[index]
 
 
+def test_layer_stack(pdk: kf.KCLayout) -> None:
+    assert pdk.layer_stack.to_dict().keys() == {"wg", "clad"}
+    with pytest.raises(KeyError):
+        pdk.layer_stack["invalid"]
+
+
 if __name__ == "__main__":
-    pytest.main(["-v", __file__])
+    pytest.main(["-s", __file__])

--- a/tests/test_packing.py
+++ b/tests/test_packing.py
@@ -1,0 +1,33 @@
+import pytest
+
+import kfactory as kf
+
+
+def test_pack_kcells(kcl: kf.KCLayout) -> None:
+    c = kcl.kcell()
+    straight = kf.factories.straight.straight_dbu_factory(kcl)(
+        width=1000, length=1000, layer=kf.kdb.LayerInfo(1, 0)
+    )
+    instance_group = kf.packing.pack_kcells(
+        c, [straight] * 4, max_height=2000, max_width=2000
+    )
+    assert instance_group.bbox() == kf.kdb.DBox(0, 0, 2000, 2000)
+
+
+def test_pack_instances(kcl: kf.KCLayout) -> None:
+    c = kcl.kcell()
+    straight = kf.factories.straight.straight_dbu_factory(kcl)(
+        width=1000, length=1000, layer=kf.kdb.LayerInfo(1, 0)
+    )
+    ref = c << straight
+    ref2 = c << straight
+    ref3 = c << straight
+    ref4 = c << straight
+    instance_group = kf.packing.pack_instances(
+        c, [ref, ref2, ref3, ref4], max_height=2000, max_width=2000
+    )
+    assert instance_group.bbox() == kf.kdb.DBox(0, 0, 2000, 2000)
+
+
+if __name__ == "__main__":
+    pytest.main(["-s", __file__])

--- a/tests/test_port.py
+++ b/tests/test_port.py
@@ -125,8 +125,25 @@ def test_base_port_eq(kcl: kf.KCLayout, layers: Layers) -> None:
     assert port1 != 2
 
 
+def test_port_eq(kcl: kf.KCLayout, layers: Layers) -> None:
+    port1 = kf.port.Port(
+        name=None,
+        kcl=kcl,
+        cross_section=kcl.get_cross_section(
+            CrossSectionSpec(main_layer=layers.WG, width=2000)
+        ),
+        port_type="optical",
+        trans=kf.kdb.Trans(1, 0),
+    )
+    port2 = port1.copy()
+    assert port1 == port2
+    port2.trans = kf.kdb.Trans(2, 0)
+    assert port1 != port2
+    assert port1 != 2
+
+
 def test_port_kcl(kcl: kf.KCLayout, pdk: kf.KCLayout, layers: Layers) -> None:
-    port = kf.port.BasePort(
+    port = kf.port.Port(
         name=None,
         kcl=kcl,
         cross_section=kcl.get_cross_section(
@@ -216,8 +233,11 @@ def test_port_orientation(kcl: kf.KCLayout, layers: Layers) -> None:
     assert math.isclose(port.orientation, 1)
     assert port.angle == 0
 
+    port.orientation = 45
+    assert port.orientation == 45
+    assert port.angle == 0
+
     port.angle = 7
-    assert port.angle == 3
     assert port.orientation == 270
 
     port.angle = 12
@@ -244,6 +264,79 @@ def test_to_itype() -> None:
     assert itype.layer == 1
     assert itype.center == (1000, 1000)
     assert itype.angle == 1
+
+
+def test_port_copy(kcl: kf.KCLayout, layers: Layers) -> None:
+    port = kf.DPort(
+        name=None,
+        kcl=kcl,
+        cross_section=kcl.get_cross_section(
+            CrossSectionSpec(main_layer=layers.WG, width=2000)
+        ),
+        port_type="optical",
+        trans=kf.kdb.Trans(1, 0),
+    )
+    port2 = port.copy()
+    port.trans = kf.kdb.Trans(2, 0)
+    assert port2.name is None
+    assert port2.kcl is kcl
+    assert port2.cross_section is kcl.get_cross_section(
+        CrossSectionSpec(main_layer=layers.WG, width=2000)
+    )
+    assert port2.port_type == "optical"
+    assert port2.trans == kf.kdb.Trans(1, 0)
+    assert port.trans == kf.kdb.Trans(2, 0)
+
+
+def test_port_mirror(kcl: kf.KCLayout, layers: Layers) -> None:
+    port = kf.port.DPort(
+        base=kf.port.BasePort(
+            name=None,
+            kcl=kcl,
+            cross_section=kcl.get_cross_section(
+                CrossSectionSpec(main_layer=layers.WG, width=2000)
+            ),
+            port_type="optical",
+            trans=kf.kdb.Trans(1, 0),
+        )
+    )
+    port.mirror = True
+    assert port.mirror
+    port.mirror = False
+    assert not port.mirror
+
+
+def test_port_xy(kcl: kf.KCLayout, layers: Layers) -> None:
+    port = kf.port.DPort(
+        base=kf.port.BasePort(
+            name=None,
+            kcl=kcl,
+            cross_section=kcl.get_cross_section(
+                CrossSectionSpec(main_layer=layers.WG, width=2000)
+            ),
+            port_type="optical",
+            trans=kf.kdb.Trans(0, 0),
+        )
+    )
+    port.dx = 1000
+    assert port.dx == 1000
+    assert port.dy == 0
+    assert port.dcenter == (1000, 0)
+
+    port.dcenter = (1000, 1000)
+    assert port.dx == 1000
+    assert port.dy == 1000
+    assert port.dcenter == (1000, 1000)
+
+    port.dy = 1000
+    assert port.dx == 1000
+    assert port.dy == 1000
+    assert port.dcenter == (1000, 1000)
+
+    port.center = (1, 1)
+    assert port.x == 1
+    assert port.y == 1
+    assert port.center == (1, 1)
 
 
 if __name__ == "__main__":

--- a/tests/test_port.py
+++ b/tests/test_port.py
@@ -1,0 +1,250 @@
+import math
+
+import pytest
+from conftest import Layers
+
+import kfactory as kf
+from kfactory.cross_section import CrossSectionSpec
+
+
+def test_create_port_error(kcl: kf.KCLayout, layers: Layers) -> None:
+    db = kf.rdb.ReportDatabase("Connectivity Check")
+    db_cell = db.create_cell("test")
+    subc = db.create_category("WidthMismatch")
+
+    cell = kf.factories.straight.straight_dbu_factory(kcl)(
+        length=10000, width=2000, layer=layers.WG
+    )
+    cell2 = kf.factories.straight.straight_dbu_factory(kcl)(
+        length=10000, width=2000, layer=layers.WG
+    )
+
+    kf.port.create_port_error(
+        cell.ports["o1"],
+        cell2.ports["o1"],
+        cell,
+        cell2,
+        db,
+        db_cell,
+        subc,
+        kcl.dbu,
+    )
+
+
+def test_invalid_base_port_trans(kcl: kf.KCLayout, layers: Layers) -> None:
+    with pytest.raises(ValueError, match="Both trans and dcplx_trans cannot be None."):
+        kf.port.BasePort(
+            name=None,
+            kcl=kcl,
+            cross_section=kcl.get_cross_section(
+                CrossSectionSpec(main_layer=layers.WG, width=2000)
+            ),
+            port_type="optical",
+        )
+
+    with pytest.raises(
+        ValueError, match="Only one of trans or dcplx_trans can be set."
+    ):
+        kf.port.BasePort(
+            name=None,
+            kcl=kcl,
+            cross_section=kcl.get_cross_section(
+                CrossSectionSpec(main_layer=layers.WG, width=2000)
+            ),
+            port_type="optical",
+            trans=kf.kdb.Trans(1, 0),
+            dcplx_trans=kf.kdb.DCplxTrans(1, 0),
+        )
+
+
+def test_base_port_ser_model(kcl: kf.KCLayout, layers: Layers) -> None:
+    port = kf.port.BasePort(
+        name=None,
+        kcl=kcl,
+        cross_section=kcl.get_cross_section(
+            CrossSectionSpec(main_layer=layers.WG, width=2000)
+        ),
+        port_type="optical",
+        trans=kf.kdb.Trans(1, 0),
+    )
+    assert port.ser_model()
+    port = kf.port.BasePort(
+        name=None,
+        kcl=kcl,
+        cross_section=kcl.get_cross_section(
+            CrossSectionSpec(main_layer=layers.WG, width=2000)
+        ),
+        port_type="optical",
+        dcplx_trans=kf.kdb.DCplxTrans(1, 0),
+    )
+    assert port.ser_model()
+
+
+def test_base_port_get_trans(kcl: kf.KCLayout, layers: Layers) -> None:
+    port = kf.port.BasePort(
+        name=None,
+        kcl=kcl,
+        cross_section=kcl.get_cross_section(
+            CrossSectionSpec(main_layer=layers.WG, width=2000)
+        ),
+        port_type="optical",
+        trans=kf.kdb.Trans(1, 0),
+    )
+
+    assert port.get_trans() == kf.kdb.Trans(1, 0)
+    assert port.get_dcplx_trans() == kf.kdb.DCplxTrans(0.001, 0)
+
+    port = kf.port.BasePort(
+        name=None,
+        kcl=kcl,
+        cross_section=kcl.get_cross_section(
+            CrossSectionSpec(main_layer=layers.WG, width=2000)
+        ),
+        port_type="optical",
+        dcplx_trans=kf.kdb.DCplxTrans(1, 0),
+    )
+
+    assert port.get_dcplx_trans() == kf.kdb.ICplxTrans(1, 0)
+    assert port.get_trans() == kf.kdb.ICplxTrans(1000, 0).s_trans()
+
+
+def test_base_port_eq(kcl: kf.KCLayout, layers: Layers) -> None:
+    port1 = kf.port.BasePort(
+        name=None,
+        kcl=kcl,
+        cross_section=kcl.get_cross_section(
+            CrossSectionSpec(main_layer=layers.WG, width=2000)
+        ),
+        port_type="optical",
+        trans=kf.kdb.Trans(1, 0),
+    )
+    port2 = port1.model_copy()
+    assert port1 == port2
+    port2.trans = kf.kdb.Trans(2, 0)
+    assert port1 != port2
+    assert port1 != 2
+
+
+def test_port_kcl(kcl: kf.KCLayout, pdk: kf.KCLayout, layers: Layers) -> None:
+    port = kf.port.BasePort(
+        name=None,
+        kcl=kcl,
+        cross_section=kcl.get_cross_section(
+            CrossSectionSpec(main_layer=layers.WG, width=2000)
+        ),
+        port_type="optical",
+        trans=kf.kdb.Trans(1, 0),
+    )
+    assert port.kcl is kcl
+    port.kcl = pdk
+    assert port.kcl is pdk
+
+
+def test_port_cross_section(kcl: kf.KCLayout, layers: Layers) -> None:
+    base_port = kf.port.BasePort(
+        name=None,
+        kcl=kcl,
+        cross_section=kcl.get_cross_section(
+            CrossSectionSpec(main_layer=layers.WG, width=2000)
+        ),
+        port_type="optical",
+        trans=kf.kdb.Trans(1, 0),
+    )
+    port = kf.port.Port(base=base_port)
+    assert port.cross_section is kcl.get_cross_section(
+        CrossSectionSpec(main_layer=layers.WG, width=2000)
+    )
+    assert port.cross_section.width == 2000
+    port.cross_section = kcl.get_cross_section(
+        CrossSectionSpec(main_layer=layers.WG, width=3000)
+    )
+    assert port.cross_section is kcl.get_cross_section(
+        CrossSectionSpec(main_layer=layers.WG, width=3000)
+    )
+    assert port.width == 3000
+
+
+def test_port_info(kcl: kf.KCLayout, layers: Layers) -> None:
+    port = kf.port.Port(
+        base=kf.port.BasePort(
+            name=None,
+            kcl=kcl,
+            cross_section=kcl.get_cross_section(
+                CrossSectionSpec(main_layer=layers.WG, width=2000)
+            ),
+            port_type="optical",
+            trans=kf.kdb.Trans(1, 0),
+        )
+    )
+    assert port.info == kf.Info()
+    port.info = kf.Info(test="test")
+    assert port.info == kf.Info(test="test")
+
+
+def test_port_orientation(kcl: kf.KCLayout, layers: Layers) -> None:
+    port = kf.port.Port(
+        base=kf.port.BasePort(
+            name=None,
+            kcl=kcl,
+            cross_section=kcl.get_cross_section(
+                CrossSectionSpec(main_layer=layers.WG, width=2000)
+            ),
+            port_type="optical",
+            trans=kf.kdb.Trans(1, 0),
+        )
+    )
+    assert port.orientation == 0
+    assert port.angle == 0
+
+    port.orientation = 90
+    assert port.orientation == 90
+    assert port.angle == 1
+
+    port.orientation = 180
+    assert port.orientation == 180
+    assert port.angle == 2
+
+    port.orientation = 270
+    assert port.orientation == 270
+    assert port.angle == 3
+
+    port.orientation = 360
+    assert port.orientation == 0
+    assert port.angle == 0
+
+    port.orientation = 361
+    assert math.isclose(port.orientation, 1)
+    assert port.angle == 0
+
+    port.angle = 7
+    assert port.angle == 3
+    assert port.orientation == 270
+
+    port.angle = 12
+    assert port.angle == 0
+    assert port.orientation == 0
+
+
+def test_to_dtype() -> None:
+    port = kf.Port(name="o1", width=10, layer=1, center=(1000, 1000), angle=1)
+    dtype = port.to_dtype()
+    assert dtype.name == "o1"
+    assert dtype.width == 0.01
+    assert dtype.layer == 1
+    assert dtype.center == (1, 1)
+    assert dtype.angle == 1
+    assert dtype.orientation == 90
+
+
+def test_to_itype() -> None:
+    port = kf.DPort(name="o1", width=0.01, layer=1, center=(1, 1), orientation=90)
+    itype = port.to_itype()
+    assert itype.name == "o1"
+    assert itype.width == 10
+    assert itype.layer == 1
+    assert itype.center == (1000, 1000)
+    assert itype.angle == 1
+
+
+if __name__ == "__main__":
+    pytest.main(["-s", __file__])

--- a/tests/test_port.py
+++ b/tests/test_port.py
@@ -11,8 +11,8 @@ _PortsType = tuple[kf.port.DPort, kf.port.Port, kf.port.DPort, kf.port.Port]
 
 
 kcl = kf.KCLayout("TEST_PORT")
-LAYERS = Layers()
-kcl.infos = LAYERS
+layers = Layers()
+kcl.infos = layers
 
 
 def get_ports() -> _PortsType:
@@ -20,7 +20,7 @@ def get_ports() -> _PortsType:
         name=None,
         kcl=kcl,
         cross_section=kcl.get_cross_section(
-            CrossSectionSpec(main_layer=LAYERS.WG, width=2000)
+            CrossSectionSpec(main_layer=layers.WG, width=2000)
         ),
         port_type="optical",
         trans=kf.kdb.Trans(0, 0),
@@ -415,9 +415,9 @@ def test_dport_copy_polar(kcl: kf.KCLayout) -> None:
     assert port2.dcplx_trans == kf.kdb.DCplxTrans(x=1, y=1, rot=45, mirrx=True)
 
 
-def test_autorename(kcl: kf.KCLayout) -> None:
+def test_autorename(kcl: kf.KCLayout, layers: Layers) -> None:
     cell = kf.factories.straight.straight_dbu_factory(kcl)(
-        length=10000, width=2000, layer=LAYERS.WG
+        length=10000, width=2000, layer=layers.WG
     )
 
     def _rename_ports(ports: kf.Ports) -> None:

--- a/tests/test_port.py
+++ b/tests/test_port.py
@@ -1,10 +1,39 @@
 import math
+from typing import Any
 
 import pytest
 from conftest import Layers
 
 import kfactory as kf
 from kfactory.cross_section import CrossSectionSpec
+
+_PortsType = tuple[kf.port.DPort, kf.port.Port, kf.port.DPort, kf.port.Port]
+
+
+kcl = kf.KCLayout("TEST_PORT")
+LAYERS = Layers()
+kcl.infos = LAYERS
+
+
+def get_ports() -> _PortsType:
+    base = kf.port.BasePort(
+        name=None,
+        kcl=kcl,
+        cross_section=kcl.get_cross_section(
+            CrossSectionSpec(main_layer=LAYERS.WG, width=2000)
+        ),
+        port_type="optical",
+        trans=kf.kdb.Trans(0, 0),
+    )
+    complex_base = base.__copy__()
+    complex_base.dcplx_trans = kf.kdb.DCplxTrans(1, rot=20, x=0, y=0)
+    complex_base.trans = None
+    return (
+        kf.port.DPort(base=base.__copy__()),
+        kf.port.Port(base=base.__copy__()),
+        kf.port.DPort(base=complex_base.__copy__()),
+        kf.port.Port(base=complex_base.__copy__()),
+    )
 
 
 def test_create_port_error(kcl: kf.KCLayout, layers: Layers) -> None:
@@ -125,21 +154,13 @@ def test_base_port_eq(kcl: kf.KCLayout, layers: Layers) -> None:
     assert port1 != 2
 
 
-def test_port_eq(kcl: kf.KCLayout, layers: Layers) -> None:
-    port1 = kf.port.Port(
-        name=None,
-        kcl=kcl,
-        cross_section=kcl.get_cross_section(
-            CrossSectionSpec(main_layer=layers.WG, width=2000)
-        ),
-        port_type="optical",
-        trans=kf.kdb.Trans(1, 0),
-    )
-    port2 = port1.copy()
-    assert port1 == port2
+@pytest.mark.parametrize("port", get_ports())
+def test_port_eq(port: kf.port.ProtoPort[Any]) -> None:
+    port2 = port.copy()
+    assert port == port2
     port2.trans = kf.kdb.Trans(2, 0)
-    assert port1 != port2
-    assert port1 != 2
+    assert port != port2
+    assert port != 2
 
 
 def test_port_kcl(kcl: kf.KCLayout, pdk: kf.KCLayout, layers: Layers) -> None:
@@ -182,34 +203,15 @@ def test_port_cross_section(kcl: kf.KCLayout, layers: Layers) -> None:
 
 
 def test_port_info(kcl: kf.KCLayout, layers: Layers) -> None:
-    port = kf.port.Port(
-        base=kf.port.BasePort(
-            name=None,
-            kcl=kcl,
-            cross_section=kcl.get_cross_section(
-                CrossSectionSpec(main_layer=layers.WG, width=2000)
-            ),
-            port_type="optical",
-            trans=kf.kdb.Trans(1, 0),
-        )
-    )
+    port = get_ports()[0].copy()
     assert port.info == kf.Info()
     port.info = kf.Info(test="test")
     assert port.info == kf.Info(test="test")
 
 
-def test_port_orientation(kcl: kf.KCLayout, layers: Layers) -> None:
-    port = kf.port.Port(
-        base=kf.port.BasePort(
-            name=None,
-            kcl=kcl,
-            cross_section=kcl.get_cross_section(
-                CrossSectionSpec(main_layer=layers.WG, width=2000)
-            ),
-            port_type="optical",
-            trans=kf.kdb.Trans(1, 0),
-        )
-    )
+@pytest.mark.parametrize("port", get_ports())
+def test_port_orientation(port: kf.port.ProtoPort[Any]) -> None:
+    port.orientation = 0
     assert port.orientation == 0
     assert port.angle == 0
 
@@ -234,7 +236,7 @@ def test_port_orientation(kcl: kf.KCLayout, layers: Layers) -> None:
     assert port.angle == 0
 
     port.orientation = 45
-    assert port.orientation == 45
+    assert math.isclose(port.orientation, 45)
     assert port.angle == 0
 
     port.angle = 7
@@ -288,55 +290,188 @@ def test_port_copy(kcl: kf.KCLayout, layers: Layers) -> None:
     assert port.trans == kf.kdb.Trans(2, 0)
 
 
-def test_port_mirror(kcl: kf.KCLayout, layers: Layers) -> None:
-    port = kf.port.DPort(
-        base=kf.port.BasePort(
-            name=None,
-            kcl=kcl,
-            cross_section=kcl.get_cross_section(
-                CrossSectionSpec(main_layer=layers.WG, width=2000)
-            ),
-            port_type="optical",
-            trans=kf.kdb.Trans(1, 0),
-        )
-    )
+@pytest.mark.parametrize("port", get_ports())
+def test_port_mirror(port: kf.port.ProtoPort[Any]) -> None:
     port.mirror = True
     assert port.mirror
     port.mirror = False
     assert not port.mirror
 
 
-def test_port_xy(kcl: kf.KCLayout, layers: Layers) -> None:
-    port = kf.port.DPort(
-        base=kf.port.BasePort(
-            name=None,
-            kcl=kcl,
-            cross_section=kcl.get_cross_section(
-                CrossSectionSpec(main_layer=layers.WG, width=2000)
-            ),
-            port_type="optical",
-            trans=kf.kdb.Trans(0, 0),
-        )
-    )
-    port.dx = 1000
-    assert port.dx == 1000
-    assert port.dy == 0
-    assert port.dcenter == (1000, 0)
+@pytest.mark.parametrize("port", get_ports())
+def test_port_xy_center(port: kf.port.ProtoPort[Any]) -> None:
+    port.dx = 543
+    assert port.dx == 543
 
-    port.dcenter = (1000, 1000)
-    assert port.dx == 1000
-    assert port.dy == 1000
-    assert port.dcenter == (1000, 1000)
+    port.dy = 789
+    assert port.dy == 789
 
-    port.dy = 1000
-    assert port.dx == 1000
-    assert port.dy == 1000
-    assert port.dcenter == (1000, 1000)
+    port.dcenter = (654, 321)
+    assert port.dcenter == (654, 321)
+
+    port.x = 987
+    assert port.x == 987
+
+    port.y = 654
+    assert port.y == 654
 
     port.center = (1, 1)
-    assert port.x == 1
-    assert port.y == 1
     assert port.center == (1, 1)
+
+    port.ix = 121
+    assert port.ix == 121
+
+    port.iy = 122
+    assert port.iy == 122
+
+
+def test_print() -> None:
+    port = get_ports()[0]
+    port.print()
+
+
+def test_port_init_with_port() -> None:
+    port = kf.Port(name="o1", width=10, layer=1, center=(1000, 1000), angle=1)
+    port2 = kf.Port(port=port)
+    assert port2.name == "o1"
+    assert port2.width == 10
+    assert port2.layer == 1
+    assert port2.center == (1000, 1000)
+    assert port2.angle == 1
+
+
+def test_dport_init_with_port() -> None:
+    port = kf.DPort(name="o1", width=10, layer=1, center=(1000, 1000), orientation=45)
+    port2 = kf.DPort(port=port)
+    assert port2.name == "o1"
+    assert port2.width == 10
+    assert port2.center == (1000, 1000)
+    assert math.isclose(port2.orientation, 45)
+
+
+def test_port_invalid_init() -> None:
+    with pytest.raises(ValueError):
+        kf.Port(name="o1", layer=1, center=(1000, 1000), angle=1)  # type: ignore[call-overload]
+
+    with pytest.raises(ValueError):
+        kf.Port(name="o1", width=10, center=(1000, 1000), angle=1)  # type: ignore[call-overload]
+
+    with pytest.raises(ValueError):
+        kf.Port(name="o1", layer=1, width=10)  # type: ignore[call-overload]
+
+    with pytest.raises(ValueError, match="Width must be greater than 0."):
+        kf.Port(name="o1", width=-10, layer=1, center=(1000, 1000), angle=1)
+
+
+def test_dport_invalid_init() -> None:
+    with pytest.raises(ValueError):
+        kf.DPort(name="o1", layer=1, center=(1000, 1000), orientation=90)  # type: ignore[call-overload]
+
+    with pytest.raises(ValueError):
+        kf.DPort(name="o1", width=10, center=(1000, 1000), orientation=90)  # type: ignore[call-overload]
+
+    with pytest.raises(ValueError):
+        kf.DPort(name="o1", layer=1, width=10)  # type: ignore[call-overload]
+
+    with pytest.raises(ValueError, match="Width must be greater than 0."):
+        kf.DPort(name="o1", width=-10, layer=1, center=(1000, 1000), orientation=90)
+
+
+def test_port_init(kcl: kf.KCLayout) -> None:
+    port = kf.Port(
+        name="o1",
+        width=10,
+        layer=1,
+        trans=kf.kdb.Trans(1, 0).to_s(),
+        kcl=kcl,
+        port_type="optical",
+    )
+    assert port.trans == kf.kdb.Trans(1, 0)
+
+    port = kf.Port(
+        name="o1",
+        width=10,
+        layer=1,
+        dcplx_trans=kf.kdb.DCplxTrans(1, 0).to_s(),
+        kcl=kcl,
+        port_type="optical",
+    )
+    assert port.dcplx_trans == kf.kdb.DCplxTrans(1, 0)
+
+
+def test_dport_init() -> None:
+    dport = kf.DPort(name="o1", width=10, layer=1, trans=kf.kdb.Trans(1, 0).to_s())
+    assert dport.trans == kf.kdb.Trans(1, 0)
+
+    dport = kf.DPort(
+        name="o1", width=10, layer=1, dcplx_trans=kf.kdb.DCplxTrans(1, 0).to_s()
+    )
+    assert dport.dcplx_trans == kf.kdb.DCplxTrans(1, 0)
+
+
+def test_dport_copy_polar(kcl: kf.KCLayout) -> None:
+    port = kf.DPort(name="o1", width=10, layer=1, center=(0, 0), orientation=0)
+    port2 = port.copy_polar(d=1, d_orth=1, angle=45, mirror=True)
+    assert port2.dcplx_trans == kf.kdb.DCplxTrans(x=1, y=1, rot=45, mirrx=True)
+
+
+def test_autorename(kcl: kf.KCLayout) -> None:
+    cell = kf.factories.straight.straight_dbu_factory(kcl)(
+        length=10000, width=2000, layer=LAYERS.WG
+    )
+
+    def _rename_ports(ports: kf.Ports) -> None:
+        ports["o1"].name = "o3"
+        ports["o2"].name = "o4"
+
+    kf.port.autorename(cell, _rename_ports)
+
+    assert cell.ports.get_all_named().keys() == {"o3", "o4"}
+
+
+def test_rename_clockwise(kcl: kf.KCLayout, layers: Layers) -> None:
+    cell = kf.factories.straight.straight_dbu_factory(kcl)(
+        length=10000, width=2000, layer=layers.WG
+    )
+    _ports = cell.ports
+    kf.port.rename_clockwise(_ports, start=0)
+    assert _ports[0].name == "o0"
+    assert _ports[1].name == "o1"
+
+
+def test_filter_regex(kcl: kf.KCLayout, layers: Layers) -> None:
+    cell = kf.factories.straight.straight_dbu_factory(kcl)(
+        length=10000, width=2000, layer=layers.WG
+    )
+    ports = cell.ports
+    filtered = list(kf.port.filter_regex(ports, "o2"))
+    assert len(filtered) == 1
+
+    filtered[0].name = None
+    filtered = kf.port.filter_regex(filtered, "o2")
+    assert len(list(filtered)) == 0
+
+
+def test_filter_layer_pt_reg(kcl: kf.KCLayout, layers: Layers) -> None:
+    cell = kf.factories.straight.straight_dbu_factory(kcl)(
+        length=10000, width=2000, layer=layers.WG
+    )
+    ports = cell.ports
+    filtered = kf.port.filter_layer_pt_reg(
+        ports, layer=0, port_type="optical", regex="o2"
+    )
+    assert len(list(filtered)) == 1
+
+
+def test_rename_clockwise_multi(kcl: kf.KCLayout, layers: Layers) -> None:
+    cell = kf.factories.straight.straight_dbu_factory(kcl)(
+        length=10000, width=2000, layer=layers.WG
+    )
+    ports = cell.ports
+    ports["o1"].name = "o4"
+    ports["o2"].name = "o5"
+    kf.port.rename_clockwise_multi(ports, layers=[0], regex="o4")
+    assert len(list(ports)) == 2
 
 
 if __name__ == "__main__":

--- a/tests/test_ports.py
+++ b/tests/test_ports.py
@@ -259,26 +259,6 @@ def test_dplx_port_dbu_port_conversion(layers: Layers, kcl: kf.KCLayout) -> None
     assert p.trans == t2
 
 
-def test_to_dtype(kcl: kf.KCLayout) -> None:
-    port = kf.Port(name="o1", width=10, layer=1, center=(1000, 1000), angle=1)
-    dtype = port.to_dtype()
-    assert dtype.name == "o1"
-    assert dtype.width == 0.01
-    assert dtype.layer == 1
-    assert dtype.center == (1, 1)
-    assert dtype.angle == 90
-
-
-def test_to_itype(kcl: kf.KCLayout) -> None:
-    port = kf.DPort(name="o1", width=0.01, layer=1, center=(1, 1), angle=90)
-    itype = port.to_itype()
-    assert itype.name == "o1"
-    assert itype.width == 10
-    assert itype.layer == 1
-    assert itype.center == (1000, 1000)
-    assert itype.angle == 1
-
-
 def test_ports_to_dtype() -> None:
     port = kf.Port(name="o1", width=10, layer=1, center=(1000, 1000), angle=1)
     ports = kf.Ports(
@@ -290,7 +270,7 @@ def test_ports_to_dtype() -> None:
 
 
 def test_ports_to_itype() -> None:
-    port = kf.DPort(name="o1", width=0.01, layer=1, center=(1, 1), angle=90)
+    port = kf.DPort(name="o1", width=0.01, layer=1, center=(1, 1), orientation=90)
     ports = kf.DPorts(
         kcl=kf.kcl,
         ports=[port],
@@ -429,12 +409,12 @@ def test_dports_add_port(kcl: kf.KCLayout, layers: Layers) -> None:
     ports.add_port(port=port, name="o3")
     assert ports["o3"] == port
 
-    port2 = kf.DPort(name="o4", width=10, layer=1, center=(1000, 1000), angle=1)
+    port2 = kf.DPort(name="o4", width=10, layer=1, center=(1000, 1000), orientation=1)
     out_port = ports.add_port(port=port2, name="o4")
     assert out_port == ports["o4"]
 
     port3 = kf.DPort(
-        name="o5", width=10, layer=1, center=(1000, 1000), angle=1, kcl=kcl
+        name="o5", width=10, layer=1, center=(1000, 1000), orientation=1, kcl=kcl
     )
     port3.base.trans = None
     port3.base.dcplx_trans = kf.kdb.DCplxTrans(1, 90, False, 0, 0)
@@ -442,7 +422,7 @@ def test_dports_add_port(kcl: kf.KCLayout, layers: Layers) -> None:
     assert out_port == ports["o5"]
 
     port4 = kf.DPort(
-        name="o6", width=10, layer=1, center=(1000, 1000), angle=1, kcl=kcl
+        name="o6", width=10, layer=1, center=(1000, 1000), orientation=1, kcl=kcl
     )
     port4.base.trans = kf.kdb.Trans.R90
     port4.base.dcplx_trans = None
@@ -455,23 +435,29 @@ def test_dports_create_port(kcl: kf.KCLayout, layers: Layers) -> None:
         width=5000, length=10000, layer=layers.WG
     ).to_dtype()
     ports = c.ports
-    port = ports.create_port(name="o1", width=10, layer=1, center=(1000, 1000), angle=1)
+    port = ports.create_port(
+        name="o1", width=10, layer=1, center=(1000, 1000), orientation=1
+    )
     assert port in ports
 
     with pytest.raises(ValueError):
-        ports.create_port(name="o1", layer=1, center=(1000, 1000), angle=1)  # type: ignore[call-overload]
+        ports.create_port(name="o1", layer=1, center=(1000, 1000), orientation=1)  # type: ignore[call-overload]
 
     with pytest.raises(ValueError):
-        ports.create_port(name="o1", width=10, center=(1000, 1000), angle=1)  # type: ignore[call-overload]
+        ports.create_port(name="o1", width=10, center=(1000, 1000), orientation=1)  # type: ignore[call-overload]
 
     with pytest.raises(ValueError):
         ports.create_port(name="o1", layer=1, width=10)  # type: ignore[call-overload]
 
     with pytest.raises(ValueError, match="width needs to be set and be >0"):
-        ports.create_port(name="o1", width=-10, layer=1, center=(1000, 1000), angle=1)
+        ports.create_port(
+            name="o1", width=-10, layer=1, center=(1000, 1000), orientation=1
+        )
 
     with pytest.raises(ValueError, match="width needs to be even to snap to grid"):
-        ports.create_port(name="o1", width=0.001, layer=1, center=(1000, 1000), angle=1)
+        ports.create_port(
+            name="o1", width=0.001, layer=1, center=(1000, 1000), orientation=1
+        )
 
     port = ports.create_port(name="o1", width=10, layer=1, trans=kf.kdb.Trans.R90)
     assert port in ports

--- a/tests/test_ports.py
+++ b/tests/test_ports.py
@@ -345,7 +345,7 @@ def test_ports_create_port(kcl: kf.KCLayout, layers: Layers) -> None:
     with pytest.raises(ValueError):
         ports.create_port(name="o1", layer=1, width=10)  # type: ignore[call-overload]
 
-    with pytest.raises(ValueError, match="width needs to be set and be >0"):
+    with pytest.raises(ValueError, match="Width must be greater than 0."):
         ports.create_port(name="o1", width=-10, layer=1, center=(1000, 1000), angle=1)
 
 
@@ -449,7 +449,7 @@ def test_dports_create_port(kcl: kf.KCLayout, layers: Layers) -> None:
     with pytest.raises(ValueError):
         ports.create_port(name="o1", layer=1, width=10)  # type: ignore[call-overload]
 
-    with pytest.raises(ValueError, match="width needs to be set and be >0"):
+    with pytest.raises(ValueError, match="Width must be greater than 0."):
         ports.create_port(
             name="o1", width=-10, layer=1, center=(1000, 1000), orientation=1
         )

--- a/tests/test_ports.py
+++ b/tests/test_ports.py
@@ -1,4 +1,5 @@
 import re
+from collections.abc import Sequence
 
 import pytest
 from conftest import Layers
@@ -258,16 +259,6 @@ def test_dplx_port_dbu_port_conversion(layers: Layers, kcl: kf.KCLayout) -> None
     assert p.trans == t2
 
 
-def test_ports_eq() -> None:
-    kcell = kf.KCell(name="test_ports_eq")
-    dkcell = kcell.to_dtype()
-
-    port = kf.Port(name="test", layer=1, width=2, center=(0, 0), angle=90)
-
-    dkcell.ports = [port]  # type: ignore[assignment]
-    assert kcell.ports == [port]
-
-
 def test_to_dtype(kcl: kf.KCLayout) -> None:
     port = kf.Port(name="o1", width=10, layer=1, center=(1000, 1000), angle=1)
     dtype = port.to_dtype()
@@ -308,5 +299,258 @@ def test_ports_to_itype() -> None:
     assert itype[0] == port
 
 
+def test_ports_filter(kcl: kf.KCLayout, layers: Layers) -> None:
+    c = kf.factories.straight.straight_dbu_factory(kcl)(
+        width=5000, length=10000, layer=layers.WG
+    )
+    ports = c.ports
+
+    assert len(ports.filter(angle=0)) == 1
+    assert len(ports.filter(angle=1)) == 0
+    assert len(ports.filter(angle=2)) == 1
+    assert len(ports.filter(angle=3)) == 0
+
+    assert len(ports.filter(orientation=0)) == 1
+    assert len(ports.filter(orientation=180)) == 1
+
+    assert len(ports.filter(layer=0)) == 2
+    assert len(ports.filter(layer=1)) == 0
+
+    assert len(ports.filter(regex="o.*")) == 2
+    assert len(ports.filter(regex="o3")) == 0
+
+    assert len(ports.filter(port_type="optical")) == 2
+    assert len(ports.filter(port_type="non-optical")) == 0
+
+
+def test_ports_contains(kcl: kf.KCLayout, layers: Layers) -> None:
+    c = kf.factories.straight.straight_dbu_factory(kcl)(
+        width=5000, length=10000, layer=layers.WG
+    )
+    ports = c.ports
+    port1 = ports[0]
+    assert port1 in ports
+    assert port1.base in ports
+    assert port1.name is not None
+    assert port1.name in ports
+    assert "o3" not in ports
+
+
+def test_ports_eq(kcl: kf.KCLayout, layers: Layers) -> None:
+    c = kf.factories.straight.straight_dbu_factory(kcl)(
+        width=5000, length=10000, layer=layers.WG
+    )
+    ports = c.ports
+    ports2 = c.ports.copy()
+    assert ports == ports2
+    assert ports != list(ports)[:-1]
+    assert ports != list(ports)[::-1]
+    assert not ports == 1
+
+
+def test_ports_create_port(kcl: kf.KCLayout, layers: Layers) -> None:
+    c = kf.factories.straight.straight_dbu_factory(kcl)(
+        width=5000, length=10000, layer=layers.WG
+    )
+    ports = c.ports
+    port = ports.create_port(name="o1", width=10, layer=1, center=(1000, 1000), angle=1)
+    assert port in ports
+
+    with pytest.raises(ValueError):
+        ports.create_port(name="o1", layer=1, center=(1000, 1000), angle=1)  # type: ignore[call-overload]
+
+    with pytest.raises(ValueError):
+        ports.create_port(name="o1", width=10, center=(1000, 1000), angle=1)  # type: ignore[call-overload]
+
+    with pytest.raises(ValueError):
+        ports.create_port(name="o1", layer=1, width=10)  # type: ignore[call-overload]
+
+    with pytest.raises(ValueError, match="width needs to be set and be >0"):
+        ports.create_port(name="o1", width=-10, layer=1, center=(1000, 1000), angle=1)
+
+
+def test_ports_get_all_named(kcl: kf.KCLayout, layers: Layers) -> None:
+    c = kf.factories.straight.straight_dbu_factory(kcl)(
+        width=5000, length=10000, layer=layers.WG
+    )
+    ports = c.ports
+    assert ports.get_all_named().keys() == {"o1", "o2"}
+
+
+def test_ports_copy(kcl: kf.KCLayout, layers: Layers) -> None:
+    c = kf.factories.straight.straight_dbu_factory(kcl)(
+        width=5000, length=10000, layer=layers.WG
+    )
+    ports = c.ports
+    ports2 = ports.copy()
+    assert ports2 == ports
+
+    def _rename(ports: Sequence[kf.Port]) -> None:
+        ports[0].name = "o3"
+        ports[1].name = "o4"
+
+    ports3 = ports.copy(rename_function=_rename)
+    assert ports3[0].name == "o3"
+    assert ports3[1].name == "o4"
+
+
+def test_ports_print(kcl: kf.KCLayout, layers: Layers) -> None:
+    c = kf.factories.straight.straight_dbu_factory(kcl)(
+        width=5000, length=10000, layer=layers.WG
+    )
+    ports = c.ports
+    ports.print()
+
+
+def test_ports_pformat(kcl: kf.KCLayout, layers: Layers) -> None:
+    c = kf.factories.straight.straight_dbu_factory(kcl)(
+        width=5000, length=10000, layer=layers.WG
+    )
+    ports = c.ports
+    assert ports.pformat()
+
+
+def test_ports_getitem(kcl: kf.KCLayout, layers: Layers) -> None:
+    c = kf.factories.straight.straight_dbu_factory(kcl)(
+        width=5000, length=10000, layer=layers.WG
+    )
+    ports = c.ports
+    assert ports[0] == ports["o1"]
+    with pytest.raises(KeyError):
+        ports["o3"]
+
+
+def test_dports_add_port(kcl: kf.KCLayout, layers: Layers) -> None:
+    c = kf.factories.straight.straight_dbu_factory(kcl)(
+        width=5000, length=10000, layer=layers.WG
+    ).to_dtype()
+    ports = c.ports
+    port = kf.Port(name="o3", width=10, layer=1, center=(1000, 1000), angle=1, kcl=kcl)
+    ports.add_port(port=port, name="o3")
+    assert ports["o3"] == port
+
+    port2 = kf.DPort(name="o4", width=10, layer=1, center=(1000, 1000), angle=1)
+    out_port = ports.add_port(port=port2, name="o4")
+    assert out_port == ports["o4"]
+
+    port3 = kf.DPort(
+        name="o5", width=10, layer=1, center=(1000, 1000), angle=1, kcl=kcl
+    )
+    port3.base.trans = None
+    port3.base.dcplx_trans = kf.kdb.DCplxTrans(1, 90, False, 0, 0)
+    out_port = ports.add_port(port=port3, name="o5")
+    assert out_port == ports["o5"]
+
+    port4 = kf.DPort(
+        name="o6", width=10, layer=1, center=(1000, 1000), angle=1, kcl=kcl
+    )
+    port4.base.trans = kf.kdb.Trans.R90
+    port4.base.dcplx_trans = None
+    out_port = ports.add_port(port=port4, name="o6")
+    assert "o6" in ports.get_all_named().keys()
+
+
+def test_dports_create_port(kcl: kf.KCLayout, layers: Layers) -> None:
+    c = kf.factories.straight.straight_dbu_factory(kcl)(
+        width=5000, length=10000, layer=layers.WG
+    ).to_dtype()
+    ports = c.ports
+    port = ports.create_port(name="o1", width=10, layer=1, center=(1000, 1000), angle=1)
+    assert port in ports
+
+    with pytest.raises(ValueError):
+        ports.create_port(name="o1", layer=1, center=(1000, 1000), angle=1)  # type: ignore[call-overload]
+
+    with pytest.raises(ValueError):
+        ports.create_port(name="o1", width=10, center=(1000, 1000), angle=1)  # type: ignore[call-overload]
+
+    with pytest.raises(ValueError):
+        ports.create_port(name="o1", layer=1, width=10)  # type: ignore[call-overload]
+
+    with pytest.raises(ValueError, match="width needs to be set and be >0"):
+        ports.create_port(name="o1", width=-10, layer=1, center=(1000, 1000), angle=1)
+
+    with pytest.raises(ValueError, match="width needs to be even to snap to grid"):
+        ports.create_port(name="o1", width=0.001, layer=1, center=(1000, 1000), angle=1)
+
+    port = ports.create_port(name="o1", width=10, layer=1, trans=kf.kdb.Trans.R90)
+    assert port in ports.get_all_named().values()
+
+
+def test_dports_get_all_named(kcl: kf.KCLayout, layers: Layers) -> None:
+    c = kf.factories.straight.straight_dbu_factory(kcl)(
+        width=5000, length=10000, layer=layers.WG
+    ).to_dtype()
+    ports = c.ports
+    assert ports.get_all_named().keys() == {"o1", "o2"}
+
+
+def test_dports_getitem(kcl: kf.KCLayout, layers: Layers) -> None:
+    c = kf.factories.straight.straight_dbu_factory(kcl)(
+        width=5000, length=10000, layer=layers.WG
+    ).to_dtype()
+    ports = c.ports
+    assert ports[0] == ports["o1"]
+    with pytest.raises(KeyError):
+        ports["o3"]
+
+
+def test_dports_copy(kcl: kf.KCLayout, layers: Layers) -> None:
+    c = kf.factories.straight.straight_dbu_factory(kcl)(
+        width=5000, length=10000, layer=layers.WG
+    ).to_dtype()
+    ports = c.ports
+    ports2 = ports.copy()
+    assert ports2 == ports
+
+    def _rename(ports: Sequence[kf.DPort]) -> None:
+        ports[0].name = "o3"
+        ports[1].name = "o4"
+
+    ports3 = ports.copy(rename_function=_rename)
+    assert ports3[0].name == "o3"
+    assert ports3[1].name == "o4"
+
+
+def test_dports_filter(kcl: kf.KCLayout, layers: Layers) -> None:
+    c = kf.factories.straight.straight_dbu_factory(kcl)(
+        width=5000, length=10000, layer=layers.WG
+    ).to_dtype()
+    ports = c.ports
+
+    assert len(ports.filter(angle=0)) == 1
+    assert len(ports.filter(angle=1)) == 0
+    assert len(ports.filter(angle=2)) == 1
+    assert len(ports.filter(angle=3)) == 0
+
+    assert len(ports.filter(orientation=0)) == 1
+    assert len(ports.filter(orientation=180)) == 1
+
+    assert len(ports.filter(layer=0)) == 2
+    assert len(ports.filter(layer=1)) == 0
+
+    assert len(ports.filter(regex="o.*")) == 2
+    assert len(ports.filter(regex="o3")) == 0
+
+    assert len(ports.filter(port_type="optical")) == 2
+    assert len(ports.filter(port_type="non-optical")) == 0
+
+
+def test_dports_print(kcl: kf.KCLayout, layers: Layers) -> None:
+    c = kf.factories.straight.straight_dbu_factory(kcl)(
+        width=5000, length=10000, layer=layers.WG
+    ).to_dtype()
+    ports = c.ports
+    ports.print()
+
+
+def test_dports_pformat(kcl: kf.KCLayout, layers: Layers) -> None:
+    c = kf.factories.straight.straight_dbu_factory(kcl)(
+        width=5000, length=10000, layer=layers.WG
+    ).to_dtype()
+    ports = c.ports
+    assert ports.pformat()
+
+
 if __name__ == "__main__":
-    pytest.main([__file__])
+    pytest.main([__file__, "-s"])

--- a/tests/test_ports.py
+++ b/tests/test_ports.py
@@ -259,20 +259,20 @@ def test_dplx_port_dbu_port_conversion(layers: Layers, kcl: kf.KCLayout) -> None
     assert p.trans == t2
 
 
-def test_ports_to_dtype() -> None:
+def test_ports_to_dtype(kcl: kf.KCLayout) -> None:
     port = kf.Port(name="o1", width=10, layer=1, center=(1000, 1000), angle=1)
     ports = kf.Ports(
-        kcl=kf.kcl,
+        kcl=kcl,
         ports=[port],
     )
     dtype = ports.to_dtype()
     assert dtype[0] == port
 
 
-def test_ports_to_itype() -> None:
+def test_ports_to_itype(kcl: kf.KCLayout) -> None:
     port = kf.DPort(name="o1", width=0.01, layer=1, center=(1, 1), orientation=90)
     ports = kf.DPorts(
-        kcl=kf.kcl,
+        kcl=kcl,
         ports=[port],
     )
     itype = ports.to_itype()

--- a/tests/test_ports.py
+++ b/tests/test_ports.py
@@ -345,7 +345,7 @@ def test_ports_eq(kcl: kf.KCLayout, layers: Layers) -> None:
     assert ports == ports2
     assert ports != list(ports)[:-1]
     assert ports != list(ports)[::-1]
-    assert not ports == 1
+    assert ports != 1
 
 
 def test_ports_create_port(kcl: kf.KCLayout, layers: Layers) -> None:

--- a/tests/test_ports.py
+++ b/tests/test_ports.py
@@ -447,7 +447,7 @@ def test_dports_add_port(kcl: kf.KCLayout, layers: Layers) -> None:
     port4.base.trans = kf.kdb.Trans.R90
     port4.base.dcplx_trans = None
     out_port = ports.add_port(port=port4, name="o6")
-    assert "o6" in ports.get_all_named().keys()
+    assert out_port in ports
 
 
 def test_dports_create_port(kcl: kf.KCLayout, layers: Layers) -> None:
@@ -474,7 +474,7 @@ def test_dports_create_port(kcl: kf.KCLayout, layers: Layers) -> None:
         ports.create_port(name="o1", width=0.001, layer=1, center=(1000, 1000), angle=1)
 
     port = ports.create_port(name="o1", width=10, layer=1, trans=kf.kdb.Trans.R90)
-    assert port in ports.get_all_named().values()
+    assert port in ports
 
 
 def test_dports_get_all_named(kcl: kf.KCLayout, layers: Layers) -> None:


### PR DESCRIPTION
## Summary by Sourcery

Add support for Ports in kfactory.

New Features:
- Add `Ports.filter`, `Ports.contains`, `Ports.create_port`, `Ports.get_all_named`, `Ports.copy`, `Ports.print`, and `Ports.pformat` methods.
- Add support for DPorts.
- Add support for InstancePorts.
- Add support for creating ports from YAML files.

Tests:
- Add tests for ports, dports, and instance ports.