### PR TITLE
Add concrete iter for InstancePorts and DInstancePorts

### DIFF
--- a/src/kfactory/instance_ports.py
+++ b/src/kfactory/instance_ports.py
@@ -191,7 +191,7 @@ class ProtoTInstancePorts(
     @abstractmethod
     def cell_ports(self) -> ProtoPorts[TUnit]: ...
 
-    def __iter__(self) -> Iterator[ProtoPort[TUnit]]:
+    def each_port(self) -> Iterator[ProtoPort[TUnit]]:
         """Create a copy of the ports to iterate through."""
         if not self.instance.is_regular_array():
             if not self.instance.is_complex():
@@ -219,6 +219,9 @@ class ProtoTInstancePorts(
                     for i_b in range(self.instance.nb)
                     for p in self.cell_ports
                 )
+
+    @abstractmethod
+    def __iter__(self) -> Iterator[ProtoPort[TUnit]]: ...
 
     def each_by_array_coord(self) -> Iterator[tuple[int, int, ProtoPort[TUnit]]]:
         if not self.instance.is_regular_array():
@@ -356,6 +359,9 @@ class InstancePorts(ProtoTInstancePorts[int]):
     ) -> Port:
         return Port(base=super().__getitem__(key).base)
 
+    def __iter__(self) -> Iterator[Port]:
+        yield from map(lambda p: p.to_itype(), self.each_port())
+
 
 class DInstancePorts(ProtoTInstancePorts[float]):
     def __init__(self, instance: DInstance) -> None:
@@ -387,6 +393,9 @@ class DInstancePorts(ProtoTInstancePorts[float]):
         self, key: int | str | tuple[int | str | None, int, int] | None
     ) -> DPort:
         return DPort(base=super().__getitem__(key).base)
+
+    def __iter__(self) -> Iterator[DPort]:
+        yield from map(lambda p: p.to_dtype(), self.each_port())
 
 
 class VInstancePorts(ProtoInstancePorts[float, VInstance]):

--- a/tests/test_instance_ports.py
+++ b/tests/test_instance_ports.py
@@ -256,6 +256,30 @@ def test_vinstance_ports_contains(kcl: kf.KCLayout, layers: Layers) -> None:
         trans=kf.kdb.DCplxTrans(mag=2),
     )
     assert ref.ports[0] in ref.ports
+    assert ref.ports[0].name is not None
+    assert ref.ports[0].name in ref.ports
+
+
+def test_iter(kcl: kf.KCLayout, layers: Layers) -> None:
+    kcell = kcl.kcell()
+    iref = kcell.create_inst(
+        kf.factories.straight.straight_dbu_factory(kcl)(
+            width=5000, length=10000, layer=layers.WG
+        ),
+        trans=kf.kdb.ICplxTrans(mag=2),
+    )
+    assert len(list(iref.ports)) == 2
+    assert all(isinstance(p, kf.Port) for p in iref.ports)
+
+    dkcell = kcl.dkcell()
+    dref = dkcell.create_inst(
+        kf.factories.straight.straight_dbu_factory(kcl)(
+            width=5000, length=10000, layer=layers.WG
+        ),
+        trans=kf.kdb.DCplxTrans(mag=2),
+    )
+    assert len(list(dref.ports)) == 2
+    assert all(isinstance(p, kf.DPort) for p in dref.ports)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary by Sourcery

New Features:
- Iterate over InstancePorts and DInstancePorts using `iter` and return Port and Dport objects respectively.