### PR TITLE
Add default args for DPort center and orientation

### DIFF
--- a/src/kfactory/port.py
+++ b/src/kfactory/port.py
@@ -937,8 +937,8 @@ class DPort(ProtoPort[float]):
         port_type: str = "optical",
         trans: kdb.Trans | str | None = None,
         dcplx_trans: kdb.DCplxTrans | str | None = None,
-        orientation: float | None = None,
-        center: tuple[float, float] | None = None,
+        orientation: float = 0,
+        center: tuple[float, float] = (0, 0),
         mirror_x: bool = False,
         port: ProtoPort[Any] | None = None,
         kcl: KCLayout | None = None,
@@ -1002,7 +1002,7 @@ class DPort(ProtoPort[float]):
                 info=info_,
                 port_type=port_type,
             )
-        elif orientation is not None:
+        else:
             assert center is not None
             dcplx_trans_ = kdb.DCplxTrans.R0
             self._base = BasePort(
@@ -1016,8 +1016,6 @@ class DPort(ProtoPort[float]):
             self.center = center
             self.orientation = orientation
             self.mirror_x = mirror_x
-        else:
-            raise ValueError("Missing port parameters given")
 
     def copy(
         self,

--- a/tests/test_port.py
+++ b/tests/test_port.py
@@ -370,9 +370,6 @@ def test_dport_invalid_init() -> None:
     with pytest.raises(ValueError):
         kf.DPort(name="o1", width=10, center=(1000, 1000), orientation=90)
 
-    with pytest.raises(ValueError):
-        kf.DPort(name="o1", layer=1, width=10)
-
     with pytest.raises(ValueError, match="Width must be greater than 0."):
         kf.DPort(name="o1", width=-10, layer=1, center=(1000, 1000), orientation=90)
 


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Set default `center` and `orientation` arguments for `DPort`.