### PR TITLE
Fix KCLayout.clear_kcells

### DIFF
--- a/src/kfactory/layout.py
+++ b/src/kfactory/layout.py
@@ -1570,7 +1570,8 @@ class KCLayout(
     def clear_kcells(self) -> None:
         """Clears all cells in the Layout object."""
         for tc in self.top_kcells():
-            tc.prune_cell()
+            tc.locked = False
+            tc.kdb_cell.prune_cell()
         self.tkcells = {}
 
     def get_enclosure(

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -227,5 +227,14 @@ def test_cell_decorator_types(kcl: kf.KCLayout) -> None:
         test_no_output_type()
 
 
+def test_clear_kcells(kcl: kf.KCLayout, layers: Layers) -> None:
+    straight = kf.factories.straight.straight_dbu_factory(kcl)(
+        length=1000, width=1000, layer=layers.WG
+    )
+    kcl.clear_kcells()
+    assert len(kcl.kcells) == 0
+    assert straight.destroyed()
+
+
 if __name__ == "__main__":
     pytest.main(["-s", __file__])


### PR DESCRIPTION
## Summary by Sourcery

Tests:
- Add `test_clear_kcells` to test clearing kcells in a layout.