### PR TITLE
Fix clear kcells

### DIFF
--- a/src/kfactory/layout.py
+++ b/src/kfactory/layout.py
@@ -1569,8 +1569,9 @@ class KCLayout(
 
     def clear_kcells(self) -> None:
         """Clears all cells in the Layout object."""
+        for kc in self.kcells.values():
+            kc.locked = False
         for tc in self.top_kcells():
-            tc.locked = False
             tc.kdb_cell.prune_cell()
         self.tkcells = {}
 

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -228,12 +228,15 @@ def test_cell_decorator_types(kcl: kf.KCLayout) -> None:
 
 
 def test_clear_kcells(kcl: kf.KCLayout, layers: Layers) -> None:
+    c = kcl.kcell(name="c")
     straight = kf.factories.straight.straight_dbu_factory(kcl)(
         length=1000, width=1000, layer=layers.WG
     )
+    c << straight
     kcl.clear_kcells()
     assert len(kcl.kcells) == 0
     assert straight.destroyed()
+    assert c.destroyed()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fixed an issue where clearing kcells would raise an error if the cells were locked.