### PR TITLE
Fix route_bundle and DPort.copy_polar

### DIFF
--- a/src/kfactory/port.py
+++ b/src/kfactory/port.py
@@ -446,17 +446,6 @@ class ProtoPort(Generic[TUnit], ABC):
         """Copy the port with a transformation."""
         ...
 
-    @abstractmethod
-    def copy_polar(
-        self,
-        d: TUnit,
-        d_orth: TUnit,
-        angle: TUnit,
-        mirror: bool = False,
-    ) -> ProtoPort[TUnit]:
-        """Copy the port with a polar transformation."""
-        ...
-
     @property
     def center(self) -> tuple[TUnit, TUnit]:
         """Returns port center."""
@@ -1038,7 +1027,11 @@ class DPort(ProtoPort[float]):
         return DPort(base=self._base.transformed(trans=trans, post_trans=post_trans))
 
     def copy_polar(
-        self, d: float = 0, d_orth: float = 0, angle: float = 2, mirror: bool = False
+        self,
+        d: float = 0,
+        d_orth: float = 0,
+        orientation: float = 180,
+        mirror: bool = False,
     ) -> DPort:
         """Get a polar copy of the port.
 
@@ -1049,11 +1042,11 @@ class DPort(ProtoPort[float]):
             d: The distance to the old port
             d_orth: Orthogonal distance (positive is positive y for a port which is
                 facing angle=0°)
-            angle: Relative angle to the original port (0=0°,1=90°,2=180°,3=270°).
+            orientation: Relative angle to the original port, in degrees.
             mirror: Whether to mirror the port relative to the original port.
         """
         return self.copy(
-            post_trans=kdb.DCplxTrans(rot=angle, mirrx=mirror, x=d, y=d_orth)
+            post_trans=kdb.DCplxTrans(rot=orientation, mirrx=mirror, x=d, y=d_orth)
         )
 
     @property

--- a/src/kfactory/routing/optical.py
+++ b/src/kfactory/routing/optical.py
@@ -331,6 +331,8 @@ def route_bundle(
     if min_straight_taper:
         min_straight_taper = c.kcl.to_dbu(min_straight_taper)
 
+    bboxes_ = [c.kcl.to_dbu(b) for b in cast(list[kdb.DBox], bboxes)]
+
     return route_bundle_generic(
         c=c.kcl[c.cell_index()],
         start_ports=start_ports_,
@@ -348,7 +350,7 @@ def route_bundle(
             "separation": c.kcl.to_dbu(separation),
             "sort_ports": sort_ports,
             "bbox_routing": bbox_routing,
-            "bboxes": list(bboxes),
+            "bboxes": list(bboxes_),
             "waypoints": waypoints,
         },
         placer_function=place90,

--- a/tests/test_port.py
+++ b/tests/test_port.py
@@ -406,7 +406,7 @@ def test_dport_init() -> None:
 
 def test_dport_copy_polar(kcl: kf.KCLayout) -> None:
     port = kf.DPort(name="o1", width=10, layer=1, center=(0, 0), orientation=0)
-    port2 = port.copy_polar(d=1, d_orth=1, angle=45, mirror=True)
+    port2 = port.copy_polar(d=1, d_orth=1, orientation=45, mirror=True)
     assert port2.dcplx_trans == kf.kdb.DCplxTrans(x=1, y=1, rot=45, mirrx=True)
 
 


### PR DESCRIPTION
## Summary by Sourcery

Update the `copy_polar` method to use degrees instead of multiples of 90° for the angle argument, and rename the `angle` argument to `orientation`. Also, fix a bug in `route_bundle_generic` where the bounding boxes were not converted to DBU.

Bug Fixes:
- Fix a bug in `route_bundle_generic` where the bounding boxes were not converted to DBU.

Enhancements:
- Update `copy_polar` to use degrees instead of multiples of 90° for angle.

Tests:
- Update tests for `copy_polar` to use degrees.