### PR TITLE
Fix route width

### DIFF
--- a/src/kfactory/routing/generic.py
+++ b/src/kfactory/routing/generic.py
@@ -136,9 +136,9 @@ def check_collisions(
     for i, (ps, pe, router) in enumerate(
         zip(start_ports, end_ports, routers, strict=False)
     ):
-        _edges, router_edges = router.collisions(log_errors=None)
-        if not _edges.is_empty():
-            collision_edges[f"{ps.name} - {pe.name} (index: {i})"] = _edges
+        edges_, router_edges = router.collisions(log_errors=None)
+        if not edges_.is_empty():
+            collision_edges[f"{ps.name} - {pe.name} (index: {i})"] = edges_
         inter_route_collision = all_router_edges.interacting(router_edges)
         if not inter_route_collision.is_empty():
             inter_route_collisions.join_with(inter_route_collision)
@@ -188,9 +188,9 @@ def check_collisions(
                     error_region_shapes.insert(shape_region & r)
                 shape_region.insert(r)
             for i, inst in enumerate(insts):
-                _inst_region = kdb.Region(inst.bbox(layer_))
+                inst_region_ = kdb.Region(inst.bbox(layer_))
                 # inst_shapes: kdb.Region | None = None
-                if not (inst_region & _inst_region).is_empty():
+                if not (inst_region & inst_region_).is_empty():
                     # if inst_shapes is None:
                     inst_shapes = kdb.Region()
                     shape_it = c.begin_shapes_rec_overlapping(layer_, inst.bbox(layer_))
@@ -202,22 +202,22 @@ def check_collisions(
                                 _it.shape().polygon.transformed(_it.trans())
                             )
                     for j, _reg in inst_regions.items():
-                        if _reg & _inst_region:
-                            __reg = kdb.Region()
+                        if _reg & inst_region_:
+                            reg = kdb.Region()
                             shape_it = c.begin_shapes_rec_touching(
-                                layer_, (_reg & _inst_region).bbox()
+                                layer_, (_reg & inst_region_).bbox()
                             )
                             shape_it.select_cells([insts[j].cell.cell_index()])
                             shape_it.min_depth = 1
                             for _it in shape_it.each():
                                 if _it.path()[0].inst() == insts[j].instance:
-                                    __reg.insert(
+                                    reg.insert(
                                         _it.shape().polygon.transformed(_it.trans())
                                     )
 
-                            error_region_instances.insert(__reg & inst_shapes)
-                inst_region += _inst_region
-                inst_regions[i] = _inst_region
+                            error_region_instances.insert(reg & inst_shapes)
+                inst_region += inst_region_
+                inst_regions[i] = inst_region_
 
             if not error_region_shapes.is_empty():
                 any_layer_collision = True
@@ -272,9 +272,9 @@ def get_radius(
     p1, p2 = ports_
     if p1.angle == p2.angle:
         return int((p1.trans.disp - p2.trans.disp).length())
-    _p = kdb.Point(1, 0)
-    e1 = kdb.Edge(p1.trans.disp.to_p(), p1.trans * _p)
-    e2 = kdb.Edge(p2.trans.disp.to_p(), p2.trans * _p)
+    p = kdb.Point(1, 0)
+    e1 = kdb.Edge(p1.trans.disp.to_p(), p1.trans * p)
+    e2 = kdb.Edge(p2.trans.disp.to_p(), p2.trans * p)
 
     center = e1.cut_point(e2)
     if center is None:
@@ -522,7 +522,6 @@ def route_bundle(
             placer_errors.append(e)
             error_routes.append((ps, pe, router.start.pts, router.width))
     if placer_errors and on_placer_error == "show_error":
-        print(len(placer_errors))
         db = rdb.ReportDatabase("Route Placing Errors")
         cell = db.create_cell(
             c.name
@@ -540,7 +539,6 @@ def route_bundle(
             )
             it.add_value(f"Exception: {error}")
             path = kdb.Path(pts, width or ps.cross_section.width)
-            print(f"{width=}")
             it.add_value(c.kcl.to_um(path.polygon()))
         c.show(lyrdb=db)
     if placer_errors and on_placer_error is not None:

--- a/src/kfactory/routing/optical.py
+++ b/src/kfactory/routing/optical.py
@@ -286,6 +286,7 @@ def route_bundle(
                 "allow_layer_mismatch": allow_width_mismatch,
                 "allow_type_mismatch": allow_type_mismatch,
                 "purpose": purpose,
+                "route_width": route_width,
             },
             start_angles=cast(list[int] | int, start_angles),
             end_angles=cast(list[int] | int, end_angles),
@@ -365,6 +366,7 @@ def route_bundle(
             "allow_layer_mismatch": allow_width_mismatch,
             "allow_type_mismatch": allow_type_mismatch,
             "purpose": purpose,
+            "route_width": route_width,
         },
         start_angles=start_angles,
         end_angles=end_angles,
@@ -554,7 +556,7 @@ def place90(
             wg.connect(
                 wg_p1,
                 p1,
-                allow_width_mismatch=allow_width_mismatch,
+                allow_width_mismatch=route_width is not None or allow_width_mismatch,
                 allow_layer_mismatch=allow_layer_mismatch,
                 allow_type_mismatch=allow_type_mismatch,
             )
@@ -568,7 +570,7 @@ def place90(
             t1.connect(
                 taperp1.name,
                 p1,
-                allow_width_mismatch=allow_width_mismatch,
+                allow_width_mismatch=route_width is not None or allow_width_mismatch,
                 allow_layer_mismatch=allow_layer_mismatch,
                 allow_type_mismatch=allow_type_mismatch,
             )
@@ -1079,13 +1081,25 @@ def route(
                     case 1:
                         bend180 = c << bend180_cell
                         bend180.purpose = purpose
-                        bend180.connect(b180p1.name, p1)
+                        bend180.connect(
+                            b180p1.name,
+                            p1,
+                            allow_width_mismatch=allow_width_mismatch,
+                            allow_layer_mismatch=allow_layer_mismatch,
+                            allow_type_mismatch=allow_type_mismatch,
+                        )
                         start_port = bend180.ports[b180p2.name]
                         pts = pts[1:]
                     case 3:
                         bend180 = c << bend180_cell
                         bend180.purpose = purpose
-                        bend180.connect(b180p2.name, p1)
+                        bend180.connect(
+                            b180p2.name,
+                            p1,
+                            allow_width_mismatch=allow_width_mismatch,
+                            allow_layer_mismatch=allow_layer_mismatch,
+                            allow_type_mismatch=allow_type_mismatch,
+                        )
                         start_port = bend180.ports[b180p1.name]
                         pts = pts[1:]
             if (vec := pts[-1] - pts[-2]).length() == b180r:
@@ -1093,14 +1107,26 @@ def route(
                     case 1:
                         bend180 = c << bend180_cell
                         bend180.purpose = purpose
-                        bend180.connect(b180p1.name, p2)
+                        bend180.connect(
+                            b180p1.name,
+                            p2,
+                            allow_width_mismatch=allow_width_mismatch,
+                            allow_layer_mismatch=allow_layer_mismatch,
+                            allow_type_mismatch=allow_type_mismatch,
+                        )
                         end_port = bend180.ports[b180p2.name]
                         pts = pts[:-1]
                     case 3:
                         bend180 = c << bend180_cell
                         bend180.purpose = purpose
                         # bend180.mirror = True
-                        bend180.connect(b180p2.name, p2)
+                        bend180.connect(
+                            b180p2.name,
+                            p2,
+                            allow_width_mismatch=allow_width_mismatch,
+                            allow_layer_mismatch=allow_layer_mismatch,
+                            allow_type_mismatch=allow_type_mismatch,
+                        )
                         end_port = bend180.ports[b180p1.name]
                         pts = pts[:-1]
 
@@ -1121,10 +1147,22 @@ def route(
                         bend180 = c << bend180_cell
                         bend180.purpose = purpose
                         if start_port.name == b180p2.name:
-                            bend180.connect(b180p1.name, start_port)
+                            bend180.connect(
+                                b180p1.name,
+                                start_port,
+                                allow_width_mismatch=allow_width_mismatch,
+                                allow_layer_mismatch=allow_layer_mismatch,
+                                allow_type_mismatch=allow_type_mismatch,
+                            )
                             start_port = bend180.ports[b180p2.name]
                         else:
-                            bend180.connect(b180p2.name, start_port)
+                            bend180.connect(
+                                b180p2.name,
+                                start_port,
+                                allow_width_mismatch=allow_width_mismatch,
+                                allow_layer_mismatch=allow_layer_mismatch,
+                                allow_type_mismatch=allow_type_mismatch,
+                            )
                             start_port = bend180.ports[b180p1.name]
                         j = i - 1
                     elif (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -113,6 +113,13 @@ def bend90_euler(layers: Layers, wg_enc: kf.LayerEnclosure) -> kf.KCell:
 
 
 @pytest.fixture
+def bend90_euler_small(layers: Layers, wg_enc: kf.LayerEnclosure) -> kf.KCell:
+    return kf.cells.euler.bend_euler(
+        width=0.1, radius=10, layer=layers.WG, enclosure=wg_enc, angle=90
+    )
+
+
+@pytest.fixture
 def bend180_euler(layers: Layers, wg_enc: kf.LayerEnclosure) -> kf.KCell:
     return kf.cells.euler.bend_euler(
         width=0.5, radius=10, layer=layers.WG, enclosure=wg_enc, angle=180

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -215,6 +215,56 @@ def test_route_bundle(
     c.auto_rename_ports()
 
 
+def test_route_bundle_route_width(
+    layers: Layers,
+    optical_port: kf.Port,
+    bend90_euler_small: kf.KCell,
+    straight_factory_dbu: Callable[..., kf.KCell],
+    kcl: kf.KCLayout,
+) -> None:
+    c = kcl.kcell("TEST_ROUTE_BUNDLE")
+
+    p_start = [
+        optical_port.copy(
+            kf.kdb.Trans(
+                1,
+                False,
+                i * 200_000 - 50_000,
+                (4 - i) * 6_000 if i < 5 else (i - 5) * 6_000,
+            )
+        )
+        for i in range(10)
+    ]
+    p_end = [
+        optical_port.copy(
+            kf.kdb.Trans(3, False, i * 200_000 + i**2 * 19_000 + 500_000, 300_000)
+        )
+        for i in range(10)
+    ]
+
+    c.shapes(kcl.find_layer(10, 0)).insert(kf.kdb.Box(-50_000, 0, 1_750_000, -100_000))
+    c.shapes(kcl.find_layer(10, 0)).insert(
+        kf.kdb.Box(1_000_000, 500_000, p_end[-1].x, 600_000)
+    )
+
+    routes = kf.routing.optical.route_bundle(
+        c,
+        p_start,
+        p_end,
+        5_000,
+        straight_factory=straight_factory_dbu,
+        bend90_cell=bend90_euler_small,
+        on_collision=None,
+        route_width=100,
+    )
+
+    for route in routes:
+        c.add_port(port=route.start_port)
+        c.add_port(port=route.end_port)
+
+    c.auto_rename_ports()
+
+
 def test_route_length(
     bend90_euler: kf.KCell,
     straight_factory_dbu: Callable[..., kf.KCell],


### PR DESCRIPTION
## Summary by Sourcery

Fix the handling of route width in optical routing functions and add a test to verify the correct application of route width.

Bug Fixes:
- Fix the handling of route width in the optical routing functions to ensure correct width is applied during routing.

Tests:
- Add a new test case to verify the correct handling of route width in the route_bundle function.