### PR TITLE
Update KCLayout.rebuild to add kcells from the layout

### DIFF
--- a/src/kfactory/layout.py
+++ b/src/kfactory/layout.py
@@ -1233,8 +1233,14 @@ class KCLayout(
             self.layout.delete_cells(cell_index_list)
             self.rebuild()
 
+    def assign(self, layout: kdb.Layout) -> None:
+        """Assign a new Layout object to the KCLayout object."""
+        with self.thread_lock:
+            self.layout.assign(layout)
+            self.rebuild()
+
     def rebuild(self) -> None:
-        """Rebuild the KCLayout based on the Layoutt object."""
+        """Rebuild the KCLayout based on the Layout object."""
         kcells2delete: list[int] = []
         with self.thread_lock:
             for ci, c in self.tkcells.items():
@@ -1243,6 +1249,12 @@ class KCLayout(
 
             for ci in kcells2delete:
                 del self.tkcells[ci]
+
+            for cell in self._cells("*"):
+                if cell.cell_index() not in self.tkcells:
+                    self.tkcells[cell.cell_index()] = self.get_cell(
+                        cell.cell_index(), KCell
+                    ).base
 
     def register_cell(self, kcell: AnyTKCell, allow_reregister: bool = False) -> None:
         """Register an existing cell in the KCLayout object.

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -246,5 +246,29 @@ def test_clear_kcells(kcl: kf.KCLayout, layers: Layers) -> None:
     assert c.destroyed()
 
 
+def test_kclayout_rebuild(kcl: kf.KCLayout, layers: Layers) -> None:
+    straight = kf.factories.straight.straight_dbu_factory(kcl)(
+        length=1000, width=1000, layer=layers.WG
+    )
+    del kcl.tkcells[straight.cell_index()]
+    assert len(kcl.tkcells) == 0
+    assert len(list(kcl.layout.each_cell())) == 1
+
+    kcl.rebuild()
+    assert len(kcl.kcells) == 1
+    assert len(list(kcl.layout.each_cell())) == 1
+
+
+def test_kclayout_assign(kcl: kf.KCLayout, layers: Layers) -> None:
+    kcl2 = kf.KCLayout(name="kcl2")
+    kcl2.infos = layers
+    kf.factories.straight.straight_dbu_factory(kcl2)(
+        length=1000, width=1000, layer=layers.WG
+    )
+    kcl.assign(kcl2.layout)
+    assert len(kcl2.kcells) == 1
+    assert len(list(kcl2.layout.each_cell())) == 1
+
+
 if __name__ == "__main__":
     pytest.main(["-s", __file__])

--- a/uv.lock
+++ b/uv.lock
@@ -735,7 +735,7 @@ wheels = [
 
 [[package]]
 name = "kfactory"
-version = "1.0.3"
+version = "1.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "aenum" },


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- The `rebuild` method now adds missing KCells from the layout, ensuring that all cells present in the KLayout object are also present in the KCLayout object.