### PR TITLE
fix duplicate cell because of test

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
         exclude: 'changelog\.d/.*|CHANGELOG\.md'
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.9.3
+    rev: v0.9.7
     hooks:
       # Run the linter.
       - id: ruff
@@ -34,20 +34,20 @@ repos:
         files: .ipynb
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.4.0
+    rev: v2.4.1
     hooks:
       - id: codespell
         additional_dependencies:
           - tomli
   - repo: https://github.com/PyCQA/bandit
-    rev: 1.8.2
+    rev: 1.8.3
     hooks:
       - id: bandit
         args: [--exit-zero]
         # ignore all tests, not just tests data
         exclude: ^tests/
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v1.14.1" # Use the sha / tag you want to point at
+    rev: "v1.15.0" # Use the sha / tag you want to point at
     hooks:
       - id: mypy
         require_serial: true

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -274,16 +274,16 @@ def test_get_component(layers: Layers) -> None:
     # normal functions
     kf.kcl.get_component(
         "straight", width=1000, length=10_000, layer=kf.kdb.LayerInfo(1, 0)
-    )
+    ).delete()
     kf.kcl.get_component(
         kf.cells.straight.straight, width=1, length=10, layer=layers.WG
-    )
+    ).delete()
     kf.kcl.get_component(
         kf.cells.straight.straight(width=1, length=10, layer=layers.WG)
-    )
+    ).delete()
     kf.kcl.get_component(
         kf.cells.straight.straight(width=1, length=10, layer=layers.WG).cell_index()
-    )
+    ).delete()
 
     # output_type functions
     kf.kcl.get_component(
@@ -292,29 +292,29 @@ def test_get_component(layers: Layers) -> None:
         length=10_000,
         layer=kf.kdb.LayerInfo(1, 0),
         output_type=kf.DKCell,
-    )
+    ).delete()
     kf.kcl.get_component(
         {
             "component": "straight",
             "settings": dict(width=1000, length=10_000, layer=kf.kdb.LayerInfo(1, 0)),
         },
         output_type=kf.DKCell,
-    )
+    ).delete()
     kf.kcl.get_component(
         kf.cells.straight.straight,
         width=1,
         length=10,
         layer=layers.WG,
         output_type=kf.DKCell,
-    )
+    ).delete()
     kf.kcl.get_component(
         kf.cells.straight.straight(width=1, length=10, layer=layers.WG),
         output_type=kf.DKCell,
-    )
+    ).delete()
     kf.kcl.get_component(
         kf.cells.straight.straight(width=1, length=10, layer=layers.WG).cell_index(),
         output_type=kf.DKCell,
-    )
+    ).delete()
 
     # raises errors
     with pytest.raises(ValueError):

--- a/uv.lock
+++ b/uv.lock
@@ -735,7 +735,7 @@ wheels = [
 
 [[package]]
 name = "kfactory"
-version = "1.1.3"
+version = "1.1.5"
 source = { editable = "." }
 dependencies = [
     { name = "aenum" },
@@ -812,7 +812,7 @@ requires-dist = [
     { name = "kfactory", extras = ["full"], marker = "extra == 'ci'" },
     { name = "kfactory", extras = ["full"], marker = "extra == 'dev'" },
     { name = "kfactory", extras = ["ipy"], marker = "extra == 'docs'" },
-    { name = "klayout", specifier = ">=0.29.7" },
+    { name = "klayout", specifier = ">=0.29.11,<0.30.0" },
     { name = "loguru" },
     { name = "mkdocs", marker = "extra == 'docs'" },
     { name = "mkdocs-gen-files", marker = "extra == 'docs'" },


### PR DESCRIPTION
## Summary by Sourcery

Tests:
- The test `test_get_component` now deletes the components created by `get_component` to avoid duplicate cells.