### PR TITLE
fix library/pdk cells sometimes not getting ports on creation

### DIFF
--- a/src/kfactory/kcell.py
+++ b/src/kfactory/kcell.py
@@ -480,7 +480,7 @@ class ProtoTKCell(ProtoKCell[TUnit, TKCell], Generic[TUnit], ABC):
             vinsts=VInstances(),
         )
         if kdb_cell_.is_library_cell():
-            if name or ports or info or settings:
+            if ports or info or settings:
                 raise ValueError(
                     "If a TKCell is created from a library cell (separate PDK/layout), "
                     "ports, info, and settings must not be set."

--- a/src/kfactory/kcell.py
+++ b/src/kfactory/kcell.py
@@ -458,7 +458,7 @@ class ProtoTKCell(ProtoKCell[TUnit, TKCell], Generic[TUnit], ABC):
         if base is not None:
             self._base = base
             return
-        from .layout import get_default_kcl
+        from .layout import get_default_kcl, kcls
 
         kcl_ = kcl or get_default_kcl()
         if name is None:
@@ -487,6 +487,9 @@ class ProtoTKCell(ProtoKCell[TUnit, TKCell], Generic[TUnit], ABC):
                     f"Cell {kdb_cell_.name} in {kcl_.name}: {ports=}, {info=},"
                     f" {settings=}"
                 )
+            kcls[kdb_cell_.library().name()][
+                kdb_cell_.library_cell_index()
+            ].set_meta_data()
             self.get_meta_data()
         self.kcl.register_cell(self)
 


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fixes an issue where library cells were not properly initialized with their ports when created from a separate PDK/layout, leading to missing port information.