### PR TITLE
fix connectivity checks

### DIFF
--- a/src/kfactory/utilities.py
+++ b/src/kfactory/utilities.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any, Literal
 
 from rich.json import JSON
@@ -10,6 +9,8 @@ from . import kdb
 from .conf import DEFAULT_TRANS, config
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     from .instance import Instance
     from .port import Port, ProtoPort
 
@@ -98,6 +99,8 @@ def check_cell_ports(p1: ProtoPort[Any], p2: ProtoPort[Any]) -> int:
     Returns:
         int: A bitwise representation of the differences between the two ports.
     """
+    from .port import Port
+
     p1_ = Port(base=p1.base)
     p2_ = Port(base=p2.base)
     check_int = 0


### PR DESCRIPTION
- `Port` was imported in a type checking block and hence could not be used to create a new port from
- Initially moved it out of the type checking block but got a circular reference
- Opted for importing it within the function.

## Summary by Sourcery

Bug Fixes:
- Fixes an issue where the `Port` class was not accessible at runtime.