### PR TITLE
pin klayout version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,7 +55,7 @@ repos:
           - pydantic
           - numpy
           - pytest
-          - klayout
+          - klayout==0.29.11
           - types-cachetools
           - loguru
           - pydantic-settings

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
         exclude: 'changelog\.d/.*|CHANGELOG\.md'
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.9.7
+    rev: v0.9.10
     hooks:
       # Run the linter.
       - id: ruff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "cachetools >= 5.2.0",
     "gitpython",
     "loguru",
-    "klayout >= 0.29.11, < 0.30.0",
+    "klayout >= 0.29.11, != 0.29.12, < 0.30.0",
     "pydantic >= 2.0.2, < 3",
     "pydantic-settings >= 2.0.1, < 3",
     "rectangle-packer",


### PR DESCRIPTION
## Summary by Sourcery

Pin klayout version and update ruff version.

Build:
- Pin klayout version to exclude 0.29.12.
- Update ruff version to 0.9.10.