### PR TITLE
add error messages for name conflicts on renaming

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,7 +55,7 @@ repos:
           - pydantic
           - numpy
           - pytest
-          - klayout==0.29.11
+          - klayout
           - types-cachetools
           - loguru
           - pydantic-settings

--- a/src/kfactory/kcell.py
+++ b/src/kfactory/kcell.py
@@ -420,6 +420,77 @@ class TKCell(BaseKCell):
     def name(self, value: str) -> None:
         if self.locked:
             raise LockedError(self)
+        if value != self.kcl.layout.unique_cell_name(value):
+            stack = inspect.stack()
+            module = inspect.getmodule(stack[3].frame)
+            tkcells = [
+                self.kcl.tkcells[cell.cell_index()]
+                for cell in self.kcl.layout.cells(value)
+                if not cell.is_library_cell()
+            ]
+
+            if module is not None and module.__name__ == "kfactory.layout":
+                frame_info = stack[5]
+                logger.error(
+                    "Name conflict in "
+                    f"{frame_info.frame.f_locals['f'].__code__.co_filename}::"
+                    f"{frame_info.frame.f_locals['f'].__name__} at line "
+                    f"{frame_info.frame.f_locals['f'].__code__.co_firstlineno}\n"
+                    f"Renaming {self.name} to {value} would cause it to be"
+                    " named the same as:\n"
+                    + "\n".join(
+                        f" - {tkcell.name} (cell_index={tkcell.kdb_cell.cell_index()}),"
+                        f" function_name={tkcell.function_name},"
+                        f" basename={tkcell.basename}"
+                        for tkcell in tkcells
+                    )
+                )
+            else:
+                frame_info = stack[3]
+                if module is not None:
+                    module_name = module.__name__
+                    if module_name == "__main__":
+                        module_name = frame_info.filename
+                    function_name = (
+                        "::" + frame_info.function
+                        if frame_info.function != "<module>"
+                        else ""
+                    )
+                    logger.error(
+                        "Name conflict in "
+                        f"{module_name}{function_name} at line "
+                        f"{frame_info.lineno}\n"
+                        f"Renaming {self.name} to {value} would cause it to be"
+                        " named the same as:\n"
+                        + "\n".join(
+                            f" - {tkcell.name} "
+                            f"(cell_index={tkcell.kdb_cell.cell_index()}),"
+                            f" function_name={tkcell.function_name},"
+                            f" basename={tkcell.basename}"
+                            for tkcell in tkcells
+                        )
+                    )
+                else:
+                    function_name = (
+                        "::" + frame_info.function
+                        if frame_info.function != "<module>"
+                        else ""
+                    )
+                    logger.error(
+                        "Name conflict in "
+                        f"{frame_info.filename}"
+                        f"{function_name} at line {frame_info.lineno}"
+                        f"Renaming {self.name} to {value} would cause it to be"
+                        " named the same as:\n"
+                        + "\n".join(
+                            f" - {tkcell.name} "
+                            f"(cell_index={tkcell.kdb_cell.cell_index()}),"
+                            f" function_name={tkcell.function_name},"
+                            f" basename={tkcell.basename}"
+                            for tkcell in tkcells
+                        )
+                    )
+
         self.kdb_cell.name = value
 
 

--- a/src/kfactory/kcell.py
+++ b/src/kfactory/kcell.py
@@ -431,7 +431,7 @@ class TKCell(BaseKCell):
 
             if module is not None and module.__name__ == "kfactory.layout":
                 frame_info = stack[5]
-                logger.error(
+                logger.opt(depth=2).error(
                     "Name conflict in "
                     f"{frame_info.frame.f_locals['f'].__code__.co_filename}::"
                     f"{frame_info.frame.f_locals['f'].__name__} at line "
@@ -456,7 +456,7 @@ class TKCell(BaseKCell):
                         if frame_info.function != "<module>"
                         else ""
                     )
-                    logger.error(
+                    logger.opt(depth=3).error(
                         "Name conflict in "
                         f"{module_name}{function_name} at line "
                         f"{frame_info.lineno}\n"
@@ -476,7 +476,7 @@ class TKCell(BaseKCell):
                         if frame_info.function != "<module>"
                         else ""
                     )
-                    logger.error(
+                    logger.opt(depth=3).error(
                         "Name conflict in "
                         f"{frame_info.filename}"
                         f"{function_name} at line {frame_info.lineno}"

--- a/src/kfactory/layout.py
+++ b/src/kfactory/layout.py
@@ -56,7 +56,6 @@ from .kcell import (
 from .layer import LayerEnum, LayerInfos, LayerStack, layerenum_from_dict
 from .merge import MergeDiff
 from .port import rename_clockwise_multi
-from .protocols import KCellFunc
 from .serialization import (
     DecoratorDict,
     DecoratorList,
@@ -72,6 +71,7 @@ if TYPE_CHECKING:
     from cachetools.keys import _HashedTuple  # type: ignore[attr-defined,unused-ignore]
 
     from .ports import DPorts, Ports
+    from .protocols import KCellFunc
 
 kcl: KCLayout
 kcls: dict[str, KCLayout] = {}
@@ -630,7 +630,7 @@ class KCLayout(
             else:
                 output_cell_type_ = self.default_cell_output_type
 
-            output_cell_type = cast(type[K], output_cell_type_)
+            output_cell_type = cast("type[K]", output_cell_type_)
 
             cache_: Cache[_HashedTuple, K] | dict[_HashedTuple, K] = cache or Cache(
                 maxsize=float("inf")
@@ -884,11 +884,10 @@ class KCLayout(
 
         return (
             cast(
-                Callable[[KCellFunc[KCellParams, K]], KCellFunc[KCellParams, K]]
-                | Callable[
-                    [KCellFunc[KCellParams, AnyTKCell]],
-                    KCellFunc[KCellParams, K],
-                ],
+                "Callable[[KCellFunc[KCellParams, K]], "
+                "KCellFunc[KCellParams, K]] | "
+                "Callable[[KCellFunc[KCellParams, AnyTKCell]],"
+                " KCellFunc[KCellParams, K]]",
                 decorator_autocell,
             )
             if _func is None


### PR DESCRIPTION
Example:
`test.py`
```python
import kfactory as kf
import test2

test2.my_test()

c = kf.KCell()
c.name = "test_cell"
```
`test2.py`
```python
import kfactory as kf


@kf.cell(basename="test_cell")
def test_cell1() -> kf.KCell:
    c = kf.kcl.kcell()
    return c


@kf.cell(basename="test_cell")
def test_cell2() -> kf.KCell:
    c = kf.kcl.kcell()
    return c


@kf.cell(basename="test_cell")
def test_cell3() -> kf.KCell:
    c = kf.kcl.kcell()
    return c


def my_test():
    test_cell1()
    test_cell2()
    test_cell3()
    test_cell3()
    c = kf.KCell()
    c.name = "test_cell"
```
Output:
![image](https://github.com/user-attachments/assets/506a96e8-691b-4073-8992-508f4b4c55f7)

## Summary by Sourcery

Adds error messages when renaming a cell to a name that already exists. The error message includes the location of the name conflict and information about the existing cell with the same name.