### PR TITLE
Add Test scheduled workflow

### DIFF
--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -1,5 +1,3 @@
-
-
 name: Scheduled Test
 
 on:

--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -1,0 +1,29 @@
+
+
+name: Scheduled Test
+
+on:
+  schedule:
+    - cron: '0 */12 * * *'
+  workflow_dispatch:
+    inputs:
+      date:
+        description: 'Date to run the workflow'
+        required: true
+        type: string
+        default: 'in 1 hour'
+concurrency:
+  group: schedule${{ github.event.inputs.date }}
+  cancel-in-progress: true
+
+jobs:
+  schedule-test:
+    name: Schedule Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: austenstone/schedule@v1.3
+        with:
+          github-token: ${{ secrets.TOKEN }}
+          date: ${{ github.event.inputs.date }}
+          workflow: 'test_code.yml'
+          timezone: 'GMT'

--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -23,7 +23,4 @@ jobs:
     steps:
       - uses: austenstone/schedule@v1.3
         with:
-          github-token: ${{ secrets.TOKEN }}
-          date: ${{ github.event.inputs.date }}
           workflow: 'test_code.yml'
-          timezone: 'GMT'


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Create a new GitHub Actions workflow that runs tests every 12 hours and allows manual triggering of test runs