### PR TITLE
Add github token to schedule workflow

### DIFF
--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -21,4 +21,5 @@ jobs:
     steps:
       - uses: austenstone/schedule@v1.3
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           workflow: 'test_code.yml'


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Configure the schedule workflow to use the GitHub token for authentication when triggering the test_code.yml workflow