### PR TITLE
add some extensions to griffe and mkdocs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,10 +29,10 @@ docs-clean:
 	rm -rf site
 
 docs:
-	mkdocs build -f docs/mkdocs.yml
+	uv run --extra docs --isolated mkdocs build -f docs/mkdocs.yml
 
 docs-serve:
-	mkdocs serve -f docs/mkdocs.yml
+	uv run --extra docs --isolated mkdocs serve -f docs/mkdocs.yml
 
 test:
 	uv run --extra ci --isolated pytest -s -n logical
@@ -90,4 +90,4 @@ gds-download:
 clean:
 	git clean -xdf
 
-.PHONY: build docs test test-min clean
+.PHONY: build docs docs-serve test test-min clean

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -67,6 +67,11 @@ plugins:
             separate_signature: true
             show_signature_annotations: true
             members_order: alphabetical
+            extensions:
+              - griffe_pydantic
+              - dataclasses
+              - griffe_inherited_docstrings
+              - griffe_warnings_deprecated
   - gen-files:
       scripts:
         - source/gen_ref_pages.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,9 @@ docs = [
     "mkdocs-video>=1.5.0",
     "mkdocstrings[python]>=0.29.0",
     "pymdown-extensions>=10.14.3",
+    "griffe-pydantic>=1.1.4",
+    "griffe-inherited-docstrings>=1.1.1",
+    "griffe-warnings-deprecated>=1.1.0",
 ]
 ci = [
     "pytest >= 8.3.5",


### PR DESCRIPTION
## Summary by Sourcery

Enhance documentation generation by adding Griffe extensions to improve mkdocs documentation processing

Enhancements:
- Modify mkdocs configuration to include additional Griffe extensions for more comprehensive documentation generation

Build:
- Update Makefile to use uv for running mkdocs with isolated environment
- Add documentation-related dependencies in pyproject.toml

Documentation:
- Add Griffe extensions to improve documentation generation, including Pydantic support, inherited docstrings, and deprecated warnings