### PR TITLE
add prune to cache

### DIFF
--- a/src/kfactory/decorators.py
+++ b/src/kfactory/decorators.py
@@ -398,6 +398,15 @@ class WrappedKCellFunc(Generic[KC]):
     def file(self) -> Path:
         return Path(self._f_orig.__code__.co_filename).resolve()
 
+    def prune(self) -> None:
+        cells = list(self.cache.values())
+        caller_cis = {
+            ci for cell in cells for ci in cell.caller_cells() if not cell._destroyed()
+        }
+        caller_cis |= {c.cell_index() for c in cells}
+        for ci in caller_cis:
+            self.kcl[ci].delete()
+
 
 class WrappedVKCellFunc(Generic[VK]):
     _f: Callable[..., VK]

--- a/src/kfactory/layout.py
+++ b/src/kfactory/layout.py
@@ -1137,8 +1137,8 @@ class KCLayout(
                     raise MergeError(err_msg)
 
             cells = set(self.cells("*"))
-            fn = str(Path(filename).expanduser().resolve())
-            lm = self.layout.read(fn, options)
+            binary_layout = layout_b.write_bytes(save_layout_options())
+            lm = self.layout.read_bytes(binary_layout)
             info, settings = self.get_meta_data()
 
             match update_kcl_meta_data:
@@ -1411,6 +1411,10 @@ class KCLayout(
                 "or the cell itself."
             )
         return self.kcells[spec] if isinstance(spec, int) else spec
+
+    def delete(self) -> None:
+        del kcls[self.name]
+        self.library.delete()
 
 
 KCLayout.model_rebuild()

--- a/src/kfactory/session_cache.py
+++ b/src/kfactory/session_cache.py
@@ -168,6 +168,7 @@ def load_kcl(kcl_path: Path) -> None:
 
             tkc_ = kc_._base
             factory.cache[hk] = factory.output_type(base=tkc_)
+    loaded_kcl.delete()
 
 
 @functools.cache

--- a/tests/test_cell.py
+++ b/tests/test_cell.py
@@ -568,4 +568,4 @@ def test_prune(kcl: kf.KCLayout) -> None:
 
     test_cell = test1()
     test2.prune()
-    assert test_cell._destroyed() is True
+    assert test_cell._destroyed()

--- a/tests/test_cell.py
+++ b/tests/test_cell.py
@@ -555,5 +555,17 @@ def test_factory_name(kcl: kf.KCLayout, layers: Layers) -> None:
     assert cell.factory_name == "straight"
 
 
-if __name__ == "__main__":
-    pytest.main([__file__, "-v", "-s"])
+def test_prune(kcl: kf.KCLayout) -> None:
+    @kcl.cell
+    def test2() -> kf.KCell:
+        return kcl.kcell()
+
+    @kcl.cell
+    def test1() -> kf.KCell:
+        c = kcl.kcell()
+        c << test2()
+        return c
+
+    test_cell = test1()
+    test2.prune()
+    assert test_cell._destroyed() is True


### PR DESCRIPTION
## Summary by Sourcery

Add pruning functionality to the cache mechanism in the KFactory library

New Features:
- Implement a prune method for cache management that allows deleting unused cells

Enhancements:
- Modify layout reading to use binary layout for improved performance
- Add delete method to KCell to remove cells from the library