### PR TITLE
Fix cell decorator 

### DIFF
--- a/src/kfactory/decorators.py
+++ b/src/kfactory/decorators.py
@@ -243,9 +243,9 @@ def _post_process(
         pp(cell)
 
 
-class WrappedKCellFunc(Generic[KC]):
-    _f: Callable[..., KC]
-    _f_orig: Callable[..., ProtoTKCell[Any]]
+class WrappedKCellFunc(Generic[KCellParams, KC]):
+    _f: Callable[KCellParams, KC]
+    _f_orig: Callable[KCellParams, ProtoTKCell[Any]]
     cache: Cache[int, KC] | dict[int, Any]
     name: str | None
     kcl: KCLayout
@@ -391,7 +391,7 @@ class WrappedKCellFunc(Generic[KC]):
         elif hasattr(f, "func"):
             self.name = f.func.__name__
 
-    def __call__(self, *args: Any, **kwargs: Any) -> KC:
+    def __call__(self, *args: KCellParams.args, **kwargs: KCellParams.kwargs) -> KC:
         return self._f(*args, **kwargs)
 
     @functools.cached_property

--- a/src/kfactory/layout.py
+++ b/src/kfactory/layout.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import functools
 import inspect
 from collections import UserDict, defaultdict
+from collections.abc import Callable, Iterable, Sequence  # noqa: TC003
 from pathlib import Path
 from threading import RLock
 from typing import TYPE_CHECKING, Any, Literal, cast, overload
@@ -56,12 +57,6 @@ from .typings import KC, KCIN, VK, KC_contra, KCellParams, KCellSpec, MetaData, 
 from .utilities import load_layout_options, save_layout_options
 
 if TYPE_CHECKING:
-    from collections.abc import (
-        Callable,
-        Iterable,
-        Sequence,
-    )
-
     from .ports import DPorts, Ports
 
 kcl: KCLayout


### PR DESCRIPTION
## Summary by Sourcery

Improve type annotations for cell decorator and wrapped cell function to provide more precise type hinting

Bug Fixes:
- Fix generic type parameters to correctly capture cell function parameter and return types

Enhancements:
- Update type annotations for WrappedKCellFunc to support more specific generic type parameters
- Refine type signatures for cell decorator methods to improve type checking accuracy