### PR TITLE
add better error message on none return and support partials

### DIFF
--- a/tests/test_cell.py
+++ b/tests/test_cell.py
@@ -569,3 +569,12 @@ def test_prune(kcl: kf.KCLayout) -> None:
     test_cell = test1()
     test2.prune()
     assert test_cell._destroyed()
+
+
+def test_return_none(kcl: kf.KCLayout) -> None:
+    @kcl.cell
+    def test_no_return() -> kf.KCell:  # type: ignore[return]
+        kcl.kcell()
+
+    with pytest.raises(ValueError):
+        test_no_return()

--- a/tests/test_cell.py
+++ b/tests/test_cell.py
@@ -1,3 +1,4 @@
+import functools
 import tempfile
 import threading
 import warnings
@@ -572,9 +573,10 @@ def test_prune(kcl: kf.KCLayout) -> None:
 
 
 def test_return_none(kcl: kf.KCLayout) -> None:
-    @kcl.cell
     def test_no_return() -> kf.KCell:  # type: ignore[return]
         kcl.kcell()
 
     with pytest.raises(ValueError):
-        test_no_return()
+        kcl.cell()(test_no_return)()
+    with pytest.raises(ValueError):
+        kcl.cell()(functools.partial(test_no_return))()


### PR DESCRIPTION
## Summary by Sourcery

Improve error handling for cell functions that accidentally return None

New Features:
- Add a new utility function `_get_function_name()` to extract function names consistently

Bug Fixes:
- Prevent silent failures when a cell function accidentally returns None

Enhancements:
- Refactor function name extraction into a centralized utility function
- Add a more informative error message when a cell function returns None

Tests:
- Add a new test case to verify the None return error handling