### PR TITLE
Make `@cell` return the `__call__` from the class instead of the entire class

### DIFF
--- a/tests/test_cell.py
+++ b/tests/test_cell.py
@@ -121,7 +121,9 @@ def test_getter(layers: Layers) -> None:
 
 def test_array(straight: kf.KCell) -> None:
     c = kf.KCell()
-    wg_array = c.create_inst(straight, a=(15_000, 0), b=(0, 3_000), na=3, nb=5)
+    wg_array = c.create_inst(
+        straight, a=kf.kdb.Vector(15_000, 0), b=kf.kdb.Vector(0, 3_000), na=3, nb=5
+    )
     for b in range(5):
         for a in range(3):
             wg_array["o1", a, b]
@@ -130,7 +132,9 @@ def test_array(straight: kf.KCell) -> None:
 
 def test_array_indexerror(straight: kf.KCell) -> None:
     c = kf.KCell()
-    wg_array = c.create_inst(straight, a=(15_000, 0), b=(0, 3_000), na=3, nb=5)
+    wg_array = c.create_inst(
+        straight, a=kf.kdb.Vector(15_000, 0), b=kf.kdb.Vector(0, 3_000), na=3, nb=5
+    )
     regex = kf.config.logfilter.regex
     kf.config.logfilter.regex = r"^An error has been caught in function '__getitem__'"
     with pytest.raises(IndexError):
@@ -568,12 +572,12 @@ def test_prune(kcl: kf.KCLayout) -> None:
         return c
 
     test_cell = test1()
-    assert len(test1) == 1
-    assert len(test2) == 1
-    test2.prune()
+    assert len(kcl.factories["test1"]) == 1
+    assert len(kcl.factories["test2"]) == 1
+    kcl.factories["test2"].prune()
     assert test_cell._destroyed()
-    assert len(test1) == 0
-    assert len(test2) == 0
+    assert len(kcl.factories["test1"]) == 0
+    assert len(kcl.factories["test2"]) == 0
 
 
 def test_return_none(kcl: kf.KCLayout) -> None:

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -6,6 +6,9 @@ import kfactory as kf
 def test_session_cache() -> None:
     c = session3.my_cell(a=5)
 
+    f2 = session2.kcl2.factories["my_other_cell"]
+    f1 = session1.kcl1.factories["test"]
+
     assert session1.cell_created
     assert session2.cell_created
     assert session3.cell_created
@@ -16,8 +19,8 @@ def test_session_cache() -> None:
     session2.cell_created = False
     session3.cell_created = False
 
-    session1.test.prune()
-    session2.my_other_cell.prune()
+    f1.prune()
+    f2.prune()
 
     kf.load_session()
 
@@ -27,7 +30,7 @@ def test_session_cache() -> None:
     assert not session2.cell_created
     assert not session3.cell_created
 
-    session2.my_other_cell.prune()
+    f2.prune()
 
     session1.cell_created = False
     session2.cell_created = False
@@ -41,8 +44,8 @@ def test_session_cache() -> None:
 
     kf.save_session(session1.test())
 
-    session1.test.prune()
-    session2.my_other_cell.prune()
+    f1.prune()
+    f2.prune()
 
     session1.cell_created = False
     session2.cell_created = False


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Modify the `@cell` decorator to return the `__call__` method from the class instead of the entire class, improving the decorator's usability.