### PR TITLE
Add ProtoPort.icenter

### DIFF
--- a/src/kfactory/port.py
+++ b/src/kfactory/port.py
@@ -555,6 +555,19 @@ class ProtoPort(Generic[TUnit], ABC):
             self._base.dcplx_trans.disp = kdb.DVector(*pos)
 
     @property
+    def icenter(self) -> tuple[int, int]:
+        """Coordinate of the port in dbu."""
+        vec = self.trans.disp
+        return (vec.x, vec.y)
+
+    @icenter.setter
+    def icenter(self, pos: tuple[int, int]) -> None:
+        if self._base.trans:
+            self._base.trans.disp = kdb.Vector(*pos)
+        elif self._base.dcplx_trans:
+            self._base.dcplx_trans.disp = self.kcl.to_um(kdb.Vector(*pos))
+
+    @property
     def dwidth(self) -> float:
         """Width of the port in um."""
         return self.kcl.to_um(self._base.cross_section.width)

--- a/tests/test_port.py
+++ b/tests/test_port.py
@@ -271,6 +271,7 @@ def test_to_dtype() -> None:
     assert dtype.width == 0.01
     assert dtype.layer == 1
     assert dtype.center == (1, 1)
+    assert dtype.icenter == (1000, 1000)
     assert dtype.angle == 1
     assert dtype.orientation == 90
 
@@ -282,6 +283,7 @@ def test_to_itype() -> None:
     assert itype.width == 10
     assert itype.layer == 1
     assert itype.center == (1000, 1000)
+    assert itype.icenter == (1000, 1000)
     assert itype.angle == 1
 
 
@@ -334,6 +336,9 @@ def test_port_xy_center(port: kf.port.ProtoPort[Any]) -> None:
 
     port.center = (1, 1)
     assert port.center == (1, 1)
+
+    port.icenter = (152, 153)
+    assert port.icenter == (152, 153)
 
     port.ix = 121
     assert port.ix == 121

--- a/uv.lock
+++ b/uv.lock
@@ -932,7 +932,7 @@ requires-dist = [
     { name = "requests", specifier = ">=2.23.3,<3" },
     { name = "ruamel-yaml-string", specifier = ">=0.1.1,<0.2" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.9.2" },
-    { name = "scipy", specifier = ">=1.14,<2" },
+    { name = "scipy", specifier = ">=1.14.1,<2" },
     { name = "tbump", marker = "extra == 'dev'", specifier = ">=6.11.0" },
     { name = "tomli", specifier = ">=2.2.1,<3" },
     { name = "toolz", specifier = ">=1,<2" },


### PR DESCRIPTION
## Summary by Sourcery

Add an integer-based center coordinate property `icenter` to the ProtoPort class to provide direct access to port coordinates in database units (dbu).

New Features:
- Introduce `icenter` property for ProtoPort that allows getting and setting port coordinates in integer database units

Enhancements:
- Extend port coordinate manipulation capabilities by adding integer-based coordinate setter and getter

Tests:
- Update existing tests to verify the new `icenter` property functionality