### PR TITLE
add basic lvs equivalency checks

### DIFF
--- a/src/kfactory/decorators.py
+++ b/src/kfactory/decorators.py
@@ -257,6 +257,7 @@ class WrappedKCellFunc(Generic[KCellParams, KC]):
     name: str
     kcl: KCLayout
     output_type: type[KC]
+    equivalent_ports: list[list[str]] | None = None
 
     @property
     def __name__(self) -> str:
@@ -289,6 +290,7 @@ class WrappedKCellFunc(Generic[KCellParams, KC]):
         info: dict[str, MetaData] | None,
         post_process: Iterable[Callable[[ProtoTKCell[Any]], None]],
         debug_names: bool,
+        equivalent_ports: list[list[str]] | None = None,
     ) -> None:
         self.kcl = kcl
         self.output_type = output_type
@@ -399,6 +401,7 @@ class WrappedKCellFunc(Generic[KCellParams, KC]):
         self._f = wrapper_autocell
         self._f_orig = f
         self.cache = cache
+        self.equivalent_ports = equivalent_ports
         functools.update_wrapper(self, f)
 
     def __call__(self, *args: KCellParams.args, **kwargs: KCellParams.kwargs) -> KC:

--- a/src/kfactory/decorators.py
+++ b/src/kfactory/decorators.py
@@ -257,7 +257,7 @@ class WrappedKCellFunc(Generic[KCellParams, KC]):
     name: str
     kcl: KCLayout
     output_type: type[KC]
-    equivalent_ports: list[list[str]] | None = None
+    lvs_equivalent_ports: list[list[str]] | None = None
 
     @property
     def __name__(self) -> str:
@@ -290,7 +290,7 @@ class WrappedKCellFunc(Generic[KCellParams, KC]):
         info: dict[str, MetaData] | None,
         post_process: Iterable[Callable[[ProtoTKCell[Any]], None]],
         debug_names: bool,
-        equivalent_ports: list[list[str]] | None = None,
+        lvs_equivalent_ports: list[list[str]] | None = None,
     ) -> None:
         self.kcl = kcl
         self.output_type = output_type
@@ -401,7 +401,7 @@ class WrappedKCellFunc(Generic[KCellParams, KC]):
         self._f = wrapper_autocell
         self._f_orig = f
         self.cache = cache
-        self.equivalent_ports = equivalent_ports
+        self.lvs_equivalent_ports = lvs_equivalent_ports
         functools.update_wrapper(self, f)
 
     def __call__(self, *args: KCellParams.args, **kwargs: KCellParams.kwargs) -> KC:

--- a/src/kfactory/kcell.py
+++ b/src/kfactory/kcell.py
@@ -348,6 +348,9 @@ class ProtoKCell(GeometricObject[TUnit], Generic[TUnit, TBaseCell_co], ABC):
             " automatically as a factory. Therefore it doesn't have an associated name."
         )
 
+    def has_factory_name(self) -> bool:
+        return bool(self._base.basename or self._base.function_name)
+
     def create_vinst(self, cell: AnyKCell) -> VInstance:
         """Insert the KCell as a VInstance into a VKCell or KCell."""
         if self.locked:
@@ -390,6 +393,7 @@ class TKCell(BaseKCell):
 
     kdb_cell: kdb.Cell
     boundary: kdb.DPolygon | None = None
+    equivalent_ports: list[list[str]] | None = None
 
     def __getattr__(self, name: str) -> Any:
         """If KCell doesn't have an attribute, look in the KLayout Cell."""
@@ -1763,6 +1767,7 @@ class ProtoTKCell(ProtoKCell[TUnit, TKCell], Generic[TUnit], ABC):
             | tuple[kdb.LayerInfo, kdb.LayerInfo, kdb.LayerInfo],
         ]
         | None = None,
+        port_mapping: dict[str, dict[str | None, str]] | None = None,
     ) -> kdb.LayoutToNetlist:
         """Generate a LayoutToNetlist object from the port types.
 
@@ -1776,13 +1781,21 @@ class ProtoTKCell(ProtoKCell[TUnit, TKCell], Generic[TUnit], ABC):
         connectivity = connectivity or self.kcl.connectivity
         ly_elec = self.kcl.dup().layout
 
+        port_mapping = port_mapping or {}
+
         for ci in [self.cell_index(), *self.called_cells()]:
             c_ = self.kcl[ci]
             c = ly_elec.cell(ci)
             assert c_.name == c.name
             c.locked = False
+            mapping = port_mapping.get(c_.name, {})
             for port in c_.ports:
-                if port.port_type in mark_port_types and port.name is not None:
+                port_name = mapping.get(port.name)
+                if (
+                    port_name == port.name
+                    and port.port_type in mark_port_types
+                    and port.name is not None
+                ):
                     c.shapes(port.layer_info).insert(
                         kdb.Text(string=port.name, trans=port.trans)
                     )
@@ -1829,12 +1842,35 @@ class ProtoTKCell(ProtoKCell[TUnit, TKCell], Generic[TUnit], ABC):
             | tuple[kdb.LayerInfo, kdb.LayerInfo, kdb.LayerInfo]
         ]
         | None = None,
+        *,
+        equivalent_ports: dict[str, list[list[str]]] | None = None,
         ignore_unnamed: bool = False,
         exclude_purposes: list[str] | None = None,
         allow_width_mismatch: bool = False,
     ) -> dict[str, Netlist]:
+        if equivalent_ports is None:
+            equivalent_ports = {}
+            for ci in [self.cell_index(), *self.called_cells()]:
+                c_ = self.kcl[ci]
+                eqps = (
+                    c_.equivalent_ports
+                    or c_.kcl.factories[c_.factory_name].equivalent_ports
+                    if c_.has_factory_name()
+                    else None
+                )
+                if eqps is not None:
+                    equivalent_ports[c_.name] = eqps
+        port_mapping: dict[str, dict[str | None, str]] = defaultdict(dict)
+        for cell_name, list_of_port_lists in equivalent_ports.items():
+            for port_list in list_of_port_lists:
+                if port_list:
+                    p1 = port_list[0]
+                    for port in port_list:
+                        port_mapping[cell_name][port] = p1
         l2n_elec = self.l2n_elec(
-            mark_port_types=mark_port_types, connectivity=connectivity
+            mark_port_types=mark_port_types,
+            connectivity=connectivity,
+            port_mapping=port_mapping,
         )
         l2n_opt = self.l2n_ports(
             port_types=port_types,
@@ -1845,16 +1881,29 @@ class ProtoTKCell(ProtoKCell[TUnit, TKCell], Generic[TUnit], ABC):
 
         netlists: dict[str, Netlist] = {}
 
+        for cell_name, eqps in equivalent_ports.items():
+            for eqp_list in eqps:
+                if eqp_list:
+                    p1 = eqp_list[0]
+                    for p in eqp_list:
+                        port_mapping[cell_name][p] = p1
+
         for ci in [self.cell_index(), *self.called_cells()]:
             c_ = self.kcl[ci]
             name = c_.name
-            netlists[name] = _get_netlist(
+
+            nl = _get_netlist(
                 c=c_,
                 l2n_opt=l2n_opt,
                 l2n_elec=l2n_elec,
                 ignore_unnamed=ignore_unnamed,
                 exclude_purposes=exclude_purposes,
             )
+            if equivalent_ports.get(c_.name):
+                nl = nl.with_equivalent_ports(
+                    equivalent_ports=equivalent_ports, port_mapping=port_mapping
+                )
+            netlists[name] = nl
         return netlists
 
     def circuit(
@@ -2513,6 +2562,10 @@ class ProtoTKCell(ProtoKCell[TUnit, TKCell], Generic[TUnit], ABC):
         | SymmetricalCrossSection,
         **cross_section_kwargs: Any,
     ) -> TCrossSection[TUnit]: ...
+
+    @property
+    def equivalent_ports(self) -> list[list[str]] | None:
+        return self._base.equivalent_ports
 
 
 class DKCell(ProtoTKCell[float], UMGeometricObject, DCreatePort):
@@ -3896,7 +3949,7 @@ def _get_netlist(
 ) -> Netlist:
     opt_circ = l2n_opt.netlist().circuit_by_name(c.name)
     elec_circ = l2n_elec.netlist().circuit_by_name(c.name)
-    nl = Netlist(nets=[])
+    nl = Netlist(nets=[], name=c.name)
     exclude_purposes = exclude_purposes or []
     keep_name = not ignore_unnamed
 
@@ -4006,6 +4059,6 @@ def _get_netlist(
                             )
                         break
             if len(net_refs) > 1:
-                nl.nets.append(Net(net_refs))
+                nl.create_net(*net_refs)
     nl.sort()
     return nl

--- a/src/kfactory/layout.py
+++ b/src/kfactory/layout.py
@@ -762,6 +762,7 @@ class KCLayout(
         info: dict[str, MetaData] | None = ...,
         debug_names: bool | None = ...,
         tags: list[str] | None = ...,
+        equivalent_ports: list[list[str]] | None = None,
     ) -> Callable[[Callable[KCellParams, KC]], Callable[KCellParams, KC]]: ...
 
     @overload
@@ -785,6 +786,7 @@ class KCLayout(
         post_process: Iterable[Callable[[KC_contra], None]],
         debug_names: bool | None = ...,
         tags: list[str] | None = ...,
+        equivalent_ports: list[list[str]] | None = None,
     ) -> Callable[[Callable[KCellParams, KC]], Callable[KCellParams, KC]]: ...
 
     @overload
@@ -809,6 +811,7 @@ class KCLayout(
         post_process: Iterable[Callable[[KC_contra], None]],
         debug_names: bool | None = ...,
         tags: list[str] | None = ...,
+        equivalent_ports: list[list[str]] | None = None,
     ) -> Callable[
         [Callable[KCellParams, ProtoTKCell[Any]]], Callable[KCellParams, KC]
     ]: ...
@@ -834,6 +837,7 @@ class KCLayout(
         info: dict[str, MetaData] | None = ...,
         debug_names: bool | None = ...,
         tags: list[str] | None = ...,
+        equivalent_ports: list[list[str]] | None = None,
     ) -> Callable[
         [Callable[KCellParams, ProtoTKCell[Any]]], Callable[KCellParams, KC]
     ]: ...
@@ -860,6 +864,7 @@ class KCLayout(
         post_process: Iterable[Callable[[KC_contra], None]] | None = None,
         debug_names: bool | None = None,
         tags: list[str] | None = None,
+        equivalent_ports: list[list[str]] | None = None,
     ) -> (
         Callable[KCellParams, KC]
         | Callable[
@@ -964,6 +969,7 @@ class KCLayout(
                 info=info,
                 post_process=post_process,  # type: ignore[arg-type]
                 debug_names=debug_names,
+                equivalent_ports=equivalent_ports,
             )
 
             if register_factory:

--- a/src/kfactory/layout.py
+++ b/src/kfactory/layout.py
@@ -762,7 +762,7 @@ class KCLayout(
         info: dict[str, MetaData] | None = ...,
         debug_names: bool | None = ...,
         tags: list[str] | None = ...,
-        equivalent_ports: list[list[str]] | None = None,
+        lvs_equivalent_ports: list[list[str]] | None = None,
     ) -> Callable[[Callable[KCellParams, KC]], Callable[KCellParams, KC]]: ...
 
     @overload
@@ -786,7 +786,7 @@ class KCLayout(
         post_process: Iterable[Callable[[KC_contra], None]],
         debug_names: bool | None = ...,
         tags: list[str] | None = ...,
-        equivalent_ports: list[list[str]] | None = None,
+        lvs_equivalent_ports: list[list[str]] | None = None,
     ) -> Callable[[Callable[KCellParams, KC]], Callable[KCellParams, KC]]: ...
 
     @overload
@@ -811,7 +811,7 @@ class KCLayout(
         post_process: Iterable[Callable[[KC_contra], None]],
         debug_names: bool | None = ...,
         tags: list[str] | None = ...,
-        equivalent_ports: list[list[str]] | None = None,
+        lvs_equivalent_ports: list[list[str]] | None = None,
     ) -> Callable[
         [Callable[KCellParams, ProtoTKCell[Any]]], Callable[KCellParams, KC]
     ]: ...
@@ -837,7 +837,7 @@ class KCLayout(
         info: dict[str, MetaData] | None = ...,
         debug_names: bool | None = ...,
         tags: list[str] | None = ...,
-        equivalent_ports: list[list[str]] | None = None,
+        lvs_equivalent_ports: list[list[str]] | None = None,
     ) -> Callable[
         [Callable[KCellParams, ProtoTKCell[Any]]], Callable[KCellParams, KC]
     ]: ...
@@ -864,7 +864,7 @@ class KCLayout(
         post_process: Iterable[Callable[[KC_contra], None]] | None = None,
         debug_names: bool | None = None,
         tags: list[str] | None = None,
-        equivalent_ports: list[list[str]] | None = None,
+        lvs_equivalent_ports: list[list[str]] | None = None,
     ) -> (
         Callable[KCellParams, KC]
         | Callable[
@@ -969,7 +969,7 @@ class KCLayout(
                 info=info,
                 post_process=post_process,  # type: ignore[arg-type]
                 debug_names=debug_names,
-                equivalent_ports=equivalent_ports,
+                lvs_equivalent_ports=lvs_equivalent_ports,
             )
 
             if register_factory:

--- a/src/kfactory/schema.py
+++ b/src/kfactory/schema.py
@@ -414,7 +414,6 @@ class TSchema(BaseModel, Generic[TUnit], extra="forbid"):
             )
 
         nl = Netlist(
-            name=self.name,
             instances={
                 inst.name: NetlistInstance(
                     name=inst.name,

--- a/src/kfactory/schema.py
+++ b/src/kfactory/schema.py
@@ -417,6 +417,7 @@ class TSchema(BaseModel, Generic[TUnit], extra="forbid"):
             name=self.name,
             instances={
                 inst.name: NetlistInstance(
+                    name=inst.name,
                     kcl=inst.kcl.name,
                     component=inst.component,
                     settings=inst.settings,

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -369,3 +369,167 @@ def test_netlist() -> None:
         ignore_unnamed=True, connectivity=[(layers.METAL1, layers.VIA1, layers.METAL2)]
     )
     assert nl == nl2[c.name]
+
+
+def test_netlist_equivalent() -> None:
+    class Layers(kf.LayerInfos):
+        WG: kf.kdb.LayerInfo = kf.kdb.LayerInfo(1, 0)
+        WGCLAD: kf.kdb.LayerInfo = kf.kdb.LayerInfo(111, 0)
+        WGEXCLUDE: kf.kdb.LayerInfo = kf.kdb.LayerInfo(1, 1)
+        WGCLADEXCLUDE: kf.kdb.LayerInfo = kf.kdb.LayerInfo(111, 1)
+        FILL1: kf.kdb.LayerInfo = kf.kdb.LayerInfo(2, 0)
+        FILL2: kf.kdb.LayerInfo = kf.kdb.LayerInfo(3, 0)
+        FILL3: kf.kdb.LayerInfo = kf.kdb.LayerInfo(10, 0)
+        METAL1: kf.kdb.LayerInfo = kf.kdb.LayerInfo(2, 0)
+        METAL1EX: kf.kdb.LayerInfo = kf.kdb.LayerInfo(2, 1)
+        VIA1: kf.kdb.LayerInfo = kf.kdb.LayerInfo(3, 0)
+        METAL2: kf.kdb.LayerInfo = kf.kdb.LayerInfo(4, 0)
+        METAL2EX: kf.kdb.LayerInfo = kf.kdb.LayerInfo(4, 1)
+
+    layers = Layers()
+    pdk = kf.KCLayout(
+        "SCHEMA_PDK_NETLIST",
+        infos=Layers,
+        connectivity=[(layers.METAL1, layers.VIA1, layers.METAL2)],
+    )
+
+    @pdk.cell
+    def straight(width: int, length: int) -> kf.KCell:
+        c = pdk.kcell()
+        c.shapes(layers.WG).insert(kf.kdb.Box(0, -width // 2, length, width // 2))
+        c.create_port(
+            name="o1",
+            width=width,
+            trans=kf.kdb.Trans(rot=2, mirrx=False, x=0, y=0),
+            layer_info=layers.WG,
+        )
+        c.create_port(
+            name="o2",
+            width=width,
+            trans=kf.kdb.Trans(x=length, y=0),
+            layer_info=layers.WG,
+        )
+
+        return c
+
+    @pdk.cell(equivalent_ports=[["e1", "e2", "e3", "e4"]])
+    def pad_m1() -> kf.KCell:
+        c = pdk.kcell()
+        c.shapes(layers.METAL1).insert(kf.kdb.Box(100_000))
+        c.create_port(
+            name="e1",
+            trans=kf.kdb.Trans(2, False, -50_000, 0),
+            width=50_000,
+            layer_info=layers.METAL1,
+            port_type="electrical",
+        )
+        c.create_port(
+            name="e2",
+            trans=kf.kdb.Trans(1, False, 0, 50_000),
+            width=50_000,
+            layer_info=layers.METAL1,
+            port_type="electrical",
+        )
+        c.create_port(
+            name="e3",
+            trans=kf.kdb.Trans(50_000, 0),
+            width=50_000,
+            layer_info=layers.METAL1,
+            port_type="electrical",
+        )
+        c.create_port(
+            name="e4",
+            trans=kf.kdb.Trans(3, False, 0, -50_000),
+            width=50_000,
+            layer_info=layers.METAL1,
+            port_type="electrical",
+        )
+        return c
+
+    bend90_function = kf.factories.euler.bend_euler_factory(kcl=pdk)
+    bend90 = bend90_function(width=0.500, radius=10, layer=layers.WG)
+
+    @pdk.routing_strategy
+    def route_bundle(
+        c: kf.ProtoTKCell[Any],
+        start_ports: Sequence[kf.ProtoPort[Any]],
+        end_ports: Sequence[kf.ProtoPort[Any]],
+        separation: int = 5000,
+    ) -> list[kf.routing.generic.ManhattanRoute]:
+        return kf.routing.optical.route_bundle(
+            c=kf.KCell(base=c._base),
+            start_ports=[kf.Port(base=sp.base) for sp in start_ports],
+            end_ports=[kf.Port(base=ep.base) for ep in end_ports],
+            separation=separation,
+            straight_factory=straight,
+            bend90_cell=bend90,
+        )
+
+    @pdk.routing_strategy
+    def route_bundle_elec(
+        c: kf.ProtoTKCell[Any],
+        start_ports: Sequence[kf.ProtoPort[Any]],
+        end_ports: Sequence[kf.ProtoPort[Any]],
+        separation: int = 5000,
+        start_straight: int = 0,
+        end_straight: int = 0,
+    ) -> list[kf.routing.generic.ManhattanRoute]:
+        return kf.routing.electrical.route_bundle(
+            c=kf.KCell(base=c._base),
+            start_ports=[kf.Port(base=sp.base) for sp in start_ports],
+            end_ports=[kf.Port(base=ep.base) for ep in end_ports],
+            separation=separation,
+            starts=start_straight,
+            ends=end_straight,
+        )
+
+    schema = kf.Schema(kcl=pdk)
+
+    padm1_1 = schema.create_inst(name="padm1_1", component="pad_m1")
+    padm1_2 = schema.create_inst(name="padm1_2", component="pad_m1")
+    padm1_3 = schema.create_inst(name="padm1_3", component="pad_m1")
+    padm1_4 = schema.create_inst(name="padm1_4", component="pad_m1")
+
+    padm1_1.place(x=-100_000, y=0)
+    padm1_2.place(x=100_000, y=0)
+    padm1_3.place(x=-100_000, y=-100_000)
+    padm1_4.place(
+        x=100_000,
+        y=-100_000,
+    )
+
+    schema.add_route(
+        "pm1_1-pm1_2",
+        [padm1_1["e1"]],
+        [padm1_2["e1"]],
+        "route_bundle_elec",
+        separation=20_000,
+    )
+    schema.add_route(
+        "pm1_2-pm1_3",
+        [padm1_2["e1"]],
+        [padm1_3["e1"]],
+        "route_bundle_elec",
+        separation=20_000,
+    )
+    schema.add_route(
+        "pm1_3-pm1_4",
+        [padm1_3["e1"]],
+        [padm1_4["e1"]],
+        "route_bundle_elec",
+        separation=20_000,
+    )
+    schema.add_route(
+        "pm1_4-pm1_1",
+        [padm1_4["e1"]],
+        [padm1_1["e1"]],
+        "route_bundle_elec",
+        separation=20_000,
+    )
+
+    nl = schema.netlist()
+    c = schema.create_cell(kf.KCell)
+    nl2 = c.netlist(
+        ignore_unnamed=True, connectivity=[(layers.METAL1, layers.VIA1, layers.METAL2)]
+    )
+    assert nl == nl2[c.name]


### PR DESCRIPTION
## Summary

Adds basic lvs equivalency options to netlists.

## Test Plan

tests/test_schema.py::test_netlist and tests/test_schema.py::test_netlist_equivalent
