### PR TITLE
fix #705 - better error message on cell name serialization problem of dictionary

### DIFF
--- a/src/kfactory/serialization.py
+++ b/src/kfactory/serialization.py
@@ -13,6 +13,7 @@ import numpy as np
 import toolz  # type: ignore[import-untyped,unused-ignore]
 
 from .conf import config
+from .exceptions import CellNameError
 from .typings import JSONSerializable, MetaData, SerializableShape
 
 if TYPE_CHECKING:
@@ -81,7 +82,14 @@ def clean_value(
     if isinstance(value, list | tuple):
         return "_".join(clean_value(v) for v in value)
     if isinstance(value, dict):
-        return dict2name(**value)
+        try:
+            return dict2name(**value)
+        except TypeError as e:
+            raise CellNameError(
+                "Dictionaries passed to functions as args/kwargs"
+                " must be of type dict[str, ...] to be properly serialized"
+                " for Cell/Component names or similar."
+            ) from e
     if hasattr(value, "name"):
         return clean_name(value.name)  # type: ignore[arg-type]
     if callable(value):

--- a/tests/test_cell.py
+++ b/tests/test_cell.py
@@ -5,6 +5,7 @@ import warnings
 from collections.abc import Callable
 from pathlib import Path
 from tempfile import NamedTemporaryFile
+from typing import Any
 
 import pytest
 
@@ -37,6 +38,16 @@ def test_unnamed_cell(kcl: kf.KCLayout) -> None:
     c1 = unnamed_cell("test_unnamed_cell")
     c2 = unnamed_cell("test_unnamed_cell")
     assert c1 is c2
+
+
+def test_wrong_dict(kcl: kf.KCLayout) -> None:
+    with pytest.raises(kf.exceptions.CellNameError):
+
+        @kf.cell
+        def wrong_dict_cell(a: dict[Any, Any]) -> kf.KCell:
+            return kcl.kcell()
+
+        wrong_dict_cell({(1, 0): 555, (2, 0): 10})
 
 
 def test_nested_dict_list(kcl: kf.KCLayout) -> None:


### PR DESCRIPTION
## Summary

Better 

## Test Plan

`tests/test_cell.py::test_wrong_dict`
