### PR TITLE
Ability to get a slice of ports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ dev = [
     "types-pygments>=2.19.0.20250305",
     "types-requests>=2.32.0.20250328",
     "types-setuptools>=76.0.0.20250328",
+    "scipy-stubs",
 ]
 docs = [
     "kfactory[ipy]",

--- a/src/kfactory/ports.py
+++ b/src/kfactory/ports.py
@@ -696,11 +696,10 @@ class Ports(ProtoPorts[int], ICreatePort):
         """Get ports by slice."""
 
     def __getitem__(self, key: slice | int | str | None) -> Self | Port:
-        if isinstance(key, slice):
-            return self.__class__(bases=self._bases[key], kcl=self.kcl)
-
         if isinstance(key, int):
             return Port(base=self._bases[key])
+        if isinstance(key, slice):
+            return self.__class__(bases=self._bases[key], kcl=self.kcl)
         try:
             return Port(base=next(filter(lambda base: base.name == key, self._bases)))
         except StopIteration as e:

--- a/src/kfactory/ports.py
+++ b/src/kfactory/ports.py
@@ -178,9 +178,16 @@ class ProtoPorts(Protocol[TUnit]):
             name = p.name or ""
             self.add_port(port=p, name=prefix + name + suffix, keep_mirror=keep_mirror)
 
+    @overload
     @abstractmethod
     def __getitem__(self, key: int | str | None) -> ProtoPort[TUnit]:
         """Get a port by index or name."""
+        ...
+
+    @overload
+    @abstractmethod
+    def __getitem__(self, key: slice) -> Self:
+        """Get ports by slice."""
         ...
 
     @abstractmethod
@@ -680,8 +687,18 @@ class Ports(ProtoPorts[int], ICreatePort):
         """Get all ports in a dictionary with names as keys."""
         return {v.name: Port(base=v) for v in self._bases if v.name is not None}
 
+    @overload
     def __getitem__(self, key: int | str | None) -> Port:
-        """Get a specific port by name."""
+        """Get a port by index or name."""
+
+    @overload
+    def __getitem__(self, key: slice) -> Self:
+        """Get ports by slice."""
+
+    def __getitem__(self, key: slice | int | str | None) -> Self | Port:
+        if isinstance(key, slice):
+            return self.__class__(bases=self._bases[key], kcl=self.kcl)
+
         if isinstance(key, int):
             return Port(base=self._bases[key])
         try:
@@ -792,8 +809,18 @@ class DPorts(ProtoPorts[float], DCreatePort):
         """Get all ports in a dictionary with names as keys."""
         return {v.name: DPort(base=v) for v in self._bases if v.name is not None}
 
+    @overload
     def __getitem__(self, key: int | str | None) -> DPort:
-        """Get a specific port by name."""
+        """Get a port by index or name."""
+
+    @overload
+    def __getitem__(self, key: slice) -> Self:
+        """Get ports by slice."""
+
+    def __getitem__(self, key: slice | int | str | None) -> Self | DPort:
+        if isinstance(key, slice):
+            return self.__class__(bases=self._bases[key], kcl=self.kcl)
+
         if isinstance(key, int):
             return DPort(base=self._bases[key])
         try:

--- a/src/kfactory/ports.py
+++ b/src/kfactory/ports.py
@@ -818,11 +818,10 @@ class DPorts(ProtoPorts[float], DCreatePort):
         """Get ports by slice."""
 
     def __getitem__(self, key: slice | int | str | None) -> Self | DPort:
-        if isinstance(key, slice):
-            return self.__class__(bases=self._bases[key], kcl=self.kcl)
-
         if isinstance(key, int):
             return DPort(base=self._bases[key])
+        if isinstance(key, slice):
+            return self.__class__(bases=self._bases[key], kcl=self.kcl)
         try:
             return DPort(base=next(filter(lambda base: base.name == key, self._bases)))
         except StopIteration as e:

--- a/tests/test_ports.py
+++ b/tests/test_ports.py
@@ -367,6 +367,15 @@ def test_ports_getitem(kcl: kf.KCLayout, layers: Layers) -> None:
         ports["o3"]
 
 
+def test_ports_getitem_slice(kcl: kf.KCLayout, layers: Layers) -> None:
+    c = kf.factories.straight.straight_dbu_factory(kcl)(
+        width=5000, length=10000, layer=layers.WG
+    )
+    ports = c.ports
+    assert ports == ports[:]
+    assert ports == ports[0 : len(ports)]
+
+
 def test_dports_add_port(kcl: kf.KCLayout, layers: Layers) -> None:
     c = kf.factories.straight.straight_dbu_factory(kcl)(
         width=5000, length=10000, layer=layers.WG
@@ -446,6 +455,15 @@ def test_dports_getitem(kcl: kf.KCLayout, layers: Layers) -> None:
     assert ports[0] == ports["o1"]
     with pytest.raises(KeyError):
         ports["o3"]
+
+
+def test_dports_getitem_slice(kcl: kf.KCLayout, layers: Layers) -> None:
+    c = kf.factories.straight.straight_dbu_factory(kcl)(
+        width=5000, length=10000, layer=layers.WG
+    ).to_dtype()
+    ports = c.ports
+    assert ports == ports[:]
+    assert ports == ports[0 : len(ports)]
 
 
 def test_dports_copy(kcl: kf.KCLayout, layers: Layers) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -822,7 +822,7 @@ wheels = [
 
 [[package]]
 name = "kfactory"
-version = "1.8.2"
+version = "1.10.1"
 source = { editable = "." }
 dependencies = [
     { name = "aenum" },
@@ -862,6 +862,7 @@ dev = [
     { name = "pytest-xdist" },
     { name = "python-lsp-server", extra = ["all"] },
     { name = "ruff" },
+    { name = "scipy-stubs" },
     { name = "tbump" },
     { name = "ty" },
     { name = "types-cachetools" },
@@ -939,6 +940,7 @@ requires-dist = [
     { name = "ruamel-yaml-string", specifier = ">=0.1.1,<0.2" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.9.2" },
     { name = "scipy", specifier = ">=1.14.1,<2" },
+    { name = "scipy-stubs", marker = "extra == 'dev'" },
     { name = "tbump", marker = "extra == 'dev'", specifier = ">=6.11.0" },
     { name = "tomli", specifier = ">=2.2.1,<3" },
     { name = "toolz", specifier = ">=1,<2" },
@@ -1551,6 +1553,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/a3/1e536797fd10eb3c5dbd2e376671667c9af19e241843548575267242ea02/numpy-2.3.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:33a5a12a45bb82d9997e2c0b12adae97507ad7c347546190a18ff14c28bbca12", size = 14398078, upload-time = "2025-06-07T14:52:00.122Z" },
     { url = "https://files.pythonhosted.org/packages/7c/61/9d574b10d9368ecb1a0c923952aa593510a20df4940aa615b3a71337c8db/numpy-2.3.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:54dfc8681c1906d239e95ab1508d0a533c4a9505e52ee2d71a5472b04437ef97", size = 16751324, upload-time = "2025-06-07T14:52:25.077Z" },
     { url = "https://files.pythonhosted.org/packages/39/de/bcad52ce972dc26232629ca3a99721fd4b22c1d2bda84d5db6541913ef9c/numpy-2.3.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:e017a8a251ff4d18d71f139e28bdc7c31edba7a507f72b1414ed902cbe48c74d", size = 12924237, upload-time = "2025-06-07T14:52:44.713Z" },
+]
+
+[[package]]
+name = "optype"
+version = "0.13.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4b/b5/c295280c848a622e402d1f4c329d0f4d8055e281a140d3ca52aa8eda462d/optype-0.13.1.tar.gz", hash = "sha256:9b1d590597b0c093faf5253e38238c5a5e1a1f9afb04530836c38ac94fdd5cf6", size = 99030, upload-time = "2025-07-30T12:52:49.941Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/0f/35fd26222a48cb4601c62616f992586b39fdcb963bd362bbeec435f81355/optype-0.13.1-py3-none-any.whl", hash = "sha256:811c6b4c3d40e10b6602e33a546b30b5e595e9ec7c59e050b5e328332ed2659c", size = 87632, upload-time = "2025-07-30T12:52:48.334Z" },
 ]
 
 [[package]]
@@ -2448,6 +2462,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/8e/038ccfe29d272b30086b25a4960f757f97122cb2ec42e62b460d02fe98e9/scipy-1.15.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:40e54d5c7e7ebf1aa596c374c49fa3135f04648a0caabcb66c52884b943f02b4", size = 36393132, upload-time = "2025-05-08T16:08:15.34Z" },
     { url = "https://files.pythonhosted.org/packages/10/7e/5c12285452970be5bdbe8352c619250b97ebf7917d7a9a9e96b8a8140f17/scipy-1.15.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:5e721fed53187e71d0ccf382b6bf977644c533e506c4d33c3fb24de89f5c3ed5", size = 38979503, upload-time = "2025-05-08T16:08:21.513Z" },
     { url = "https://files.pythonhosted.org/packages/81/06/0a5e5349474e1cbc5757975b21bd4fad0e72ebf138c5592f191646154e06/scipy-1.15.3-cp313-cp313t-win_amd64.whl", hash = "sha256:76ad1fb5f8752eabf0fa02e4cc0336b4e8f021e2d5f061ed37d6d264db35e3ca", size = 40308097, upload-time = "2025-05-08T16:08:27.627Z" },
+]
+
+[[package]]
+name = "scipy-stubs"
+version = "1.16.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "optype" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4b/19/a8461383f7328300e83c34f58bf38ccc05f57c2289c0e54e2bea757de83c/scipy_stubs-1.16.0.2.tar.gz", hash = "sha256:f83aacaf2e899d044de6483e6112bf7a1942d683304077bc9e78cf6f21353acd", size = 306747, upload-time = "2025-07-01T23:19:04.513Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/30/b73418e6d3d8209fef684841d9a0e5b439d3528fa341a23b632fe47918dd/scipy_stubs-1.16.0.2-py3-none-any.whl", hash = "sha256:dc364d24a3accd1663e7576480bdb720533f94de8a05590354ff6d4a83d765c7", size = 491346, upload-time = "2025-07-01T23:19:03.222Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

I want the ability to easily get a slice of ports.
It's useful for example if I want every other port in a `gf.c.array` by using something like `[1::2]` for routing.

## Test Plan

Added tests for `Ports` and `DPorts`