### PR TITLE
add capabilities to automatically apply klayout technologies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
         exclude: 'changelog\.d/.*|CHANGELOG\.md'
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.12.0
+    rev: v0.12.7
     hooks:
       # Run the linter.
       - id: ruff
@@ -40,14 +40,14 @@ repos:
         additional_dependencies:
           - tomli
   - repo: https://github.com/PyCQA/bandit
-    rev: 1.8.5
+    rev: 1.8.6
     hooks:
       - id: bandit
         args: [--exit-zero]
         # ignore all tests, not just tests data
         exclude: ^tests/
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v1.16.1" # Use the sha / tag you want to point at
+    rev: "v1.17.1" # Use the sha / tag you want to point at
     hooks:
       - id: mypy
         args: [--ignore-missing-imports, --strict, --config-file=pyproject.toml]

--- a/src/kfactory/kcell.py
+++ b/src/kfactory/kcell.py
@@ -3676,10 +3676,12 @@ def show(
     layout: KCLayout | AnyKCell | Path | str,
     lyrdb: rdb.ReportDatabase | Path | str | None = None,
     l2n: kdb.LayoutToNetlist | Path | str | None = None,
+    technology: str | None = None,
     keep_position: bool = True,
     save_options: kdb.SaveLayoutOptions | None = None,
     use_libraries: bool = True,
     library_save_options: kdb.SaveLayoutOptions | None = None,
+    set_technology: bool = True,
 ) -> None:
     """Show GDS in klayout.
 
@@ -3776,6 +3778,8 @@ def show(
                     p = (dir_ / _kcl.name).with_suffix(".oas").resolve()
                 _kcl.write(p, library_save_options)
                 kcl_paths.append({"name": _kcl.name, "file": str(p)})
+        if technology is None and layout.technology_file is not None:
+            technology = layout.technology.name
 
     elif isinstance(layout, ProtoKCell):
         file = None
@@ -3820,6 +3824,8 @@ def show(
                 p = (dir_ / _kcl.name).with_suffix(".oas").resolve()
                 _kcl.write(p, library_save_options)
                 kcl_paths.append({"name": _kcl.name, "file": str(p)})
+        if technology is None and layout.kcl.technology_file is not None:
+            technology = layout.kcl.technology.name
 
     elif isinstance(layout, str | Path):
         file = Path(layout).expanduser().resolve()
@@ -3928,6 +3934,9 @@ def show(
             raise ValueError(f"{lyrdbfile} is not a File")
         data_dict["l2n"] = str(l2nfile)
 
+    if set_technology and technology is not None:
+        data_dict["technology"] = technology
+
     data = json.dumps(data_dict)
     try:
         conn = socket.create_connection(("127.0.0.1", 8082), timeout=0.5)
@@ -3945,17 +3954,39 @@ def show(
                 jmsg = json.loads(msg)
                 match jmsg["type"]:
                     case "open":
-                        logger.info(
-                            "klive v{version}: Opened file '{file}'",
-                            version=jmsg["version"],
-                            file=jmsg["file"],
-                        )
+                        info = jmsg.get("info")
+                        if info:
+                            (
+                                logger.info(
+                                    "klive v{version}: Opened file '{file}'"
+                                    ", Messages: {info}",
+                                    version=jmsg["version"],
+                                    file=jmsg["file"],
+                                    info=info,
+                                ),
+                            )
+                        else:
+                            logger.info(
+                                "klive v{version}: Opened file '{file}'",
+                                version=jmsg["version"],
+                                file=jmsg["file"],
+                            )
                     case "reload":
-                        logger.info(
-                            "klive v{version}: Reloaded file '{file}'",
-                            version=jmsg["version"],
-                            file=jmsg["file"],
-                        )
+                        info = jmsg.get("info")
+                        if info:
+                            logger.info(
+                                "klive v{version}: Reloaded file '{file}'"
+                                ", Messages: {info}",
+                                version=jmsg["version"],
+                                file=jmsg["file"],
+                                info=info,
+                            )
+                        else:
+                            logger.info(
+                                "klive v{version}: Reloaded file '{file}'",
+                                version=jmsg["version"],
+                                file=jmsg["file"],
+                            )
                 # check klive version
                 klive_version = [int(s) for s in jmsg["version"].split(".")]
                 rec_klive_version = (0, 3, 3)


### PR DESCRIPTION
## Summary

Adds `show(technology=technology_name` to `show`

Also if the KCLayout defines `technology_file` (str or path), kfactory will load that technology and use it to plot or show in klive (if available in the proper klayout app)


example:

```python
from pathlib import Path

import kfactory as kf

kf.kcl.read("./reference.oas")
kf.kcl.technology_file = Path.home() / ".klayout/salt/gdsfactory/tech.lyt"

kc = kf.kcl[0]

png_data = kf.utilities.as_png_data(kc)

with Path("./test.png").open("wb") as f:
    f.write(png_data)
```

<img width="800" height="600" alt="image" src="https://github.com/user-attachments/assets/e43a45a9-406c-4f86-ae23-490e8d3a3f9e" />


