### PR TITLE
fix missing technology attribute in show function

### DIFF
--- a/tests/custom/show.py
+++ b/tests/custom/show.py
@@ -17,6 +17,7 @@ def show(
     save_options: kfactory.kdb.SaveLayoutOptions | None = None,
     use_libraries: bool = True,
     library_save_options: kfactory.kdb.SaveLayoutOptions | None = None,
+    technology: str | None = None,
 ) -> None:
     import kfactory as kf
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -17,6 +17,7 @@ def test_custom_show() -> None:
         save_options: kf.kdb.SaveLayoutOptions = _layout_options,
         use_libraries: bool = True,
         library_save_options: kf.kdb.SaveLayoutOptions = _layout_options,
+        technology: str | None = None,
     ) -> None:
         nonlocal showed
         showed = True


### PR DESCRIPTION
## Summary

Adds missing `technology` kwarg in show function of ProtoTKCell.
