### PR TITLE
remove find_layer from standard kfactory cells and utils

### DIFF
--- a/src/kfactory/factories/bezier.py
+++ b/src/kfactory/factories/bezier.py
@@ -144,13 +144,13 @@ def bend_s_bezier_factory(
         c.create_port(
             width=int(width / c.kcl.dbu),
             trans=kdb.Trans(2, False, 0, 0),
-            layer=c.kcl.find_layer(layer),
+            layer=c.kcl.layer(layer),
             port_type="optical",
         )
         c.create_port(
             width=int(width / c.kcl.dbu),
             trans=kdb.Trans(0, False, c.bbox().right, kcl.to_dbu(height)),
-            layer=c.kcl.find_layer(layer),
+            layer=c.kcl.layer(layer),
             port_type="optical",
         )
         _info: dict[str, MetaData] = {}

--- a/src/kfactory/factories/circular.py
+++ b/src/kfactory/factories/circular.py
@@ -151,12 +151,12 @@ def bend_circular_factory(
         c.create_port(
             trans=kdb.Trans(2, False, 0, 0),
             width=int(width / c.kcl.dbu),
-            layer=c.kcl.find_layer(layer),
+            layer=c.kcl.layer(layer),
         )
         c.create_port(
             dcplx_trans=kdb.DCplxTrans(1, angle, False, backbone[-1].to_v()),
             width=c.kcl.to_dbu(width),
-            layer=c.kcl.find_layer(layer),
+            layer=c.kcl.layer(layer),
         )
         c.auto_rename_ports()
         c.boundary = center_path

--- a/src/kfactory/factories/euler.py
+++ b/src/kfactory/factories/euler.py
@@ -300,7 +300,7 @@ def bend_euler_factory(
             start_angle=0,
             end_angle=angle,
         )
-        li = c.kcl.find_layer(layer)
+        li = c.kcl.layer(layer)
         c.create_port(
             layer=li,
             width=c.kcl.to_dbu(width),
@@ -429,7 +429,7 @@ def bend_s_euler_factory(
         else:
             p1 = c.kcl.to_dbu(backbone[0])
             p2 = c.kcl.to_dbu(backbone[-1])
-        li = c.kcl.find_layer(layer)
+        li = c.kcl.layer(layer)
         c.create_port(
             trans=kdb.Trans(2, False, p1.to_v()),
             width=c.kcl.to_dbu(width),

--- a/src/kfactory/factories/straight.py
+++ b/src/kfactory/factories/straight.py
@@ -157,7 +157,7 @@ def straight_dbu_factory(
         if width // 2 * 2 != width:
             raise ValueError("The width (w) must be a multiple of 2 database units")
 
-        li = c.kcl.find_layer(layer)
+        li = c.kcl.layer(layer)
         c.shapes(li).insert(kdb.Box(0, -width // 2, length, width // 2))
         c.create_port(trans=kdb.Trans(2, False, 0, 0), layer=li, width=width)
         c.create_port(trans=kdb.Trans(0, False, length, 0), layer=li, width=width)

--- a/src/kfactory/factories/taper.py
+++ b/src/kfactory/factories/taper.py
@@ -162,7 +162,7 @@ def taper_factory(
             )
             width2 = -width2
 
-        li = c.kcl.find_layer(layer)
+        li = c.kcl.layer(layer)
         taper = c.shapes(li).insert(
             kdb.Polygon(
                 [

--- a/src/kfactory/factories/virtual/circular.py
+++ b/src/kfactory/factories/virtual/circular.py
@@ -159,7 +159,7 @@ def virtual_bend_circular_factory(
 
         c.create_port(
             name="o1",
-            layer=c.kcl.find_layer(layer),
+            layer=c.kcl.layer(layer),
             width=round(width / c.kcl.dbu),
             dcplx_trans=kdb.DCplxTrans(1, 180, False, backbone[0].to_v()),
         )
@@ -167,7 +167,7 @@ def virtual_bend_circular_factory(
             name="o2",
             dcplx_trans=kdb.DCplxTrans(1, angle, False, backbone[-1].to_v()),
             width=width,
-            layer=c.kcl.find_layer(layer),
+            layer=c.kcl.layer(layer),
         )
         return c
 

--- a/src/kfactory/factories/virtual/euler.py
+++ b/src/kfactory/factories/virtual/euler.py
@@ -144,7 +144,7 @@ def virtual_bend_euler_factory(
 
         c.create_port(
             name="o1",
-            layer=c.kcl.find_layer(layer),
+            layer=c.kcl.layer(layer),
             width=width,
             dcplx_trans=kdb.DCplxTrans(1, 180, False, backbone[0].to_v()),
         )
@@ -152,7 +152,7 @@ def virtual_bend_euler_factory(
             name="o2",
             dcplx_trans=kdb.DCplxTrans(1, angle, False, backbone[-1].to_v()),
             width=width,
-            layer=c.kcl.find_layer(layer),
+            layer=c.kcl.layer(layer),
         )
         return c
 

--- a/src/kfactory/factories/virtual/straight.py
+++ b/src/kfactory/factories/virtual/straight.py
@@ -148,13 +148,13 @@ def virtual_straight_factory(
         c.create_port(
             name="o1",
             dcplx_trans=kdb.DCplxTrans(1, 180, False, 0, 0),
-            layer=c.kcl.find_layer(layer),
+            layer=c.kcl.layer(layer),
             width=width,
         )
         c.create_port(
             name="o2",
             dcplx_trans=kdb.DCplxTrans(1, 0, False, length, 0),
-            layer=c.kcl.find_layer(layer),
+            layer=c.kcl.layer(layer),
             width=width,
         )
         return c

--- a/src/kfactory/factories/virtual/utils.py
+++ b/src/kfactory/factories/virtual/utils.py
@@ -33,13 +33,11 @@ def extrude_backbone(
         backbone, width=width, start_angle=start_angle, end_angle=end_angle
     )
     center_path_r.reverse()
-    c.shapes(c.kcl.find_layer(layer)).insert(
-        kdb.DPolygon(center_path_l + center_path_r)
-    )
+    c.shapes(c.kcl.layer(layer)).insert(kdb.DPolygon(center_path_l + center_path_r))
 
     if enclosure:
         for _layer, sections in enclosure.layer_sections.items():
-            _li = c.kcl.find_layer(_layer)
+            _li = c.kcl.layer(_layer)
             for section in sections.sections:
                 if section.d_min is not None:
                     inner_l, inner_r = extrude_path_points(

--- a/src/kfactory/port.py
+++ b/src/kfactory/port.py
@@ -347,9 +347,7 @@ class ProtoPort(Generic[TUnit], ABC):
         This corresponds to the port's cross section's main layer converted to the
         index.
         """
-        return self.kcl.find_layer(
-            self.cross_section.layer, allow_undefined_layers=True
-        )
+        return self.kcl.layout.layer(self.cross_section.layer)
 
     @property
     def layer_info(self) -> kdb.LayerInfo:

--- a/src/kfactory/utils/difftest.py
+++ b/src/kfactory/utils/difftest.py
@@ -154,8 +154,8 @@ def xor(
     for layer in c.kcl.layer_infos():
         # exists in both
         if (
-            new_kcell.kcl.layout.find_layer(layer) is not None
-            and old_kcell.kcl.layout.find_layer(layer) is not None
+            new_kcell.kcl.layout.layer(layer) is not None
+            and old_kcell.kcl.layout.layer(layer) is not None
         ):
             layer_ref = old_kcell.layer(layer)
             layer_run = new_kcell.layer(layer)
@@ -179,7 +179,7 @@ def xor(
                     equivalent = False
                 print(message)
         # only in new
-        elif new_kcell.kcl.layout.find_layer(layer) is not None:
+        elif new_kcell.kcl.layout.layer(layer) is not None:
             layer_id = new_kcell.layer(layer)
             region = kdb.Region(new_kcell.begin_shapes_rec(layer_id))
             diff.shapes(c.kcl.layer(layer)).insert(region)
@@ -187,7 +187,7 @@ def xor(
             equivalent = False
 
         # only in old
-        elif old_kcell.kcl.layout.find_layer(layer) is not None:
+        elif old_kcell.kcl.layout.layer(layer) is not None:
             layer_id = old_kcell.layer(layer)
             region = kdb.Region(old_kcell.begin_shapes_rec(layer_id))
             diff.shapes(c.kcl.layer(layer)).insert(region)
@@ -346,8 +346,8 @@ def diff(
             for layer in c.kcl.layer_infos():
                 # exists in both
                 if (
-                    new.kcl.layout.find_layer(layer) is not None
-                    and old.kcl.layout.find_layer(layer) is not None
+                    new.kcl.layout.layer(layer) is not None
+                    and old.kcl.layout.layer(layer) is not None
                 ):
                     layer_ref = old.layer(layer)
                     layer_run = new.layer(layer)
@@ -371,7 +371,7 @@ def diff(
                             equivalent = False
                         print(message)
                 # only in new
-                elif new.kcl.layout.find_layer(layer) is not None:
+                elif new.kcl.layout.layer(layer) is not None:
                     layer_id = new.layer(layer)
                     region = kdb.Region(new.begin_shapes_rec(layer_id))
                     diff.shapes(c.kcl.layer(layer)).insert(region)
@@ -379,7 +379,7 @@ def diff(
                     equivalent = False
 
                 # only in old
-                elif old.kcl.layout.find_layer(layer) is not None:
+                elif old.kcl.layout.layer(layer) is not None:
                     layer_id = old.layer(layer)
                     region = kdb.Region(old.begin_shapes_rec(layer_id))
                     diff.shapes(c.kcl.layer(layer)).insert(region)

--- a/src/kfactory/utils/violations.py
+++ b/src/kfactory/utils/violations.py
@@ -94,7 +94,7 @@ def fix_spacing_tiled(
     if tile_size is None:
         min(25 * min_space, 250)
         tile_size = (30 * min_space * c.kcl.dbu, 30 * min_space * c.kcl.dbu)
-    li = c.kcl.find_layer(layer)
+    li = c.kcl.layer(layer)
     tp = kdb.TilingProcessor()
     tp.frame = c.kcl.to_um(c.bbox(li))  # type: ignore[misc, assignment]
     tp.dbu = c.kcl.dbu
@@ -173,7 +173,7 @@ def fix_spacing_sizing_tiled(
     if tile_size is None:
         size = min_space * 20 * c.kcl.dbu
         tile_size = (size, size)
-    li = c.kcl.find_layer(layer)
+    li = c.kcl.layer(layer)
     tp.frame = c.kcl.to_um(c.bbox(li))  # type: ignore[misc, assignment]
     tp.dbu = c.kcl.dbu
     tp.tile_size(*tile_size)  # tile size in um
@@ -239,7 +239,7 @@ def fix_spacing_minkowski_tiled(
 
     tp.tile_size(*tile_size)
     if isinstance(ref, kdb.LayerInfo):
-        tp.input("main_layer", c.kcl.layout, c.cell_index(), c.kcl.find_layer(ref))
+        tp.input("main_layer", c.kcl.layout, c.cell_index(), c.kcl.layer(ref))
     else:
         tp.input("main_layer", ref)
 
@@ -314,7 +314,7 @@ def fix_width_minkowski_tiled(
 
     tp.tile_size(*tile_size)
     if isinstance(ref, kdb.LayerInfo):
-        tp.input("main_layer", c.kcl.layout, c.cell_index(), c.kcl.find_layer(ref))
+        tp.input("main_layer", c.kcl.layout, c.cell_index(), c.kcl.layer(ref))
     else:
         tp.input("main_layer", ref)
 
@@ -395,7 +395,7 @@ def fix_width_and_spacing_minkowski_tiled(
 
     tp.tile_size(*tile_size)
     if isinstance(ref, kdb.LayerInfo):
-        tp.input("main_layer", c.kcl.layout, c.cell_index(), c.kcl.find_layer(ref))
+        tp.input("main_layer", c.kcl.layout, c.cell_index(), c.kcl.layer(ref))
     else:
         tp.input("main_layer", ref)
 


### PR DESCRIPTION
## Summary

removes `find_layer` from standard factories and utils in order to not break if a layer is unknown in the current state.