### PR TITLE
catch errors if wrong class is returned

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: "v5.0.0"
+    rev: "v6.0.0"
     hooks:
       - id: check-added-large-files
       - id: check-case-conflict
@@ -21,7 +21,7 @@ repos:
         exclude: 'changelog\.d/.*|CHANGELOG\.md'
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.12.7
+    rev: v0.12.8
     hooks:
       # Run the linter.
       - id: ruff

--- a/src/kfactory/decorators.py
+++ b/src/kfactory/decorators.py
@@ -400,10 +400,16 @@ class WrappedKCellFunc(Generic[KCellParams, KC]):
                     name_ = None
                 cell = f(**params)  # type: ignore[call-arg]
                 if cell is None:
-                    raise ValueError(
+                    raise (
                         f"The cell function {self.name!r} in {str(self.file)!r}"
                         " returned None. Did you forget to return the cell or component"
                         " at the end of the function?"
+                    )
+                if not isinstance(cell, ProtoTKCell):
+                    raise TypeError(
+                        f"The cell function {self.name!r} in {str(self.file)!r}"
+                        f" returned {type(cell)=}. This decorator only supports"
+                        " KCell/DKCell or any SubClass such as Component."
                     )
 
                 logger.debug("Constructed {}", name_ or cell.name)
@@ -636,6 +642,12 @@ class WrappedVKCellFunc(Generic[KCellParams, VK]):
                         " returned None. Did you forget to return the cell or component"
                         " at the end of the function?"
                     )
+                if not isinstance(cell, ProtoTKCell):
+                    raise TypeError(
+                        f"The cell function {self.name!r} in {str(self.file)!r}"
+                        f" returned {type(cell)=}. This decorator only supports"
+                        " CKCell/or any SubClass such as ComponentAllAngle."
+                    )
 
                 logger.debug("Constructed {}", name_ or cell.name)
 
@@ -660,15 +672,15 @@ class WrappedVKCellFunc(Generic[KCellParams, VK]):
                 if self.ports_definition is not None:
                     port_lengths = 0
                     for direction in Direction:
-                        port_lengths += len(self.ports_definition.get(direction, []))  # type: ignore[arg-type]
+                        port_lengths += len(self.ports_definition.get(direction, []))
                     mapping = {0: "right", 1: "top", 2: "left", 3: "bottom"}
                     if len(cell.ports) != port_lengths:
                         received_ports = PortsDefinition()
                         for port in cell.ports:
                             mapped: Direction = Direction(mapping[port.trans.angle])
                             if mapped not in received_ports:
-                                received_ports[mapped] = []  # type: ignore[literal-required]
-                            received_ports[mapped].append(port.name)  # type: ignore[literal-required]
+                                received_ports[mapped] = []
+                            received_ports[mapped].append(port.name)
                         raise ValueError(
                             "The `@cell` decorator defines ports, but they do not match"
                             " the extracted ports. Declared ports: "
@@ -680,7 +692,7 @@ class WrappedVKCellFunc(Generic[KCellParams, VK]):
                     port_names: list[str | None] = []
                     for direction in Direction:
                         if direction in self.ports_definition:
-                            port_names.extend(self.ports_definition[direction])  # type: ignore[literal-required]
+                            port_names.extend(self.ports_definition[direction])
 
                     for port in cell.ports:
                         if port.name not in port_names:

--- a/src/kfactory/decorators.py
+++ b/src/kfactory/decorators.py
@@ -26,6 +26,7 @@ from typing_extensions import Unpack
 from . import kdb
 from .conf import CheckInstances, logger
 from .exceptions import CellNameError
+from .kcell import AnyKCell, ProtoTKCell, TKCell, VKCell
 from .serialization import (
     DecoratorDict,
     DecoratorList,
@@ -49,7 +50,6 @@ from .typings import (
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable, Sequence
 
-    from .kcell import AnyKCell, ProtoTKCell, TKCell, VKCell
     from .layout import KCLayout
 
 
@@ -400,7 +400,7 @@ class WrappedKCellFunc(Generic[KCellParams, KC]):
                     name_ = None
                 cell = f(**params)  # type: ignore[call-arg]
                 if cell is None:
-                    raise (
+                    raise TypeError(
                         f"The cell function {self.name!r} in {str(self.file)!r}"
                         " returned None. Did you forget to return the cell or component"
                         " at the end of the function?"
@@ -408,7 +408,7 @@ class WrappedKCellFunc(Generic[KCellParams, KC]):
                 if not isinstance(cell, ProtoTKCell):
                     raise TypeError(
                         f"The cell function {self.name!r} in {str(self.file)!r}"
-                        f" returned {type(cell)=}. This decorator only supports"
+                        f" returned {type(cell)=}. The `@cell` decorator only supports"
                         " KCell/DKCell or any SubClass such as Component."
                     )
 
@@ -637,16 +637,16 @@ class WrappedVKCellFunc(Generic[KCellParams, VK]):
                     name_ = None
                 cell = f(**params)  # type: ignore[call-arg]
                 if cell is None:
-                    raise ValueError(
+                    raise TypeError(
                         f"The cell function {self.name!r} in {str(self.file)!r}"
                         " returned None. Did you forget to return the cell or component"
                         " at the end of the function?"
                     )
-                if not isinstance(cell, ProtoTKCell):
+                if not isinstance(cell, VKCell):
                     raise TypeError(
                         f"The cell function {self.name!r} in {str(self.file)!r}"
-                        f" returned {type(cell)=}. This decorator only supports"
-                        " CKCell/or any SubClass such as ComponentAllAngle."
+                        f" returned {type(cell)=}. The `@vcell` decorator only supports"
+                        " VKCell or any SubClass such as ComponentAllAngle."
                     )
 
                 logger.debug("Constructed {}", name_ or cell.name)
@@ -672,15 +672,15 @@ class WrappedVKCellFunc(Generic[KCellParams, VK]):
                 if self.ports_definition is not None:
                     port_lengths = 0
                     for direction in Direction:
-                        port_lengths += len(self.ports_definition.get(direction, []))
+                        port_lengths += len(self.ports_definition.get(direction, []))  # type: ignore[arg-type]
                     mapping = {0: "right", 1: "top", 2: "left", 3: "bottom"}
                     if len(cell.ports) != port_lengths:
                         received_ports = PortsDefinition()
                         for port in cell.ports:
                             mapped: Direction = Direction(mapping[port.trans.angle])
                             if mapped not in received_ports:
-                                received_ports[mapped] = []
-                            received_ports[mapped].append(port.name)
+                                received_ports[mapped] = []  # type: ignore[literal-required]
+                            received_ports[mapped].append(port.name)  # type: ignore[literal-required]
                         raise ValueError(
                             "The `@cell` decorator defines ports, but they do not match"
                             " the extracted ports. Declared ports: "
@@ -692,7 +692,7 @@ class WrappedVKCellFunc(Generic[KCellParams, VK]):
                     port_names: list[str | None] = []
                     for direction in Direction:
                         if direction in self.ports_definition:
-                            port_names.extend(self.ports_definition[direction])
+                            port_names.extend(self.ports_definition[direction])  # type: ignore[literal-required]
 
                     for port in cell.ports:
                         if port.name not in port_names:

--- a/tests/test_cell.py
+++ b/tests/test_cell.py
@@ -597,10 +597,17 @@ def test_return_none(kcl: kf.KCLayout) -> None:
     def test_no_return() -> kf.KCell:  # type: ignore[return]
         kcl.kcell()
 
+    def test_no_return_vk() -> kf.VKCell:  # type: ignore[return]
+        kcl.vkcell()
+
     with pytest.raises(TypeError):
         kcl.cell()(test_no_return)()
     with pytest.raises(TypeError):
         kcl.cell()(functools.partial(test_no_return))()
+    with pytest.raises(TypeError):
+        kcl.vcell(test_no_return_vk)()
+    with pytest.raises(TypeError):
+        kcl.vcell(functools.partial(test_no_return_vk))()
 
 
 def test_return_wrong_type(kcl: kf.KCLayout) -> None:

--- a/tests/test_cell.py
+++ b/tests/test_cell.py
@@ -597,7 +597,20 @@ def test_return_none(kcl: kf.KCLayout) -> None:
     def test_no_return() -> kf.KCell:  # type: ignore[return]
         kcl.kcell()
 
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         kcl.cell()(test_no_return)()
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         kcl.cell()(functools.partial(test_no_return))()
+
+
+def test_return_wrong_type(kcl: kf.KCLayout) -> None:
+    def test_vk() -> kf.VKCell:
+        return kcl.vkcell()
+
+    def test_kc() -> kf.KCell:
+        return kcl.kcell()
+
+    with pytest.raises(TypeError):
+        kcl.cell()(test_vk)()  # type: ignore[type-var]
+    with pytest.raises(TypeError):
+        kcl.vcell(test_kc)()  # type: ignore[type-var]


### PR DESCRIPTION
## Summary

Return error if `cell` or `vcell` do not get the intended type (i.e. KCell/DKCell or VKCell)

## Test Plan

tests/test_cell.py::test_wrong_return_type
