### PR TITLE
fix netlist kcl factories retrieval

### DIFF
--- a/src/kfactory/kcell.py
+++ b/src/kfactory/kcell.py
@@ -1967,6 +1967,9 @@ class ProtoTKCell(ProtoKCell[TUnit, TKCell], Generic[TUnit], ABC):
                         eqps = c_.kcl.virtual_factories[
                             c_.factory_name
                         ].lvs_equivalent_ports
+                    elif c_.is_library_cell():
+                        from .layout import kcls
+                        eqps = kcls[c_.library().name()].factories[c_.factory_name].lvs_equivalent_ports
                     else:
                         eqps = c_.kcl.factories[c_.factory_name].lvs_equivalent_ports
                 if eqps is not None:

--- a/src/kfactory/kcell.py
+++ b/src/kfactory/kcell.py
@@ -1969,6 +1969,7 @@ class ProtoTKCell(ProtoKCell[TUnit, TKCell], Generic[TUnit], ABC):
                         ].lvs_equivalent_ports
                     elif c_.is_library_cell():
                         from .layout import kcls
+
                         eqps = (
                             kcls[c_.library().name()]
                             .factories[c_.factory_name]

--- a/src/kfactory/kcell.py
+++ b/src/kfactory/kcell.py
@@ -1969,7 +1969,11 @@ class ProtoTKCell(ProtoKCell[TUnit, TKCell], Generic[TUnit], ABC):
                         ].lvs_equivalent_ports
                     elif c_.is_library_cell():
                         from .layout import kcls
-                        eqps = kcls[c_.library().name()].factories[c_.factory_name].lvs_equivalent_ports
+                        eqps = (
+                            kcls[c_.library().name()]
+                            .factories[c_.factory_name]
+                            .lvs_equivalent_ports
+                        )
                     else:
                         eqps = c_.kcl.factories[c_.factory_name].lvs_equivalent_ports
                 if eqps is not None:


### PR DESCRIPTION
## Summary

netlists and schemas failed on cases where >1 KCLayout is involved

## Test Plan

`tests/test_schema.py::test_schema_kcl_mix_netlist`
