### PR TITLE
Remove `if __name__ == '__main__'` in test files

### DIFF
--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -36,7 +36,3 @@ def test_show_function() -> None:
         temp_file.chmod(0o000)
 
         show(temp_file)
-
-
-if __name__ == "__main__":
-    test_show_function()

--- a/tests/test_dkcell.py
+++ b/tests/test_dkcell.py
@@ -255,7 +255,3 @@ def test_cell_decorator(kcl: kf.KCLayout) -> None:
     assert isinstance(cell3, kf.DKCell)
     assert isinstance(cell4, kf.DKCell)
     assert isinstance(cell5, kf.DKCell)
-
-
-if __name__ == "__main__":
-    pytest.main([__file__])

--- a/tests/test_instance.py
+++ b/tests/test_instance.py
@@ -710,7 +710,3 @@ def test_to_dtype(kcl: kf.KCLayout) -> None:
     ref = dref.to_itype()
     assert ref.bbox() == kf.kdb.Box(-5000, -5000, 5000, 5000)
     assert isinstance(ref, kf.Instance)
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-s"])

--- a/tests/test_instance_group.py
+++ b/tests/test_instance_group.py
@@ -221,7 +221,3 @@ def test_instnace_group_iter(
     instance1, *_ = instance_groups
     for inst in instance1:
         assert isinstance(inst, kf.Instance)
-
-
-if __name__ == "__main__":
-    pytest.main([__file__])

--- a/tests/test_instance_ports.py
+++ b/tests/test_instance_ports.py
@@ -280,7 +280,3 @@ def test_iter(kcl: kf.KCLayout, layers: Layers) -> None:
 
 def test_dinstance_ports_repr(dinstance_ports: kf.DInstance) -> None:
     assert repr(dinstance_ports.ports)
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-s"])

--- a/tests/test_instances.py
+++ b/tests/test_instances.py
@@ -1,5 +1,3 @@
-import pytest
-
 import kfactory as kf
 from tests.conftest import Layers
 
@@ -94,7 +92,3 @@ def test_to_dtype(kcl: kf.KCLayout) -> None:
     ref = dref.to_itype()
     assert ref.bbox() == kf.kdb.Box(-5000, -5000, 5000, 5000)
     assert isinstance(ref, kf.Instance)
-
-
-if __name__ == "__main__":
-    pytest.main([__file__])

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -87,7 +87,3 @@ def test_layer_stack(pdk: kf.KCLayout) -> None:
     assert pdk.layer_stack.to_dict().keys() == {"wg", "clad"}
     with pytest.raises(KeyError):
         pdk.layer_stack["invalid"]
-
-
-if __name__ == "__main__":
-    pytest.main(["-s", __file__])

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -338,7 +338,3 @@ def test_get_component(layers: Layers) -> None:
             {"component": "straight"},
             output_type=kf.DKCell,
         )
-
-
-if __name__ == "__main__":
-    pytest.main(["-s", __file__])

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -2,8 +2,6 @@
 
 from tempfile import NamedTemporaryFile
 
-import pytest
-
 import kfactory as kf
 from tests.conftest import Layers
 
@@ -179,7 +177,3 @@ def test_info_dump(kcl: kf.KCLayout) -> None:
         wg_read.get_meta_data()
         assert wg_read.info == c.info
         assert wg_read.info["d"] == {"a": 1, "b": 2}
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-v", "-s"])

--- a/tests/test_packing.py
+++ b/tests/test_packing.py
@@ -1,5 +1,3 @@
-import pytest
-
 import kfactory as kf
 
 
@@ -27,7 +25,3 @@ def test_pack_instances(kcl: kf.KCLayout) -> None:
         c, [ref, ref2, ref3, ref4], max_height=2000, max_width=2000
     )
     assert instance_group.bbox() == kf.kdb.DBox(0, 0, 2000, 2000)
-
-
-if __name__ == "__main__":
-    pytest.main(["-s", __file__])

--- a/tests/test_pdk.py
+++ b/tests/test_pdk.py
@@ -277,7 +277,3 @@ def test_pdk_cell_infosettings(straight: kf.KCell) -> None:
     _wg = c << straight
     assert _wg.cell.settings == straight.settings
     assert _wg.cell.info == straight.info
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-v", "-s"])

--- a/tests/test_port.py
+++ b/tests/test_port.py
@@ -504,7 +504,3 @@ def test_create(kcl: kf.KCLayout, layers: Layers) -> None:
         port_type="optical",
         trans=kf.kdb.Trans(1, 0),
     )
-
-
-if __name__ == "__main__":
-    pytest.main(["-s", __file__])

--- a/tests/test_ports.py
+++ b/tests/test_ports.py
@@ -549,7 +549,3 @@ def test_ports_repr(kcl: kf.KCLayout, layers: Layers) -> None:
         width=5000, length=10000, layer=layers.WG
     )
     repr(c.ports)
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-s"])

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -110,7 +110,3 @@ def test_info_str() -> None:
 def test_settings_str() -> None:
     settings = KCellSettings(param1=42)
     assert str(settings) == "KCellSettings(param1=42)"
-
-
-if __name__ == "__main__":
-    test_info_restrict_types()

--- a/tests/test_simplify.py
+++ b/tests/test_simplify.py
@@ -1,5 +1,4 @@
 import klayout.db as kdb
-import pytest
 
 from kfactory.utils.simplify import dsimplify, simplify
 
@@ -72,7 +71,3 @@ def test_simplify_single_point() -> None:
     points = [kdb.DPoint(0, 0)]
     simplified = dsimplify(points, 0.1)
     assert simplified == points
-
-
-if __name__ == "__main__":
-    pytest.main([__file__])

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -108,7 +108,3 @@ def test_pprint_ports(layers: Layers, kcl: kf.KCLayout) -> None:
     )
     for case, ports_ in a:
         pprint_ports(ports_, case)
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-s"])

--- a/tests/test_vkcell.py
+++ b/tests/test_vkcell.py
@@ -106,7 +106,3 @@ def test_vkcell_attributes() -> None:
     assert c.size_info.nc == (5, 10)
     assert c.size_info.cc == (5, 5)
     assert c.size_info.center == (5, 5)
-
-
-if __name__ == "__main__":
-    test_vkcell_attributes()


### PR DESCRIPTION
## Summary

Clean up test files by removing `if __name__ == '__main__'` blocks

