### PR TITLE
added labels flag to flatten

### DIFF
--- a/src/kfactory/kcell.py
+++ b/src/kfactory/kcell.py
@@ -1097,7 +1097,7 @@ class ProtoTKCell(ProtoKCell[TUnit, TKCell], Generic[TUnit], ABC):
         else:
             rename_func(self.ports)
 
-    def flatten(self, merge: bool = True) -> None:
+    def flatten(self, merge: bool = True, labels: bool = True) -> None:
         """Flatten the cell.
 
         Args:
@@ -1117,7 +1117,8 @@ class ProtoTKCell(ProtoKCell[TUnit, TKCell], Generic[TUnit], ABC):
                 texts = kdb.Texts(self.shapes(layer))
                 self.kdb_cell.clear(layer)
                 self.shapes(layer).insert(reg)
-                self.shapes(layer).insert(texts)
+                if labels:
+                    self.shapes(layer).insert(texts)
 
     def convert_to_static(self, recursive: bool = True) -> None:
         """Convert the KCell to a static cell if it is pdk KCell."""


### PR DESCRIPTION
## Summary

Flatten in other EDA tools like Magic have an option to remove labels. These changes provide this capability.

## Test Plan

Merge flag is on by default. I observed if the labels on metal layers existed by default or when labels flag was set to False.
