### PR TITLE
added self as return value of ComponentReference.connect

### DIFF
--- a/src/kfactory/instance.py
+++ b/src/kfactory/instance.py
@@ -315,7 +315,7 @@ class ProtoTInstance(ProtoInstance[TUnit], Generic[TUnit]):
         allow_type_mismatch: bool | None = None,
         use_mirror: bool | None = None,
         use_angle: bool | None = None,
-    ) -> None: ...
+    ) -> Self: ...
 
     @overload
     def connect(
@@ -330,7 +330,7 @@ class ProtoTInstance(ProtoInstance[TUnit], Generic[TUnit]):
         allow_type_mismatch: bool | None = None,
         use_mirror: bool | None = None,
         use_angle: bool | None = None,
-    ) -> None: ...
+    ) -> Self: ...
 
     @overload
     def connect(
@@ -345,7 +345,7 @@ class ProtoTInstance(ProtoInstance[TUnit], Generic[TUnit]):
         allow_type_mismatch: bool | None = None,
         use_mirror: bool | None = None,
         use_angle: bool | None = None,
-    ) -> None: ...
+    ) -> Self: ...
 
     def connect(
         self,
@@ -359,7 +359,7 @@ class ProtoTInstance(ProtoInstance[TUnit], Generic[TUnit]):
         allow_type_mismatch: bool | None = None,
         use_mirror: bool | None = None,
         use_angle: bool | None = None,
-    ) -> None:
+    ) -> Self:
         """Align port with name `portname` to a port.
 
         Function to allow to transform this instance so that a port of this instance is
@@ -466,6 +466,8 @@ class ProtoTInstance(ProtoInstance[TUnit], Generic[TUnit]):
                     self.dmirror_y(op.dcplx_trans.disp.y)
                 case _:
                     raise NotImplementedError("This shouldn't happen")
+
+        return self
 
     def __repr__(self) -> str:
         """Return a string representation of the instance."""


### PR DESCRIPTION
## Summary

Adding self as a return value to connect allows the chaining of multiple << and connect statement without multiple variables when no variable to intermediate references needs to be kept. 

As example, this gdsfactory code:
```python
c = gf.Component()

st = gf.c.straight(length=10.0)

_ = c << st

_2 = c << st
_2.connect("o1", _.ports["o2"])

_3 = c << st
_3.connect("o1", _2.ports["o2"])
```
could be simplified to this:
```python
c = gf.Component()

st = gf.c.straight(length=10.0)

_ = c << st
_ = (c << st).connect("o1", _.ports["o2"])
_ = (c << st).connect("o1", _.ports["o2"])
```
