### PR TITLE
Fix inconsistent angle assignment via `Port.angle` instead of `Port.trans.angle`

### DIFF
--- a/src/kfactory/ports.py
+++ b/src/kfactory/ports.py
@@ -631,7 +631,10 @@ class DCreatePort(ABC):
                     kcl=self.kcl,
                 )
             else:
-                trans_ = kdb.Trans(rot=int(dcplx_trans.angle // 90), u=self.kcl.to_dbu(dcplx_trans.disp))
+                trans_ = kdb.Trans(
+                    rot=int(dcplx_trans.angle // 90),
+                    u=self.kcl.to_dbu(dcplx_trans.disp),
+                )
                 port = DPort(
                     name=name,
                     trans=trans_,

--- a/src/kfactory/routing/optical.py
+++ b/src/kfactory/routing/optical.py
@@ -793,7 +793,7 @@ def place_manhattan(
             "place_manhattan needs to be passed a fixed bend90 cell with two optical"
             " ports which are 90° apart from each other with port_type 'port_type'."
         )
-    
+
     if p1.dcplx_trans.is_complex() or p2.dcplx_trans.is_complex():
         raise ValueError(
             "place_manhattan does not support complex port transformations."


### PR DESCRIPTION
Assigning to Port.trans.angle sometimes fails silently when using a virtual port.
This PR updates `place_manhattan()` to modify Port.angle instead.

Fixes #823 
