### PR TITLE
add 'multi' parameter to FillOperator call in fill_tiled()

### DIFF
--- a/src/kfactory/utils/fill.py
+++ b/src/kfactory/utils/fill.py
@@ -226,6 +226,7 @@ def fill_tiled(
         row_step=row_step_,
         column_step=col_step_,
         origin=c.bbox().p1,
+        multi=multi,
     )
     tp.output(
         "to_fill",


### PR DESCRIPTION
## Summary

Currently in the `fill_tiled()` function the `multi` parameter was ignored.
In this PR it is passed to the `FillOperator` call (which was likely the intention initially?).

## Test Plan
Using the code snippet
```python
import gdsfactory as gf

for multi in [True, False]:
    c = gf.Component()
    c << gf.c.rectangle((5, 5), layer='WG')
    (c << gf.c.rectangle((5, 5), layer='WG')).dmove((8, 0))
    (c << gf.c.rectangle((5, 5), layer='WG')).dmove((0.5, 8))
    (c << gf.c.rectangle((5, 5), layer='WG')).dmove((8.5, 8))
    c << gf.c.rectangle((20, 20), layer='WAFER', centered=False)
    c.fill(gf.c.rectangle((0.9, 0.9), layer='WG'), [('WAFER', 0)], exclude_layers=[('WG', 1)], multi=multi)
    c.plot()
```
will result in the same filling pattern before PR and in different patterns after PR:
<img width="800" height="600" alt="multi_false" src="https://github.com/user-attachments/assets/54220918-2834-406a-b296-f573f4ce8fae" />
<img width="800" height="600" alt="multi_true" src="https://github.com/user-attachments/assets/ac3b6852-9a8d-4113-8eda-530fb2155021" />

