### PR TITLE
Build gitignore

### DIFF
--- a/src/kfactory/cli/build.py
+++ b/src/kfactory/cli/build.py
@@ -14,7 +14,7 @@ from typing import Annotated
 
 import typer
 
-from ..conf import config, logger
+from ..conf import logger
 from ..kcell import KCell
 from ..kcell import show as kfshow
 from ..layout import kcls

--- a/src/kfactory/kcell.py
+++ b/src/kfactory/kcell.py
@@ -28,7 +28,6 @@ from collections.abc import (
     ValuesView,
 )
 from pathlib import Path
-from tempfile import gettempdir
 from typing import (
     TYPE_CHECKING,
     Any,

--- a/src/kfactory/session_cache.py
+++ b/src/kfactory/session_cache.py
@@ -10,7 +10,7 @@ from hashlib import sha256
 from shutil import rmtree
 from typing import TYPE_CHECKING
 
-from .conf import config, logger
+from .conf import logger
 from .layout import KCLayout, kcls
 from .utilities import get_session_directory, save_layout_options
 

--- a/src/kfactory/utilities.py
+++ b/src/kfactory/utilities.py
@@ -326,10 +326,9 @@ def get_build_path(
         filepath = build_dir / Path(filename).with_suffix(f".{file_format}")
         filepath.parent.mkdir(parents=True, exist_ok=True)
         return filepath, False
-    else:
-        filepath = Path(gettempdir()) / Path(filename).with_suffix(f".{file_format}")
-        filepath.parent.mkdir(parents=True, exist_ok=True)
-        return filepath, True
+    filepath = Path(gettempdir()) / Path(filename).with_suffix(f".{file_format}")
+    filepath.parent.mkdir(parents=True, exist_ok=True)
+    return filepath, True
 
 
 def get_session_directory(custom_dir: Path | None = None) -> Path:
@@ -347,6 +346,5 @@ def get_session_directory(custom_dir: Path | None = None) -> Path:
     build_dir = ensure_build_directory("session/kcls", create_gitignore=True)
     if build_dir:
         return build_dir
-    else:
-        # Fallback to current directory
-        return Path() / "build/session/kcls"
+    # Fallback to current directory
+    return Path() / "build/session/kcls"


### PR DESCRIPTION
## Summary

Many tools add a `.gitignore` with `*` by default to a cache or build directory. This is a nicer UX.

There is also quite a bit of repetition in these Git operations, so I refactored in a second commit.

## Test Plan


