### PR TITLE
Parse decorator tags to func wrapper

### DIFF
--- a/src/kfactory/layout.py
+++ b/src/kfactory/layout.py
@@ -1329,6 +1329,7 @@ class KCLayout(
                 info=info,
                 post_process=post_process,  # type: ignore[arg-type]
                 debug_names=debug_names,
+                tags=tags,
                 lvs_equivalent_ports=lvs_equivalent_ports,
                 ports=ports,
                 schematic_function=schematic_function,
@@ -1540,6 +1541,7 @@ class KCLayout(
                 info=info,
                 check_ports=check_ports,
                 check_pins=check_pins,
+                tags=tags,
                 lvs_equivalent_ports=lvs_equivalent_ports,
                 ports=ports,
             )


### PR DESCRIPTION
## Summary

Argument "tags" of cell and vcell decorators is not parsed to the function wrappers.

