### PR TITLE
include instance names in connectivity check reports

### DIFF
--- a/src/kfactory/port.py
+++ b/src/kfactory/port.py
@@ -48,11 +48,28 @@ def create_port_error(
     db_cell: rdb.RdbCell,
     cat: rdb.RdbCategory,
     dbu: float,
+    inst_name1: str | None = None,
+    inst_name2: str | None = None,
 ) -> None:
-    """Create an error report for two ports."""
+    """Create an error report for two ports.
+
+    Args:
+        p1: First port.
+        p2: Second port.
+        c1: Cell of the first port.
+        c2: Cell of the second port.
+        db: ReportDatabase to add the item to.
+        db_cell: RdbCell to add the item to.
+        cat: RdbCategory to add the item to.
+        dbu: Database unit.
+        inst_name1: Optional explicit instance name for first port's instance.
+        inst_name2: Optional explicit instance name for second port's instance.
+    """
     it = db.create_item(db_cell, cat)
     if p1.name and p2.name:
-        it.add_value(f"Port Names: {c1.name}.{p1.name}/{c2.name}.{p2.name}")
+        label1 = f"{inst_name1}.{p1.name}" if inst_name1 else f"{c1.name}.{p1.name}"
+        label2 = f"{inst_name2}.{p2.name}" if inst_name2 else f"{c2.name}.{p2.name}"
+        it.add_value(f"Port Names: {label1}/{label2}")
     it.add_value(
         port_polygon(p1.cross_section.width).transformed(p1.trans).to_dtype(dbu)
     )


### PR DESCRIPTION
## Motivation

Connectivity check reports are currently very hard to act on — both for humans and for LLMs providing automated design feedback.

### The problem: cryptic error messages

Today, an OrphanPort error looks like this:

```
Port Name: coupler_ring_gdsfactorypcomponentspcouplerspcoupler_rin_7f7d4233o3)
```

This is the **cell name concatenated directly with the port name**, with no separator and a mismatched closing parenthesis. A user seeing this has to:

1. Mentally parse where the cell name ends and the port name begins
2. Reverse-engineer the hash-truncated cell name back to a component type
3. Figure out **which instance** of that component is affected (impossible if there are multiple)

For **LLM-powered design assistants** (e.g. an AI that analyzes check results and suggests fixes), this format is even more problematic. The LLM receives a flat list of errors with no structured way to map them back to specific instances in the user's design. It cannot reliably tell the user "your coupler `coupler_1` has an unconnected port `o3`" — it can only parrot back the cryptic cell name.

### The fix: carry instance identity through the check

When instances have explicit names (common in schematic-driven flows where `inst.name` is set from the schematic, or when users call `add_ref(component, name="coupler_1")`), the report now includes them:

**Before:**
```
Port Name: coupler_ring_gdsfactorypcomponentspcouplerspcoupler_rin_7f7d4233o3)
```

**After (with explicit instance name):**
```
Port Name: coupler_1.o3 (cell: coupler_ring_gdsfactorypcomponentspcouplerspcoupler_rin_7f7d4233)
```

**After (without explicit instance name — the common case for GDS-loaded designs):**
```
Port Name: coupler_ring_gdsfactorypcomponentspcouplerspcoupler_rin_7f7d4233.o3
```

Even in the fallback case, the dot separator makes it possible to programmatically split cell name from port name — something that was impossible with the old concatenated format.

### Why this matters for the ecosystem

GDSFactory+ (and similar tools) are building IDE integrations and AI-assisted workflows on top of kfactory's check infrastructure. The connectivity report is the primary data source for:

- **VS Code sidebar panels** that show check results as filterable cards
- **LLM agents** that interpret check results and suggest fixes to the user
- **Automated CI pipelines** that gate designs on connectivity correctness

All of these consumers benefit from error messages that clearly identify: which component type, which port, and (when available) which specific instance. This PR makes that possible without breaking any existing behavior.

## Changes

**`src/kfactory/kcell.py`** — `connectivity_check` method:
- `inst_ports` dict now stores `(Port, KCell, str | None)` tuples where the third element is the explicit instance name (via `inst.is_named()`), or `None` for auto-generated names.
- OrphanPort messages use `{inst_name}.{port} (cell: {cell_name})` when an explicit instance name exists, or `{cell_name}.{port}` as fallback. Both formats use a dot separator for reliable parsing.
- All `create_port_error` call sites pass instance names through for WidthMismatch/AngleMismatch/TypeMismatch errors.
- portoverlap messages (both 2-port and >2-port cases) similarly prefer instance names when available.

**`src/kfactory/port.py`** — `create_port_error` function:
- Added optional `inst_name1` / `inst_name2` parameters (default `None`) that replace cell names in error text when provided.
- Fully backwards compatible — existing callers without the new args behave identically.

## Test plan

- [x] All 3 existing connectivity tests pass without modification (`test_connectivity`, `test_connectivity_cell_ports`, `test_connectivity_no_rec`)
- [x] No test changes required — tests assert item counts per category, not message text
- [ ] Verify with a schematic-driven design that has explicitly named instances to confirm instance names appear in reports

🤖 Generated with [Claude Code](https://claude.com/claude-code)