### PR TITLE
Fix check of metadata type

### DIFF
--- a/src/kfactory/serialization.py
+++ b/src/kfactory/serialization.py
@@ -225,11 +225,11 @@ def check_metadata_type(value: MetaData) -> MetaData:
     if isinstance(value, str | int | float | bool | SerializableShape):
         return value
     if isinstance(value, tuple):
-        return tuple(convert_metadata_type(tv) for tv in value)
+        return tuple(check_metadata_type(tv) for tv in value)
     if isinstance(value, list):
-        return [convert_metadata_type(tv) for tv in value]
+        return [check_metadata_type(tv) for tv in value]
     if isinstance(value, dict):
-        return {k: convert_metadata_type(v) for k, v in value.items()}
+        return {k: check_metadata_type(v) for k, v in value.items()}
     msg = (
         "Values of the info dict only support int, float, string, tuple or list."
         f"{value=}, {type(value)=}"

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -58,11 +58,27 @@ def test_info_setitem() -> None:
     assert info["key1"] == 100
 
 
+def test_info_setitem_rejects_bad_type() -> None:
+    info = Info(key1=42)
+    with pytest.raises(ValidationError):
+        info["bad"] = object()
+    with pytest.raises(ValidationError):
+        info["bad"] = [object()]
+
+
 def test_info_update() -> None:
     info = Info(key1=42)
     info.update({"key1": 100, "key2": "new_value"})
     assert info["key1"] == 100
     assert info["key2"] == "new_value"
+
+
+def test_info_update_rejects_bad_type() -> None:
+    info = Info(key1=42)
+    with pytest.raises(ValidationError):
+        info.update({"bad": object()})
+    with pytest.raises(ValidationError):
+        info.update({"nested_bad": [{"deeper": object()}]})
 
 
 def test_info_contains() -> None:

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -41,6 +41,15 @@ def test_check_metadata_type() -> None:
     with pytest.raises(ValueError, match=r"^Values of the info dict only support.*"):
         check_metadata_type({1, 2, 3})  # type: ignore[arg-type]
 
+    with pytest.raises(ValueError, match=r"^Values of the info dict only support.*"):
+        check_metadata_type([object()])
+    with pytest.raises(ValueError, match=r"^Values of the info dict only support.*"):
+        check_metadata_type((object(),))
+    with pytest.raises(ValueError, match=r"^Values of the info dict only support.*"):
+        check_metadata_type({"k": object()})
+    with pytest.raises(ValueError, match=r"^Values of the info dict only support.*"):
+        check_metadata_type([[object()]])
+
 
 def test_load_layout_options() -> None:
     load = load_layout_options(gds2_allow_big_records=True)


### PR DESCRIPTION
## Summary

This was recursing on the wrong function and silently converting.

## Test Plan

Unit tests.
