### PR TITLE
Add schematic pins

### DIFF
--- a/docs/source/schematics/ports_and_pins.py
+++ b/docs/source/schematics/ports_and_pins.py
@@ -1,0 +1,322 @@
+# ---
+# jupyter:
+#   jupytext:
+#     custom_cell_magics: kql
+#     formats: py:percent
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.16.2
+#   kernelspec:
+#     display_name: Python 3 (ipykernel)
+#     language: python
+#     name: python3
+# ---
+
+# %% [markdown]
+# # Schematic Ports & Pins
+#
+# A schematic exposes connectivity to the outside world through two complementary
+# objects:
+#
+# - **Ports** — individual terminals (single waveguide port, single electrical
+#   contact). They get materialized as `KCell.ports` on the resulting cell.
+# - **Pins** — *named bundles of ports*. They group one or more cell-level ports under
+#   a single logical terminal (e.g. a DC pad's two contacts, a multi-mode bus).
+#
+# This tutorial covers both APIs end-to-end: how to expose ports at the schematic
+# level, how to pin them together, how the schematic stores everything as Pydantic
+# data, and how the YAML round-trip works.
+#
+# For schematic basics (instances, placements, connections) see
+# [Schematic-Driven Design](overview.py).
+
+# %%
+import kfactory as kf
+
+# %% [markdown]
+# ## PDK setup
+#
+# A minimal PDK with a single `straight` cell. The cell exposes two waveguide ports
+# (`o1`, `o2`) and groups them under one cell-level pin called `"dc"`.
+
+
+# %%
+class LAYER(kf.LayerInfos):
+    WG: kf.kdb.LayerInfo = kf.kdb.LayerInfo(1, 0)
+
+
+L = LAYER()
+pdk = kf.KCLayout("SCHEM_PORTS_PINS", infos=LAYER)
+
+
+@pdk.cell
+def straight(width: int = 500, length: int = 10_000) -> kf.KCell:
+    """Straight waveguide. Both optical ports are also grouped under a `"dc"` pin."""
+    c = pdk.kcell()
+    c.shapes(L.WG).insert(kf.kdb.Box(0, -width // 2, length, width // 2))
+    p1 = c.create_port(
+        name="o1",
+        width=width,
+        trans=kf.kdb.Trans(rot=2, x=0, y=0),
+        layer_info=L.WG,
+    )
+    p2 = c.create_port(
+        name="o2",
+        width=width,
+        trans=kf.kdb.Trans(x=length, y=0),
+        layer_info=L.WG,
+    )
+    c.create_pin(name="dc", ports=[p1, p2], pin_type="DC", info={"role": "bus"})
+    return c
+
+
+# %% [markdown]
+# ## Part 1 — Ports on a schematic
+#
+# A `KCell` exposes ports via `c.create_port(...)`. A *schematic* exposes ports via
+# `schematic.ports` — a dict mapping name → one of three things:
+#
+# | Stored as | Created with | Meaning |
+# |-----------|--------------|---------|
+# | `PortRef` / `PortArrayRef` | `schematic.add_port(name, port=inst.ports[...])` | Forward an instance port up to the top level |
+# | `Port[T]` | `schematic.create_port(name, cross_section, x, y, ...)` | A new placeable top-level port whose position is computed at build time |
+#
+# Schematic ports are materialized as `KCell.ports` when the cell is built.
+# For `PortRef`, the underlying instance port is added to the top-level cell under
+# the schematic-port key name.
+
+# %% [markdown]
+# ### `add_port` — forward an instance port
+#
+# Use `add_port` whenever you want a top-level port that simply mirrors an existing
+# instance port. The schematic stores a `PortRef` lazily; the cell port is created
+# when `create_cell` runs.
+
+# %%
+@pdk.schematic_cell
+def forwarded_ports() -> kf.Schematic:
+    schematic = kf.Schematic(kcl=pdk)
+
+    s = schematic.create_inst(
+        name="s", component="straight", settings={"width": 500, "length": 10_000}
+    )
+    s.place(x=0, y=0)
+
+    # forward each instance port up to the top level. the schematic-port key name
+    # becomes the cell-port name on the resulting KCell — it does not have to match
+    # the instance's port name.
+    schematic.add_port(name="left", port=s.ports["o1"])
+    schematic.add_port(name="right", port=s.ports["o2"])
+
+    return schematic
+
+
+cell = forwarded_ports()
+print("cell ports:", [p.name for p in cell.ports])
+
+# %% [markdown]
+# Inside the schematic, the entries are `PortRef` objects pointing at the underlying
+# instance:
+
+# %%
+for name, port in cell.schematic.ports.items():
+    print(f"  {name!r}: {port}")
+
+# %% [markdown]
+# ### `create_port` — placeable top-level port
+#
+# Use `create_port` when the top-level port is *not* a copy of an instance port —
+# typically when you want a port at a fixed location, or whose position/orientation
+# is a function of an instance's geometry but not directly any port.
+#
+# Both absolute coordinates and `PortRef`s are accepted for `x`, `y`, and
+# `orientation`, so you can pin the new port to an instance:
+
+# %%
+@pdk.schematic_cell
+def fanout_port() -> kf.Schematic:
+    schematic = kf.Schematic(kcl=pdk)
+
+    s = schematic.create_inst(
+        name="s", component="straight", settings={"width": 500, "length": 10_000}
+    )
+    s.place(x=0, y=0)
+
+    # an extra "monitor" port placed 5 µm above the centre of the straight, facing up
+    schematic.create_port(
+        name="monitor",
+        cross_section="WG_500",
+        x=5_000,
+        y=5_000,
+        orientation=90,
+    )
+
+    schematic.add_port(name="left", port=s.ports["o1"])
+    schematic.add_port(name="right", port=s.ports["o2"])
+    return schematic
+
+
+# %% [markdown]
+# !!! note
+#     `create_port` requires a registered cross-section. The example above assumes a
+#     `WG_500` cross-section was registered on the PDK; in this notebook we don't
+#     instantiate `fanout_port()` because the PDK has no cross-section table — it's
+#     here for API illustration only. See the [PDK page](../pdk/creating_pdk.py) for
+#     setting up cross-sections.
+
+# %% [markdown]
+# ## Part 2 — Pins
+#
+# A pin is a named bundle of ports. It carries a `pin_type` (`"DC"` by default) and
+# free-form `info`. At the schematic level there are two ways to define one:
+#
+# | Stored as | Created with | Meaning |
+# |-----------|--------------|---------|
+# | `Pin` | `schematic.create_pin(name, ports=[...])` | Group existing top-level schematic ports |
+# | `PinRef` | `schematic.add_pin(name, pin=inst.pins["..."])` | Forward an instance's pin to the top level |
+#
+# Pins are **structural only** for now — they're not part of nets, connections, or
+# routes. They sit alongside ports on the schematic and on the resulting cell.
+
+# %% [markdown]
+# ### `create_pin` — explicit grouping
+#
+# Use this when the pin's member ports come from different instances or don't align
+# with any single instance pin. The constituent port names must already exist in
+# `schematic.ports` (typically via `add_port`).
+
+# %%
+@pdk.schematic_cell
+def explicit_pin() -> kf.Schematic:
+    schematic = kf.Schematic(kcl=pdk)
+
+    s = schematic.create_inst(
+        name="s", component="straight", settings={"width": 500, "length": 10_000}
+    )
+    s.place(x=0, y=0)
+
+    schematic.add_port(name="left", port=s.ports["o1"])
+    schematic.add_port(name="right", port=s.ports["o2"])
+
+    schematic.create_pin(
+        name="bus", ports=["left", "right"], pin_type="RF", info={"freq": 5}
+    )
+
+    return schematic
+
+
+cell = explicit_pin()
+for pin in cell.pins:
+    print(
+        f"pin {pin.name!r}:"
+        f" ports={[p.name for p in pin.ports]}"
+        f" type={pin.pin_type!r}"
+        f" info={dict(pin.info)}"
+    )
+
+# %% [markdown]
+# ### `add_pin` — forward an instance pin
+#
+# Use `add_pin` when an instance already exposes a pin you want at the top level.
+# `inst.pins["name"]` produces a `PinRef`; pass it to `add_pin`.
+#
+# **Pre-condition:** every constituent port of the instance pin must be exposed as a
+# top-level schematic port beforehand. The materialization step at `create_cell`
+# time looks up each port via that exposure — if any port is missing you'll get a
+# clear error.
+
+# %%
+@pdk.schematic_cell
+def forwarded_pin() -> kf.Schematic:
+    schematic = kf.Schematic(kcl=pdk)
+
+    s = schematic.create_inst(
+        name="s", component="straight", settings={"width": 500, "length": 10_000}
+    )
+    s.place(x=0, y=0)
+
+    # both underlying ports of the instance's "dc" pin are needed at the top level
+    schematic.add_port(name="left", port=s.ports["o1"])
+    schematic.add_port(name="right", port=s.ports["o2"])
+
+    # forward the pin — pin_type and info are inherited from the instance pin
+    schematic.add_pin(name="dc", pin=s.pins["dc"])
+    return schematic
+
+
+cell = forwarded_pin()
+for pin in cell.pins:
+    print(f"pin {pin.name!r}: type={pin.pin_type!r} info={dict(pin.info)}")
+
+# %% [markdown]
+# ## Part 3 — YAML round-trip
+#
+# Schematic ports and pins serialize alongside instances and placements. The format
+# accepts two shorthands:
+#
+# - Ports: `"<inst>,<port>"` (forwarded) or a `{x, y, ...}` dict (placeable)
+# - Pins: `"<inst>,<pin>"` (forwarded) or a `{ports: [...], pin_type, info}` block
+
+# %%
+yaml_str = """
+instances:
+  s:
+    component: straight
+    settings: {width: 500, length: 10000}
+
+placements:
+  s: {x: 0, y: 0}
+
+ports:
+  left:  s,o1
+  right: s,o2
+
+pins:
+  bus:
+    ports: [left, right]
+    pin_type: RF
+  fwd: s,dc
+"""
+
+from ruamel.yaml import YAML
+
+yaml = YAML(typ="safe")
+schematic = kf.Schematic.model_validate(yaml.load(yaml_str))
+
+print("ports:", {n: type(p).__name__ for n, p in schematic.ports.items()})
+print("pins:", {n: type(p).__name__ for n, p in schematic.pins.items()})
+print("bus.ports:", schematic.pins["bus"].ports)
+print("fwd:", schematic.pins["fwd"])
+
+# %% [markdown]
+# ## Pitfalls
+#
+# - **Schematic-port key ≠ original port name.** When you forward an instance port
+#   with `add_port(name="left", port=s.ports["o1"])`, the cell's top-level port is
+#   named `"left"`, not `"o1"`. The same naming applies to ports referenced from
+#   pins.
+# - **Forwarded pins need exposed underlying ports.** When you call
+#   `add_pin(pin=inst.pins["x"])`, every constituent port of the instance pin must
+#   already be a top-level schematic port. The materialization step at `create_cell`
+#   time raises a clear error otherwise.
+# - **Pins are top-level only.** They don't take part in nets, connections, or
+#   routes. Connect ports the usual way (`inst.connect`, `add_route`); pins exist
+#   purely to group ports for tooling that consumes them.
+# - **Names are unique within their dict.** `add_port`/`create_port` share
+#   `schematic.ports`; `add_pin`/`create_pin` share `schematic.pins`. Each raises on
+#   duplicate names.
+#
+# ## Summary
+#
+# | Operation | API |
+# |-----------|-----|
+# | Forward an instance port to the top level | `schematic.add_port(name, port=inst.ports[...])` |
+# | Create a placeable top-level port | `schematic.create_port(name, cross_section, x, y, orientation)` |
+# | Reference an instance port | `inst.ports["o1"]` → `PortRef` |
+# | Reference an array instance port | `inst.ports["o1", ia, ib]` → `PortArrayRef` |
+# | Group existing top-level ports into a pin | `schematic.create_pin(name, ports=[...], pin_type, info)` |
+# | Forward an instance pin to the top level | `schematic.add_pin(name, pin=inst.pins[...])` |
+# | Reference an instance pin | `inst.pins["dc"]` → `PinRef` |
+# | Inspect cell-level ports / pins | `cell.ports`, `cell.pins` |

--- a/docs/zensical.yml
+++ b/docs/zensical.yml
@@ -47,6 +47,7 @@ nav:
       - Schematics:
           - Overview: schematics/overview.md
           - Netlist & I/O: schematics/netlist.md
+          - Ports & Pins: schematics/ports_and_pins.md
           - 45° Crossing: schematics/crossing45.md
   - Utilities:
       - Grid Layout: utilities/grid.md

--- a/src/kfactory/__init__.py
+++ b/src/kfactory/__init__.py
@@ -36,7 +36,6 @@ from .schematic import (
     PathLengthMatch,
     Schematic,
     Schema,
-    get_schematic,
     read_schematic,
 )
 from .instances import Instances, DInstances, VInstances
@@ -146,7 +145,6 @@ __all__ = [
     "factories",
     "flexgrid",
     "flexgrid_dbu",
-    "get_schematic",
     "grid",
     "grid_dbu",
     "kcell",

--- a/src/kfactory/kcell.py
+++ b/src/kfactory/kcell.py
@@ -927,7 +927,7 @@ class ProtoTKCell[T: (int, float)](ProtoKCell[T, TKCell], ABC):
         name: str,
         ports: Iterable[ProtoPort[Any]],
         pin_type: str = "DC",
-        info: dict[str, int | float | str] | None = None,
+        info: dict[str, MetaData] | None = None,
     ) -> ProtoPin[T]: ...
 
     @overload
@@ -3126,7 +3126,7 @@ class DKCell(ProtoTKCell[float], UMGeometricObject, DCreatePort):
         name: str,
         ports: Iterable[ProtoPort[Any]],
         pin_type: str = "DC",
-        info: dict[str, int | float | str] | None = None,
+        info: dict[str, MetaData] | None = None,
     ) -> DPin:
         """Create a pin in the cell."""
         return self.pins.create_pin(
@@ -3330,7 +3330,7 @@ class KCell(ProtoTKCell[int], DBUGeometricObject, ICreatePort):
         name: str,
         ports: Iterable[ProtoPort[Any]],
         pin_type: str = "DC",
-        info: dict[str, int | float | str] | None = None,
+        info: dict[str, MetaData] | None = None,
     ) -> Pin:
         """Create a pin in the cell."""
         return self.pins.create_pin(

--- a/src/kfactory/pins.py
+++ b/src/kfactory/pins.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
 
     from .layout import KCLayout
     from .port import ProtoPort
+    from .typings import MetaData
 
 __all__ = ["DPins", "Pins", "ProtoPins"]
 
@@ -81,7 +82,7 @@ class ProtoPins[T: (int, float)](Protocol):
         name: str,
         ports: Iterable[ProtoPort[Any]],
         pin_type: str = "DC",
-        info: dict[str, int | float | str] | None = None,
+        info: dict[str, MetaData] | None = None,
     ) -> ProtoPin[T]:
         """Add a pin."""
         ...
@@ -136,7 +137,7 @@ class Pins(ProtoPins[int]):
         name: str,
         ports: Iterable[ProtoPort[Any]],
         pin_type: str = "DC",
-        info: dict[str, int | float | str] | None = None,
+        info: dict[str, MetaData] | None = None,
     ) -> Pin:
         """Add a pin to Pins."""
         if info is None:
@@ -197,7 +198,7 @@ class DPins(ProtoPins[float]):
         name: str,
         ports: Iterable[ProtoPort[Any]],
         pin_type: str = "DC",
-        info: dict[str, int | float | str] | None = None,
+        info: dict[str, MetaData] | None = None,
     ) -> DPin:
         """Add a pin to Pins."""
         if info is None:

--- a/src/kfactory/schematic.py
+++ b/src/kfactory/schematic.py
@@ -50,7 +50,7 @@ from pydantic import (
 from ruamel.yaml import YAML
 
 from . import kdb
-from .conf import PROPID, logger
+from .conf import logger
 from .decorators import WrappedKCellFunc, WrappedVKCellFunc
 from .instance import Instance, VInstance
 from .kcell import DKCell, KCell, ProtoTKCell, VKCell
@@ -76,7 +76,6 @@ __all__ = [
     "DSchematic",
     "PathLengthMatch",
     "Schematic",
-    "get_schematic",
     "read_schematic",
 ]
 
@@ -302,7 +301,7 @@ class Array[T: (int, float)](BaseModel, extra="forbid"):
     pitch_b: tuple[T, Annotated[T, AfterValidator(_gez)]]
 
 
-class Ports[T: (int, float)](BaseModel):
+class Ports[T: (int, float)]:
     """Indexer for an instance's ports to produce `PortRef`/`PortArrayRef`.
 
     Example:
@@ -310,7 +309,10 @@ class Ports[T: (int, float)](BaseModel):
         `inst.ports["out", 1, 0]` -> `PortArrayRef` (requires instance array)
     """
 
-    instance: SchematicInstance[T]
+    __slots__ = ("instance",)
+
+    def __init__(self, instance: SchematicInstance[T]) -> None:
+        self.instance = instance
 
     def __getitem__(self, key: str | tuple[str, int, int]) -> PortRef | PortArrayRef:
         """Return a port reference for a (standard or array) port."""
@@ -324,6 +326,23 @@ class Ports[T: (int, float)](BaseModel):
                 instance=self.instance.name, port=key[0], ia=key[1], ib=key[2]
             )
         return PortRef(instance=self.instance.name, port=key)
+
+
+class Pins[T: (int, float)]:
+    """Indexer for an instance's pins to produce `PinRef`.
+
+    Example:
+        `inst.pins["dc"]` -> `PinRef`
+    """
+
+    __slots__ = ("instance",)
+
+    def __init__(self, instance: SchematicInstance[T]) -> None:
+        self.instance = instance
+
+    def __getitem__(self, key: str) -> PinRef:
+        """Return a pin reference."""
+        return PinRef(instance=self.instance.name, pin=key)
 
 
 class SchematicInstance[T: (int, float)](
@@ -465,6 +484,10 @@ class SchematicInstance[T: (int, float)](
     @cached_property
     def ports(self) -> Ports[T]:
         return Ports(instance=self)
+
+    @cached_property
+    def pins(self) -> Pins[T]:
+        return Pins(instance=self)
 
     @property
     def xmin(self) -> AnchorRefX:
@@ -695,6 +718,58 @@ class Port[T: (int, float)](BaseModel, extra="forbid"):
 
     def as_python_str(self, schematic_name: str = "schematic") -> str:
         return f"{schematic_name}.ports[{self.name!r}]"
+
+
+class PinRef(BaseModel, extra="forbid"):
+    """Reference to a pin on a schematic instance.
+
+    Produced by ``inst.pins["name"]`` and used as the ``pin`` argument of
+    :meth:`TSchematic.add_pin` to expose an instance pin as a top-level
+    schematic pin.
+    """
+
+    instance: str
+    pin: str
+
+    @property
+    def name(self) -> str:
+        return self.pin
+
+    def __lt__(self, other: PinRef) -> bool:
+        return (self.instance, self.pin) < (other.instance, other.pin)
+
+    def __hash__(self) -> int:
+        return hash((self.instance, self.pin))
+
+    def __eq__(self, other: object) -> bool:
+        return (
+            isinstance(other, PinRef)
+            and self.instance == other.instance
+            and self.pin == other.pin
+        )
+
+    def as_python_str(self, inst_name: str | None = None) -> str:
+        return f"{inst_name or self.instance}.pins[{self.pin!r}]"
+
+
+class Pin(BaseModel, extra="forbid"):
+    """A schematic-level pin grouping one or more schematic-level ports.
+
+    The pin will be materialized on the resulting cell at ``create_cell``
+    time as a :class:`kfactory.Pin`. The ``ports`` list references entries
+    in :attr:`TSchematic.ports` by name.
+
+    Attributes:
+        name: Pin name (key in :attr:`TSchematic.pins`).
+        ports: Names of schematic-level ports that belong to this pin.
+        pin_type: Pin type (default ``"DC"``).
+        info: Free-form info attached to the pin.
+    """
+
+    name: str = Field(exclude=True)
+    ports: list[str]
+    pin_type: str = "DC"
+    info: dict[str, JSONSerializable] = Field(default_factory=dict)
 
 
 class SchematicNet[T: (int, float)](BaseModel):
@@ -986,6 +1061,9 @@ class TSchematic[T: (int, float)](BaseModel, extra="forbid"):
         connections: List of `Connection`s.
         routes: Mapping of route name -> `Route`.
         ports: Mapping of port name -> `Port`/`PortRef`/`PortArrayRef`.
+        pins: Mapping of pin name -> `Pin`/`PinRef`. Pins are top-level
+            groupings of schematic ports (purely structural — they do not
+            participate in nets/connections).
         info: dict which will be mapped to `KCell.info` (or any other derivate like
             Component).
         unit: Base coordinate unit ("dbu" or "um"). Fixed by subclass.
@@ -1001,6 +1079,7 @@ class TSchematic[T: (int, float)](BaseModel, extra="forbid"):
     )
     routes: dict[str, Route[T]] = Field(default_factory=dict)
     ports: dict[str, Port[T] | PortRef | PortArrayRef] = Field(default_factory=dict)
+    pins: dict[str, Pin | PinRef] = Field(default_factory=dict)
     constraints: list[Constraint] = Field(default_factory=list)
     kcl: KCLayout = Field(exclude=True, default_factory=get_default_kcl)
     unit: Literal["dbu", "um"]
@@ -1102,6 +1181,61 @@ class TSchematic[T: (int, float)](BaseModel, extra="forbid"):
         )
         self.ports[p.name] = p
         return p
+
+    def create_pin(
+        self,
+        name: str,
+        ports: list[str],
+        pin_type: str = "DC",
+        info: dict[str, JSONSerializable] | None = None,
+    ) -> Pin:
+        """Create a schematic-level pin grouping existing schematic ports.
+
+        Args:
+            name: Pin name. Must be unique within the schematic.
+            ports: Names of schematic ports (entries of ``self.ports``) that
+                belong to this pin. Each name must already be registered as a
+                schematic port.
+            pin_type: Pin type (default ``"DC"``).
+            info: Optional info dict attached to the pin.
+
+        Returns:
+            The created :class:`Pin`, also stored in :attr:`self.pins`.
+
+        Raises:
+            ValueError: If a pin with ``name`` already exists, ``ports`` is
+                empty, or any port name is not present in ``self.ports``.
+        """
+        if name in self.pins:
+            raise ValueError(f"Pin with name {name!r} already exists")
+        if not ports:
+            raise ValueError(
+                f"At least one port must be provided to create pin named {name!r}"
+            )
+        missing = [p for p in ports if p not in self.ports]
+        if missing:
+            raise ValueError(
+                f"Cannot create pin {name!r}: port(s) {missing!r} are not "
+                "registered as schematic ports."
+            )
+        pin = Pin(name=name, ports=list(ports), pin_type=pin_type, info=info or {})
+        self.pins[name] = pin
+        return pin
+
+    def add_pin(self, name: str | None = None, *, pin: PinRef) -> None:
+        """Expose an existing instance pin as a schematic top-level pin.
+
+        Args:
+            name: Name for the schematic pin; defaults to the underlying pin name.
+            pin: Pin reference to expose.
+
+        Raises:
+            ValueError: If a schematic pin with ``name`` already exists.
+        """
+        name = name or pin.pin
+        if name in self.pins:
+            raise ValueError(f"Pin with name {name!r} already exists")
+        self.pins[name] = pin
 
     def create_connection(
         self, port1: PortRef | Port[T], port2: PortRef
@@ -1344,6 +1478,14 @@ class TSchematic[T: (int, float)](BaseModel, extra="forbid"):
 
                 if isinstance(placement.get("y"), str):
                     raise NotImplementedError
+        pins = data.get("pins")
+        if pins:
+            for name, pin in pins.items():
+                if isinstance(pin, str):
+                    inst, pname = pin.rsplit(",", 1)
+                    pins[name] = {"instance": inst, "pin": pname}
+                elif isinstance(pin, dict) and "ports" in pin:
+                    pin["name"] = name
         return data
 
     @field_serializer("placements")
@@ -1580,6 +1722,73 @@ class TSchematic[T: (int, float)](BaseModel, extra="forbid"):
                     + port_connection_transformation_errors
                 )
             )
+
+        # materialize pins on the resulting cell. ports must already be created.
+        if self.pins:
+            # map (instance, original port name) -> schematic-port key name
+            # only PortRef-style schematic ports map to instance ports; cell
+            # port names equal the schematic-port keys (see PortRef.place).
+            ref_to_schematic_port: dict[tuple[str, str], str] = {}
+            for sname, sport in self.ports.items():
+                if isinstance(sport, PortRef) and not isinstance(sport, PortArrayRef):
+                    ref_to_schematic_port[(sport.instance, sport.port)] = sname
+
+        for pin_name, pin_def in self.pins.items():
+            if isinstance(pin_def, PinRef):
+                inst = self.instances.get(pin_def.instance)
+                if inst is None:
+                    raise ValueError(
+                        f"Pin {pin_name!r} references unknown instance "
+                        f"{pin_def.instance!r}."
+                    )
+                if inst.virtual:
+                    inst_pins = c.vinsts[pin_def.instance].cell.pins
+                else:
+                    inst_pins = c.insts[pin_def.instance].cell.pins
+                if pin_def.pin not in [p.name for p in inst_pins]:
+                    raise ValueError(
+                        f"Pin {pin_name!r} references unknown pin "
+                        f"{pin_def.pin!r} on instance {pin_def.instance!r}."
+                    )
+                inst_pin = inst_pins[pin_def.pin]
+                cell_port_names: list[str] = []
+                missing: list[str] = []
+                for p in inst_pin.ports:
+                    if p.name is None:
+                        missing.append("<unnamed>")
+                        continue
+                    key = (pin_def.instance, p.name)
+                    if key not in ref_to_schematic_port:
+                        missing.append(p.name)
+                    else:
+                        cell_port_names.append(ref_to_schematic_port[key])
+                if missing:
+                    raise ValueError(
+                        f"Cannot materialize pin {pin_name!r} from "
+                        f"{pin_def.instance!r}.{pin_def.pin!r}: underlying "
+                        f"port(s) {missing!r} are not exposed as top-level"
+                        " schematic ports (use schematic.add_port for each)."
+                    )
+                c.create_pin(
+                    name=pin_name,
+                    ports=[c.ports[n] for n in cell_port_names],
+                    pin_type=inst_pin.pin_type,
+                    info=inst_pin.info.model_dump(),
+                )
+            else:
+                missing = [p for p in pin_def.ports if p not in c.ports]
+                if missing:
+                    raise ValueError(
+                        f"Cannot materialize pin {pin_name!r}: port(s) "
+                        f"{missing!r} are not registered on the cell."
+                    )
+                c.create_pin(
+                    name=pin_name,
+                    ports=[c.ports[p] for p in pin_def.ports],
+                    pin_type=pin_def.pin_type,
+                    info=dict(pin_def.info),
+                )
+
         c.schematic = self
         if self.name:
             c.name = self.name
@@ -1823,6 +2032,32 @@ class TSchematic[T: (int, float)](BaseModel, extra="forbid"):
                         f"{_ind()}schematic.add_port("
                         f"name={name!r},"
                         f"port={port.as_python_str(names[port.instance])})\n"
+                    )
+        if self.pins:
+            schematic_cell += f"\n{_ind()}# Schematic pins\n"
+            for name, pin in sorted(
+                self.pins.items(),
+                key=lambda named_pin: (
+                    named_pin[1].__class__.__name__,
+                    named_pin[0],
+                ),
+            ):
+                if isinstance(pin, Pin):
+                    schematic_cell += f"{_ind()}schematic.create_pin(\n"
+                    indent += 2
+                    schematic_cell += f"{_ind()}name={name!r},\n"
+                    schematic_cell += f"{_ind()}ports={pin.ports!r},\n"
+                    if pin.pin_type != "DC":
+                        schematic_cell += f"{_ind()}pin_type={pin.pin_type!r},\n"
+                    if pin.info:
+                        schematic_cell += f"{_ind()}info={pin.info!r},\n"
+                    indent -= 2
+                    schematic_cell += f"{_ind()})\n"
+                else:
+                    schematic_cell += (
+                        f"{_ind()}schematic.add_pin("
+                        f"name={name!r},"
+                        f"pin={pin.as_python_str(names[pin.instance])})\n"
                     )
         if self.placements:
             schematic_cell += f"\n{_ind()}# Schematic instance placements\n"
@@ -2858,50 +3093,6 @@ def _get_placeable[T: (int, float)](
             if port.instance in placed_insts:
                 placeable_ports.add(name)
     return placeable_insts - placed_insts, placeable_ports
-
-
-@overload
-def get_schematic(
-    c: KCell,
-    exclude_port_types: Sequence[str] | None = ("placement", "pad", "bump"),
-) -> TSchematic[int]: ...
-
-
-@overload
-def get_schematic(
-    c: DKCell,
-    exclude_port_types: Sequence[str] | None = ("placement", "pad", "bump"),
-) -> TSchematic[float]: ...
-
-
-def get_schematic(
-    c: KCell | DKCell,
-) -> TSchematic[int] | TSchematic[float]:
-    """NOT FUNCTIONAL YET.
-
-    Create a minimal `TSchematic` from an existing cell.
-
-    Currently extracts named instances only. Port extraction is not yet implemented.
-
-    Args:
-        c: Source cell.
-        exclude_port_types: Port types to ignore (reserved for future use).
-
-    Returns:
-        A `Schematic` if `c` is `KCell`, otherwise a `DSchematic`.
-    """
-
-    if isinstance(c, KCell):
-        schematic: TSchematic[int] | TSchematic[float] = Schematic(name=c.name)
-    else:
-        schematic = DSchematic(name=c.name)
-
-    for inst in c.insts:
-        name = inst.property(PROPID.NAME)
-        if name is not None:
-            schematic.create_inst(name, inst.cell.factory_name or inst.cell.name)
-
-    return schematic
 
 
 @overload

--- a/tests/test_schematic.py
+++ b/tests/test_schematic.py
@@ -1386,3 +1386,201 @@ def test_route_multi(
     c = multi_pad()
     oas_regression(c)
     yaml_regression(c.schematic)  # ty:ignore[invalid-argument-type]
+
+
+def _two_port_factory(kcl: kf.KCLayout, layers: Layers) -> None:
+    """Register a `straight` cell on `kcl` with a "dc" pin grouping o1+o2."""
+
+    @kcl.cell
+    def straight(length: int = 1000) -> kf.KCell:
+        c = kcl.kcell()
+        c.shapes(layers.WG).insert(kf.kdb.Box(0, -250, length, 250))
+        p1 = c.create_port(
+            name="o1",
+            width=500,
+            trans=kf.kdb.Trans(rot=2, x=0, y=0),
+            layer_info=layers.WG,
+        )
+        p2 = c.create_port(
+            name="o2",
+            width=500,
+            trans=kf.kdb.Trans(x=length, y=0),
+            layer_info=layers.WG,
+        )
+        c.create_pin(name="dc", ports=[p1, p2], pin_type="DC", info={"role": "bus"})
+        return c
+
+
+def test_schematic_create_pin(kcl: kf.KCLayout) -> None:
+    _two_port_factory(kcl, Layers())
+
+    schematic = kf.Schematic(kcl=kcl)
+    a = schematic.create_inst(name="a", component="straight")
+    a.place(x=0, y=0)
+    schematic.add_port(name="left", port=a.ports["o1"])
+    schematic.add_port(name="right", port=a.ports["o2"])
+
+    pin = schematic.create_pin(
+        name="bus", ports=["left", "right"], pin_type="RF", info={"freq": 5}
+    )
+    assert pin.name == "bus"
+    assert pin.ports == ["left", "right"]
+    assert pin.pin_type == "RF"
+    assert pin.info == {"freq": 5}
+    assert "bus" in schematic.pins
+
+    c = schematic.create_cell(kf.KCell)
+    cell_pin_names = [p.name for p in c.pins]
+    assert "bus" in cell_pin_names
+    bus_pin = next(p for p in c.pins if p.name == "bus")
+    assert [p.name for p in bus_pin.ports] == ["left", "right"]
+    assert bus_pin.pin_type == "RF"
+
+
+def test_schematic_add_pin_forwards_instance_pin(kcl: kf.KCLayout) -> None:
+    _two_port_factory(kcl, Layers())
+
+    schematic = kf.Schematic(kcl=kcl)
+    a = schematic.create_inst(name="a", component="straight")
+    a.place(x=0, y=0)
+    schematic.add_port(name="left", port=a.ports["o1"])
+    schematic.add_port(name="right", port=a.ports["o2"])
+
+    pin_ref = a.pins["dc"]
+    assert isinstance(pin_ref, kf.schematic.PinRef)
+    assert pin_ref.instance == "a"
+    assert pin_ref.pin == "dc"
+
+    schematic.add_pin(name="forwarded", pin=pin_ref)
+    assert isinstance(schematic.pins["forwarded"], kf.schematic.PinRef)
+
+    c = schematic.create_cell(kf.KCell)
+    fwd = next(p for p in c.pins if p.name == "forwarded")
+    assert {p.name for p in fwd.ports} == {"left", "right"}
+    # pin_type and info are propagated from the underlying instance pin
+    assert fwd.pin_type == "DC"
+    assert fwd.info["role"] == "bus"
+
+
+def test_schematic_create_pin_unknown_port_raises(kcl: kf.KCLayout) -> None:
+    _two_port_factory(kcl, Layers())
+
+    schematic = kf.Schematic(kcl=kcl)
+    a = schematic.create_inst(name="a", component="straight")
+    a.place(x=0, y=0)
+    schematic.add_port(name="left", port=a.ports["o1"])
+
+    with pytest.raises(ValueError, match="not registered as schematic ports"):
+        schematic.create_pin(name="bus", ports=["left", "missing"])
+
+
+def test_schematic_create_pin_duplicate_raises(kcl: kf.KCLayout) -> None:
+    _two_port_factory(kcl, Layers())
+
+    schematic = kf.Schematic(kcl=kcl)
+    a = schematic.create_inst(name="a", component="straight")
+    a.place(x=0, y=0)
+    schematic.add_port(name="left", port=a.ports["o1"])
+    schematic.create_pin(name="bus", ports=["left"])
+
+    with pytest.raises(ValueError, match="already exists"):
+        schematic.create_pin(name="bus", ports=["left"])
+
+
+def test_schematic_create_pin_empty_ports_raises(kcl: kf.KCLayout) -> None:
+    _two_port_factory(kcl, Layers())
+
+    schematic = kf.Schematic(kcl=kcl)
+    with pytest.raises(ValueError, match="At least one port"):
+        schematic.create_pin(name="bus", ports=[])
+
+
+def test_schematic_add_pin_duplicate_raises(kcl: kf.KCLayout) -> None:
+    _two_port_factory(kcl, Layers())
+
+    schematic = kf.Schematic(kcl=kcl)
+    a = schematic.create_inst(name="a", component="straight")
+    a.place(x=0, y=0)
+    schematic.add_pin(name="dc", pin=a.pins["dc"])
+
+    with pytest.raises(ValueError, match="already exists"):
+        schematic.add_pin(name="dc", pin=a.pins["dc"])
+
+
+def test_schematic_add_pin_missing_underlying_port_raises(kcl: kf.KCLayout) -> None:
+    _two_port_factory(kcl, Layers())
+
+    schematic = kf.Schematic(kcl=kcl)
+    a = schematic.create_inst(name="a", component="straight")
+    a.place(x=0, y=0)
+    # only expose o1 as a top-level port; "dc" pin needs both o1 and o2.
+    schematic.add_port(name="left", port=a.ports["o1"])
+    schematic.add_pin(name="forwarded", pin=a.pins["dc"])
+
+    with pytest.raises(ValueError, match="not exposed as top-level"):
+        schematic.create_cell(kf.KCell)
+
+
+def test_schematic_pin_yaml_round_trip(kcl: kf.KCLayout) -> None:
+    _two_port_factory(kcl, Layers())
+
+    schematic = kf.Schematic(kcl=kcl)
+    a = schematic.create_inst(name="a", component="straight")
+    a.place(x=0, y=0)
+    schematic.add_port(name="left", port=a.ports["o1"])
+    schematic.add_port(name="right", port=a.ports["o2"])
+    schematic.create_pin(name="bus", ports=["left", "right"], pin_type="RF")
+    schematic.add_pin(name="forwarded", pin=a.pins["dc"])
+
+    dumped = schematic.model_dump()
+    dumped.pop("unit", None)
+    reloaded = kf.Schematic.model_validate(dumped)
+
+    bus = reloaded.pins["bus"]
+    assert isinstance(bus, kf.schematic.Pin)
+    assert bus.ports == ["left", "right"]
+    assert bus.pin_type == "RF"
+
+    fwd = reloaded.pins["forwarded"]
+    assert isinstance(fwd, kf.schematic.PinRef)
+    assert fwd.instance == "a"
+    assert fwd.pin == "dc"
+
+
+def test_schematic_pin_yaml_string_shorthand() -> None:
+    yaml = YAML(typ=["rt", "safe", "string"])
+    schema_yaml = """
+instances:
+  s:
+    component: straight
+    settings:
+      length: 5
+
+pins:
+  forwarded: s,dc
+"""
+    schematic = kf.DSchematic.model_validate(yaml.load(schema_yaml))
+    fwd = schematic.pins["forwarded"]
+    assert isinstance(fwd, kf.schematic.PinRef)
+    assert fwd.instance == "s"
+    assert fwd.pin == "dc"
+
+
+def test_schematic_pin_code_str(kcl: kf.KCLayout) -> None:
+    _two_port_factory(kcl, Layers())
+
+    schematic = kf.Schematic(name="schem", kcl=kcl)
+    a = schematic.create_inst(name="a", component="straight")
+    a.place(x=0, y=0)
+    schematic.add_port(name="left", port=a.ports["o1"])
+    schematic.add_port(name="right", port=a.ports["o2"])
+    schematic.create_pin(name="bus", ports=["left", "right"], pin_type="RF")
+    schematic.add_pin(name="forwarded", pin=a.pins["dc"])
+
+    code = schematic.code_str(ruff_format=False)
+    assert "schematic.create_pin(" in code
+    assert "name='bus'" in code
+    assert "ports=['left', 'right']" in code
+    assert "pin_type='RF'" in code
+    assert "schematic.add_pin(name='forwarded'" in code
+    assert "a.pins['dc']" in code


### PR DESCRIPTION
## Summary

Tests added (tests/test_schematic.py, +175 lines):
  - test_schematic_create_pin — happy path for create_pin + materialization
  - test_schematic_add_pin_forwards_instance_pin — PinRef round-trip including pin_type/info propagation
  - test_schematic_create_pin_unknown_port_raises — port-not-in-schematic error
  - test_schematic_create_pin_duplicate_raises — duplicate name error
  - test_schematic_create_pin_empty_ports_raises — empty list error
  - test_schematic_add_pin_duplicate_raises — duplicate name error
  - test_schematic_add_pin_missing_underlying_port_raises — deferred-validation error at create_cell
  - test_schematic_pin_yaml_round_trip — Schematic → dict → Schematic keeps both Pin and PinRef
  - test_schematic_pin_yaml_string_shorthand — "inst,pin" shorthand
  - test_schematic_pin_code_str — emitted code includes create_pin/add_pin

  All 10 pin tests pass; full schematic suite still green (21 passed, 1 skipped).

  Docs tutorial (docs/source/schematics/pins.py):
  - Schematic-Pins page with PDK setup, create_pin and add_pin examples, YAML round-trip (including string shorthand), pitfalls section, and a summary API table.
  - Added to navigation under PDK → Schematics → Pins (docs/zensical.yml).
  - The full just docs build fails on pygraphviz (missing system C compiler in this environment, unrelated to the tutorial). The pre-build step that executes the notebook succeeds: ✓ schematics/pins.py (3.3s) — the rendered docs/source-built/schematics/pins.md (299 lines)
  shows expected outputs from each cell (port lists, pin info dumps, the YAML reload result {'bus': 'Pin', 'fwd': 'PinRef'}, etc.).
