### PR TITLE
fix: cast port_index to str in pin metadata deserialization

### DIFF
--- a/src/kfactory/kcell.py
+++ b/src/kfactory/kcell.py
@@ -1727,7 +1727,7 @@ class ProtoTKCell[T: (int, float)](ProtoKCell[T, TKCell], ABC):
                         self.create_pin(
                             name=v.get("name"),
                             ports=[
-                                Port(base=ports[port_index].base)
+                                Port(base=ports[str(port_index)].base)
                                 for port_index in v["ports"]
                             ],
                             pin_type=v["pin_type"],


### PR DESCRIPTION
## Summary

- Pin metadata stores port references as integer indices (from `list.index()` in `set_meta_data`), but the `ports` dict in `get_meta_data` is keyed by strings (from `meta.name.removeprefix("kfactory:ports:")`)
- This causes `KeyError: 0` on GDS roundtrip for any component that uses `create_pin()`
- The library-cell path already uses `str(port_index)` — this aligns the non-library path to match

One-line fix. Same fix is also on `fix/pin-metadata-port-index-type-v2` (branched from `v2.5.1` tag) for backport to a 2.5.2 release — gdsfactory currently pins `kfactory~=2.5.0`.

## Context

Discovered while adding `create_pin()` to gdsfactory gpdk electrical components (gdsfactory/gdsfactory#4558). Every component with pins fails `test_gds` regression tests due to this deserialization bug.

cc @flaport

🤖 Generated with [Claude Code](https://claude.com/claude-code)