### PR TITLE
Normalize int→float for length/route_info_* keys in Info

### DIFF
--- a/src/kfactory/settings.py
+++ b/src/kfactory/settings.py
@@ -12,6 +12,39 @@ if TYPE_CHECKING:
 __all__ = ["Info", "KCellSettings", "KCellSettingsUnits", "SettingMixin"]
 
 
+# Info keys that get int → float coerced before being stored. Several
+# gdsfactory factories declare these props as `float` but accept callers
+# passing integer literals (e.g. `coupler_ring(length_x: float = 4)`).
+# Combined with gdsfactory's value-not-type ``@cell`` cache, the first
+# call's Python type wins and kfactory then serialises it literally into
+# the ``kfactory:info`` PROPVALUE — ``#l4`` for int, ``##4`` for float —
+# producing different GDS bytes for what callers reasonably consider the
+# same component. Normalising just these specific length/weight props
+# keeps the on-disk META stable across cache orderings, without touching
+# KCellSettings (which would change the type seen by user code reading
+# back ``cell.settings[...]``).
+_NORMALIZE_TO_FLOAT_KEYS: frozenset[str] = frozenset(
+    {"length", "route_info_length", "route_info_weight"}
+)
+
+
+def _should_normalize_to_float(key: str) -> bool:
+    if key in _NORMALIZE_TO_FLOAT_KEYS:
+        return True
+    # `route_info_<layer>_length` — layer-dependent name, always a length.
+    return key.startswith("route_info_") and key.endswith("_length")
+
+
+def _maybe_normalize_to_float(key: str, value: Any) -> Any:
+    if (
+        _should_normalize_to_float(key)
+        and isinstance(value, int)
+        and not isinstance(value, bool)
+    ):
+        return float(value)
+    return value
+
+
 class SettingMixin:
     """Mixin class for shared settings functionality."""
 
@@ -97,7 +130,7 @@ class Info(SettingMixin, BaseModel, extra="allow"):
     @staticmethod
     def _check_value(name: str, value: MetaData) -> MetaData:
         try:
-            return check_metadata_type(value)
+            return check_metadata_type(_maybe_normalize_to_float(name, value))
         except ValueError as e:
             raise ValueError(
                 "Values of the info dict only support int, float, string, "

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -155,3 +155,76 @@ def test_info_str() -> None:
 def test_settings_str() -> None:
     settings = KCellSettings(param1=42)
     assert str(settings) == "KCellSettings(param1=42)"
+
+
+def test_info_normalises_length_props_to_float() -> None:
+    """``length``-like Info props are coerced to ``float`` to keep META
+    bytes stable across call-order-sensitive cache hits.
+
+    Repro for the upstream issue: gdsfactory's ``@cell`` cache hashes
+    kwargs by value (``4 == 4.0``), so calling ``foo(length=4)`` and
+    ``bar(length=4.0)`` in the same process collapses onto whichever
+    Python type came first. The cached cell's ``info`` then serialises
+    the wrong type into the ``kfactory:info`` PROPVALUE (``#l4`` vs
+    ``##4``), producing a different GDS byte-stream depending on call
+    order. Normalising these props eliminates the discrepancy.
+    """
+    a = Info(length=4)
+    b = Info(length=4.0)
+    assert a.length == b.length
+    assert isinstance(a.length, float)
+    assert isinstance(b.length, float)
+
+    # Other route_info_* length/weight props too — they all carry the
+    # same length value through gdsfactory's straight() factory.
+    info = Info(
+        length=4,
+        route_info_length=4,
+        route_info_weight=4,
+        route_info_strip_length=4,
+        route_info_metal3_length=4,
+    )
+    assert isinstance(info.length, float)
+    assert isinstance(info.route_info_length, float)
+    assert isinstance(info.route_info_weight, float)
+    assert isinstance(info.route_info_strip_length, float)
+    assert isinstance(info.route_info_metal3_length, float)
+
+
+def test_info_preserves_int_for_non_length_props() -> None:
+    """Only the length/weight allow-list is coerced. Other int values
+    (counts, indices, etc.) keep their Python type.
+    """
+    info = Info(npoints=12, channels=3, layer=4)
+    assert info.npoints == 12 and isinstance(info.npoints, int)
+    assert info.channels == 3 and isinstance(info.channels, int)
+    assert info.layer == 4 and isinstance(info.layer, int)
+
+
+def test_info_preserves_bool_on_length_key() -> None:
+    """``bool`` inherits from ``int`` but carries semantic meaning, so
+    even if the key is in the normalise list, a bool stays a bool.
+    """
+    info = Info(length=True)
+    assert info.length is True
+
+
+def test_info_setitem_coerces_length() -> None:
+    """Per-key assignment (``Info.__setattr__``/``__setitem__``) runs the
+    same coercion as construction.
+    """
+    info = Info()
+    info["length"] = 4
+    assert isinstance(info["length"], float)
+    info.length = 5
+    assert isinstance(info.length, float)
+
+
+def test_kcell_settings_does_not_coerce_length() -> None:
+    """Coercion is scoped to ``Info``. ``KCellSettings`` keeps the
+    caller's Python type — its values are read back by user code (e.g.
+    Schematic netlist comparisons) where ``int`` vs ``float`` semantics
+    matter.
+    """
+    s = KCellSettings(length=4)
+    assert s.length == 4 and isinstance(s.length, int)


### PR DESCRIPTION
## Summary

`KCell.info`'s on-disk META serialisation is sensitive to the Python
type of numeric values: `info.length = 4` becomes `'length'=>#l4` in the
`kfactory:info` PROPVALUE, while `info.length = 4.0` becomes
`'length'=>##4`. When the same logical component is built twice in the
same process — once by a factory whose signature happens to have an
integer literal default, once by a factory whose signature has a float
default — gdsfactory's `@cell` cache (which keys by value, not by type,
because Python's `hash(4) == hash(4.0)` and `4 == 4.0`) returns
whichever was cached first. The result is **non-deterministic GDS
output**: byte-equal regression suites flip on call ordering.

This PR normalises a narrow allow-list of `Info` keys to `float` at
storage time, so `info.length = 4` and `info.length = 4.0` produce the
same META bytes downstream regardless of which factory was hit first.

### Allow-list

Coerce `int` → `float` (preserving `bool`, which subclasses `int`) for
these `Info` keys only:

- `length`
- `route_info_length`
- `route_info_weight`
- `route_info_<layer>_length` (pattern `route_info_*_length`)

These are exactly the keys that flipped int↔float in the reproducer
below — they all derive from the same `length` value inside
`gdsfactory.components.straight()`'s info dict.

`KCellSettings` is **intentionally not coerced**. Its values are read
back by user code (e.g. `Schematic.netlist()` comparing recorded vs
cell-extracted settings; `test_schematic.test_netlist` here in
kfactory's own suite uses int-annotated `length`), and silently
flipping the Python type there has user-visible ripple effects.
Empirically the `kfactory:settings` PROPVALUE didn't flip in the
reproducer anyway — only `kfactory:info` did.

## Reproducer

The non-determinism is observable end-to-end with [`cspdk`][cspdk] +
`gdsfactory` (the same upstream binary builds `cspdk.si220.cband.cells.rings.ring_single`
to two different md5s depending on whether `cspdk.coupler_ring` ran
first in the same process):

```python
\"\"\"Two md5s for the same logical component, depending on call order.

Cause: cspdk's `coupler_ring(length_x: float = 4)` has an int literal
default; cspdk's `ring_single(length_x: float = 4.0)` has a float
default. Both transitively cache `straight(length=length_x)`. Python
treats `4 == 4.0`, so the cache hits — the first call wins and locks
the cached straight's info to whichever type came first. kfactory then
writes that type literally into `kfactory:info` (`#l4` vs `##4`).

Install once:
    pip install gdsfactory==9.42.0 kfactory==2.5.2 klayout==0.30.8 cspdk==1.4.1
\"\"\"
import hashlib, os, subprocess, sys

cases = [
    (\"ring_single FRESH\",
     \"c = cband.cells.rings.ring_single(); c.write_gds('/tmp/_c1.gds')\",
     \"/tmp/_c1.gds\"),
    (\"ring_single AFTER coupler_ring\",
     \"cband.cells.couplers.coupler_ring(); \"
     \"c = cband.cells.rings.ring_single(); c.write_gds('/tmp/_c2.gds')\",
     \"/tmp/_c2.gds\"),
]
for name, body, out in cases:
    code = f\"import cspdk.si220.cband as cband\\ncband.PDK.activate()\\n{body}\\n\"
    subprocess.run([sys.executable, \"-c\", code], check=True)
    print(f\"  {name:35} md5={hashlib.md5(open(out, 'rb').read()).hexdigest()}\")
```

Before this PR (vanilla `kfactory==2.5.2`):

```
  ring_single FRESH                  md5=8398cb824bdc61ef9a513408b08841fe
  ring_single AFTER coupler_ring     md5=7a6b0bca565272de241bf95c9f3eeb88
```

Record-level diff between the two binaries (the only divergence):

```
PROPVALUE META('kfactory:info')={'length'=>##4,'route_info_length'=>##4,
  'route_info_strip_length'=>##4,'route_info_type'=>'strip',
  'route_info_weight'=>##4,'width'=>##0.45}
PROPVALUE META('kfactory:info')={'length'=>#l4,'route_info_length'=>#l4,
  'route_info_strip_length'=>#l4,'route_info_type'=>'strip',
  'route_info_weight'=>#l4,'width'=>##0.45}
```

After this PR, both runs produce identical bytes — `info` always
serialises these props as `##` (float).

A minimal **kfactory-only** repro (no gdsfactory/cspdk dependency)
lives in `tests/test_settings.py` as
`test_info_normalises_length_props_to_float`:

```python
assert Info(length=4).length == Info(length=4.0).length
assert isinstance(Info(length=4).length, float)
```

## Test Plan

- [x] `uv run pytest tests/test_settings.py tests/test_meta.py` — 33 passed
- [x] `uv run pytest tests/ -p no:randomly` — only pre-existing
  `test_connectivity.py` / `test_route_multi` failures (missing
  `tests/test_data/` fixtures, unrelated). All settings/meta/schematic/
  routing tests pass, including the int-annotated-`length`
  `test_schematic.test_netlist` (which would have broken under broader
  KCellSettings coercion, hence the narrower scope).
- New tests cover: float coercion on each allow-list key, bool
  preservation, non-allow-list key preservation, per-key assignment via
  `__setitem__`/`__setattr__`, and explicit non-coercion in
  `KCellSettings`.

[cspdk]: https://github.com/gdsfactory/cspdk