### PR TITLE
Avoid polygon changes from a VCell -> Cell conversion

### DIFF
--- a/src/kfactory/instance.py
+++ b/src/kfactory/instance.py
@@ -797,14 +797,6 @@ class VInstance(ProtoInstance[float], UMGeometricObject):
                 cell_.name = cell_name
                 for port in self.cell.ports:
                     cell_.add_port(port=port.copy(trans_))
-                for c_shapes in (
-                    cell_.shapes(layer) for layer in cell_.kcl.layer_indexes()
-                ):
-                    if not c_shapes.is_empty():
-                        r = kdb.Region(c_shapes)
-                        r.merge()
-                        c_shapes.clear()
-                        c_shapes.insert(r)
                 settings = self.cell.settings.model_copy()
                 settings_units = self.cell.settings_units.model_copy()
                 cell_.settings = settings
@@ -845,7 +837,7 @@ class VInstance(ProtoInstance[float], UMGeometricObject):
         if cell.kcl.layout_cell(cell_name) is None:
             tkcell = self.cell.dup()
             tkcell.name = cell_name
-            tkcell.flatten(True)
+            tkcell.flatten(merge=False)
             for layer in tkcell.kcl.layer_indexes():
                 tkcell.shapes(layer).transform(trans_)
             for _port in tkcell.ports:

--- a/src/kfactory/instance.py
+++ b/src/kfactory/instance.py
@@ -842,16 +842,12 @@ class VInstance(ProtoInstance[float], UMGeometricObject):
                 tkcell.shapes(layer).transform(trans_)
             for _port in tkcell.ports:
                 _port.dcplx_trans = trans_ * _port.dcplx_trans
-            if trans_ != kdb.DCplxTrans.R0:
-                tkcell._base.vtrans = trans_
-            settings = self.cell.settings.model_copy()
-            settings_units = self.cell.settings_units.model_copy()
-            tkcell.settings = settings
+            tkcell._base.vtrans = trans_
+            tkcell.settings = self.cell.settings.model_copy()
             tkcell.info = self.cell.info.model_copy(deep=True)
-            tkcell.settings_units = settings_units
+            tkcell.settings_units = self.cell.settings_units.model_copy()
             tkcell.function_name = self.cell.function_name
             tkcell.basename = self.cell.basename
-            tkcell._base.vtrans = trans_
         else:
             tkcell = cell.kcl[cell_name]
         inst_ = cell.create_inst(


### PR DESCRIPTION
## Summary

Avoid implicit polygon changes from a VCell -> Cell conversion.
This was partially handled with the `to_itype` change, but `merge` is doing this too.
Since it's happening on the parent's shape and the rest and child instances, it's a better default to avoid the merge.

There is some cleanup done as separate commits. Some dead code likely from refactors.

## Test Plan

<!-- How was it tested? -->
