### PR TITLE
rework factories, enclosure, and cross section registration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
         exclude: 'changelog\.d/.*|CHANGELOG\.md'
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.15.16
+    rev: v0.15.17
     hooks:
       # Run the linter.
       - id: ruff-check
@@ -32,7 +32,7 @@ repos:
       # Run the formatter.
       - id: ruff-format
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: v2.23.0
+    rev: v2.24.0
     hooks:
       - id: pyproject-fmt
   - repo: https://github.com/kynan/nbstripout

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 build-backend = "setuptools.build_meta"
-requires = [ "build", "setuptools>=74", "setuptools-scm[toml]>=8.1", "wheel" ]
+requires = [ "build", "setuptools>=74", "setuptools-scm[toml]>=8.1" ]
 
 [project]
 name = "kfactory"

--- a/src/kfactory/cross_section.py
+++ b/src/kfactory/cross_section.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from hashlib import sha1
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -16,6 +17,7 @@ from typing import (
 from pydantic import BaseModel, Field, PrivateAttr, model_validator
 
 from .enclosure import DLayerEnclosure, LayerEnclosure, LayerEnclosureSpec
+from .exceptions import CrossSectionNamingConflictError
 from .typings import dbu  # noqa: TC001
 
 if TYPE_CHECKING:
@@ -49,29 +51,39 @@ class SymmetricalCrossSection(BaseModel, frozen=True, arbitrary_types_allowed=Tr
     name: str = ""
     radius: dbu | None = None
     radius_min: dbu | None = None
-    bbox_sections: dict[kdb.LayerInfo, dbu]
 
     def __init__(
         self,
         width: dbu,
         enclosure: LayerEnclosure,
         name: str | None = None,
-        bbox_sections: dict[kdb.LayerInfo, dbu] | None = None,
         radius: dbu | None = None,
         radius_min: dbu | None = None,
     ) -> None:
-        """Initialized the CrossSection."""
+        """Initialized the CrossSection.
+
+        `bbox_sections` live on the `enclosure` — build the enclosure with them.
+        """
         super().__init__(
             width=width,
             enclosure=enclosure,
             name=name or f"{enclosure.name}_{width}",
-            bbox_sections=bbox_sections or {},
             radius=radius,
             radius_min=radius_min,
         )
 
+    @property
+    def bbox_sections(self) -> dict[kdb.LayerInfo, dbu]:
+        """Bounding-box sections (owned by the enclosure)."""
+        return self.enclosure.bbox_sections
+
     def auto_name(self) -> str:
         return f"{self.enclosure.name}_{self.width}"
+
+    @property
+    def is_named(self) -> bool:
+        """Whether an explicit name was given (vs. the enclosure-derived name)."""
+        return self.name != self.auto_name()
 
     @property
     def extent(self) -> dbu:
@@ -136,9 +148,21 @@ class SymmetricalCrossSection(BaseModel, frozen=True, arbitrary_types_allowed=Tr
         return super().model_copy(update=update, deep=deep)
 
     def __eq__(self, o: object) -> bool:
+        if isinstance(o, (AsymmetricalCrossSection, TAsymmetricCrossSection)):
+            return False
         if isinstance(o, TCrossSection):
-            return o == self
-        return super().__eq__(o)
+            return self == o.base
+        if isinstance(o, SymmetricalCrossSection):
+            # radius/radius_min are non-identifying metadata.
+            return (
+                self.width == o.width
+                and self.enclosure == o.enclosure
+                and self.name == o.name
+            )
+        return NotImplemented
+
+    def __hash__(self) -> int:
+        return hash((self.width, self.enclosure, self.name))
 
 
 class DSymmetricalCrossSection(BaseModel):
@@ -259,6 +283,51 @@ def _layer_sort_key(layer: kdb.LayerInfo) -> tuple[str, int, int]:
     return (layer.name, layer.layer, layer.datatype)
 
 
+def _asym_auto_name(
+    layer: kdb.LayerInfo,
+    section_min: int,
+    section_max: int,
+    sections: Sequence[CrossSectionLayer],
+    bbox_sections: Mapping[kdb.LayerInfo, int],
+) -> str:
+    """Deterministic structural name for an asymmetric cross section.
+
+    Hashes the geometry (layer, bounds, aux sections, bbox), excluding radius.
+    """
+    parts: list[Any] = [
+        str(layer),
+        section_min,
+        section_max,
+        [(str(s.layer), s.section_min, s.section_max) for s in sections],
+        sorted((str(k), v) for k, v in bbox_sections.items()),
+    ]
+    return "asym_" + sha1(str(parts).encode("UTF-8")).hexdigest()[-8:]  # noqa: S324
+
+
+def _resolve_radius(
+    canonical: SymmetricalCrossSection | AsymmetricalCrossSection,
+    incoming: SymmetricalCrossSection | AsymmetricalCrossSection,
+) -> SymmetricalCrossSection | AsymmetricalCrossSection:
+    """Resolve a re-registration of an already-registered profile.
+
+    Radius is excluded from the structural name, but a registered cross section is
+    a single source of truth: re-registering the same profile with a *different*
+    radius is a conflict and raises. To use a different bend radius for a specific
+    route, override it at the route/bend call — do not register a second profile.
+    """
+    if (incoming.radius is not None and incoming.radius != canonical.radius) or (
+        incoming.radius_min is not None and incoming.radius_min != canonical.radius_min
+    ):
+        raise CrossSectionNamingConflictError(
+            f"Cross section {canonical.name!r} is already registered with "
+            f"radius={canonical.radius}, radius_min={canonical.radius_min}; refusing "
+            f"to re-register the same profile with radius={incoming.radius}, "
+            f"radius_min={incoming.radius_min}. Override the radius at the route/bend "
+            "call instead."
+        )
+    return canonical
+
+
 def _normalize_sections(
     sections: Sequence[CrossSectionLayer] | tuple[CrossSectionLayer, ...],
 ) -> tuple[CrossSectionLayer, ...]:
@@ -335,12 +404,29 @@ class AsymmetricalCrossSection(BaseModel, frozen=True, arbitrary_types_allowed=T
                 coerced.append(CrossSectionLayer.model_validate(s))
         data["sections"] = _normalize_sections(coerced)
         if not data.get("name"):
-            layer = data["layer"]
-            data["name"] = (
-                f"asym_{layer.name or layer.layer}"
-                f"_{data['section_min']}_{data['section_max']}"
+            data["name"] = _asym_auto_name(
+                data["layer"],
+                data["section_min"],
+                data["section_max"],
+                data["sections"],
+                data.get("bbox_sections") or {},
             )
         return data
+
+    def auto_name(self) -> str:
+        """Deterministic structural name (hash of geometry, excluding radius)."""
+        return _asym_auto_name(
+            self.layer,
+            self.section_min,
+            self.section_max,
+            self.sections,
+            self.bbox_sections,
+        )
+
+    @property
+    def is_named(self) -> bool:
+        """Whether an explicit name was given (vs. the derived structural name)."""
+        return self.name != self.auto_name()
 
     @model_validator(mode="after")
     def _validate(self) -> Self:
@@ -406,9 +492,21 @@ class AsymmetricalCrossSection(BaseModel, frozen=True, arbitrary_types_allowed=T
         return super().model_copy(update=update, deep=deep)
 
     def __eq__(self, o: object) -> bool:
+        if isinstance(o, (SymmetricalCrossSection, TCrossSection)):
+            return False
         if isinstance(o, TAsymmetricCrossSection):
-            return o == self
-        return super().__eq__(o)
+            return self == o.base
+        if isinstance(o, AsymmetricalCrossSection):
+            # radius/radius_min are non-identifying metadata.
+            return (
+                self.layer == o.layer
+                and self.section_min == o.section_min
+                and self.section_max == o.section_max
+                and self.sections == o.sections
+                and self.name == o.name
+                and self.bbox_sections == o.bbox_sections
+            )
+        return NotImplemented
 
     def __hash__(self) -> int:
         return hash(
@@ -418,8 +516,6 @@ class AsymmetricalCrossSection(BaseModel, frozen=True, arbitrary_types_allowed=T
                 self.section_max,
                 self.sections,
                 self.name,
-                self.radius,
-                self.radius_min,
                 tuple(sorted(self.bbox_sections.items(), key=lambda kv: kv[0].name)),
             )
         )
@@ -938,12 +1034,14 @@ class CrossSection(TCrossSection[int]):
             base = kcl.get_symmetrical_cross_section(
                 SymmetricalCrossSection(
                     width=width,
-                    enclosure=LayerEnclosure(sections=sections, main_layer=layer),
+                    enclosure=LayerEnclosure(
+                        sections=sections,
+                        main_layer=layer,
+                        bbox_sections=list(
+                            zip(bbox_layers, bbox_offsets)  # noqa: B905
+                        ),
+                    ),
                     name=name,
-                    bbox_sections={
-                        s[0]: s[1]
-                        for s in zip(bbox_layers, bbox_offsets)  # noqa: B905
-                    },
                     radius=radius,
                     radius_min=radius_min,
                 )
@@ -1047,12 +1145,12 @@ class DCrossSection(TCrossSection[float]):
                             for s in sections
                         ],
                         main_layer=layer,
+                        bbox_sections=[
+                            (s[0], kcl.to_dbu(s[1]))
+                            for s in zip(bbox_layers, bbox_offsets)  # noqa: B905
+                        ],
                     ),
                     name=name,
-                    bbox_sections={
-                        s[0]: kcl.to_dbu(s[1])
-                        for s in zip(bbox_layers, bbox_offsets)  # noqa: B905
-                    },
                     radius=kcl.to_dbu(radius) if radius else None,
                     radius_min=kcl.to_dbu(radius_min) if radius_min else None,
                 )
@@ -1122,13 +1220,14 @@ class DCrossSectionSpec(TCrossSectionSpec[float]):
 
 
 class CrossSectionModel(BaseModel):
-    cross_sections: dict[str, SymmetricalCrossSection] = Field(default_factory=dict)
-    asymmetrical_cross_sections: dict[str, AsymmetricalCrossSection] = Field(
-        default_factory=dict
+    cross_sections: dict[str, SymmetricalCrossSection | AsymmetricalCrossSection] = (
+        Field(default_factory=dict)
     )
     kcl: KCLayout
 
-    def __getitem__(self, name: str) -> SymmetricalCrossSection:
+    def __getitem__(
+        self, name: str
+    ) -> SymmetricalCrossSection | AsymmetricalCrossSection:
         return self.cross_sections[name]
 
     def get_asymmetrical_cross_section(
@@ -1136,26 +1235,54 @@ class CrossSectionModel(BaseModel):
         cross_section: str | AsymmetricalCrossSection | DAsymmetricalCrossSection,
     ) -> AsymmetricalCrossSection:
         if isinstance(cross_section, str):
-            return self.asymmetrical_cross_sections[cross_section]
+            xs = self.cross_sections[cross_section]
+            if not isinstance(xs, AsymmetricalCrossSection):
+                raise TypeError(
+                    f"Cross section {cross_section!r} is symmetric; use "
+                    "get_(symmetrical_)cross_section."
+                )
+            return xs
         if isinstance(cross_section, DAsymmetricalCrossSection):
             cross_section = cross_section.to_itype(self.kcl)
-        if cross_section.name in self.cross_sections:
-            raise ValueError(
-                f"Name {cross_section.name!r} is already used by a symmetric"
-                " cross section. Cross section names must be unique across"
-                " symmetric and asymmetric kinds."
-            )
-        if cross_section.name not in self.asymmetrical_cross_sections:
-            self.asymmetrical_cross_sections[cross_section.name] = cross_section
+        registered = self._register(cross_section)
+        assert isinstance(registered, AsymmetricalCrossSection)
+        return registered
+
+    def _register(
+        self, cross_section: SymmetricalCrossSection | AsymmetricalCrossSection
+    ) -> SymmetricalCrossSection | AsymmetricalCrossSection:
+        """Register/resolve a cross section by its canonical (structural) name.
+
+        Entries are keyed by their `auto_name()` and, when named, additionally by
+        the explicit name. Existence is a single `get(auto_name())`.
+        """
+        auto = cross_section.auto_name()
+        canonical = self.cross_sections.get(auto)
+        if canonical is None:
+            if cross_section.is_named and cross_section.name in self.cross_sections:
+                raise CrossSectionNamingConflictError(
+                    f"Cross section name {cross_section.name!r} is already "
+                    "registered for a different structural signature."
+                )
+            self.cross_sections[auto] = cross_section
+            if cross_section.is_named:
+                self.cross_sections[cross_section.name] = cross_section
             return cross_section
-        xs = self.asymmetrical_cross_sections[cross_section.name]
-        if xs != cross_section:
-            raise ValueError(
-                "There is already an asymmetrical cross_section defined with name "
-                f"{cross_section.name}. Cannot overwrite cross_sections.\n"
-                f"old_xs={xs.model_dump()}\nnew_xs={cross_section.model_dump()}"
+        if not cross_section.is_named:
+            return _resolve_radius(canonical, cross_section)
+        if canonical.is_named:
+            if canonical.name == cross_section.name:
+                return _resolve_radius(canonical, cross_section)
+            raise CrossSectionNamingConflictError(
+                f"Cannot register cross section {cross_section.name!r}: the same "
+                f"structural signature is already registered as {canonical.name!r}."
+                " A structure can have at most one name."
             )
-        return xs
+        # Promote the unnamed canonical to the named one (radius must match).
+        _resolve_radius(canonical, cross_section)
+        self.cross_sections[auto] = cross_section
+        self.cross_sections[cross_section.name] = cross_section
+        return cross_section
 
     def get_cross_section(
         self,
@@ -1168,27 +1295,27 @@ class CrossSectionModel(BaseModel):
         | DCrossSection,
     ) -> SymmetricalCrossSection:
         if isinstance(cross_section, str):
-            return self.cross_sections[cross_section]
+            xs = self.cross_sections[cross_section]
+            if not isinstance(xs, SymmetricalCrossSection):
+                raise TypeError(
+                    f"Cross section {cross_section!r} is asymmetric; use "
+                    "get_asymmetrical_cross_section."
+                )
+            return xs
         if isinstance(cross_section, TCrossSection):
             cross_section = cross_section.base
         if isinstance(cross_section, SymmetricalCrossSection):
-            if cross_section.enclosure != self.kcl.get_enclosure(
-                cross_section.enclosure
-            ):
+            canonical_enc = self.kcl.get_enclosure(cross_section.enclosure)
+            if cross_section.enclosure != canonical_enc:
                 return self.get_cross_section(
                     SymmetricalCrossSection(
-                        enclosure=self.kcl.layer_enclosures.get_enclosure(
-                            LayerEnclosureSpec(
-                                sections=cross_section.enclosure.model_dump()[
-                                    "sections"
-                                ],
-                                main_layer=cross_section.main_layer,
-                                name=cross_section.enclosure._name,
-                            ),
-                            kcl=self.kcl,
-                        ),
-                        name=cross_section.name,
+                        enclosure=canonical_enc,
+                        # Preserve named/unnamed provenance: re-derive the auto
+                        # name from the canonical enclosure when unnamed.
+                        name=cross_section.name if cross_section.is_named else None,
                         width=cross_section.width,
+                        radius=cross_section.radius,
+                        radius_min=cross_section.radius_min,
                     )
                 )
         elif isinstance(cross_section, DSymmetricalCrossSection):
@@ -1229,23 +1356,9 @@ class CrossSectionModel(BaseModel):
                 ),
                 name=cross_section.get("name", None),
             )
-        if cross_section.name in self.asymmetrical_cross_sections:
-            raise ValueError(
-                f"Name {cross_section.name!r} is already used by an asymmetric"
-                " cross section. Cross section names must be unique across"
-                " symmetric and asymmetric kinds."
-            )
-        if cross_section.name not in self.cross_sections:
-            self.cross_sections[cross_section.name] = cross_section
-            return cross_section
-        xs = self.cross_sections[cross_section.name]
-        if not xs == cross_section:
-            raise ValueError(
-                "There is already a cross_section defined with name "
-                f"{cross_section.name}. Cannot overwrite cross_sections.\n"
-                f"old_xs={xs.model_dump()}\nnew_xs={cross_section.model_dump()}"
-            )
-        return xs
+        registered = self._register(cross_section)
+        assert isinstance(registered, SymmetricalCrossSection)
+        return registered
 
     def __repr__(self) -> str:
         return repr(self.cross_sections)

--- a/src/kfactory/decorators.py
+++ b/src/kfactory/decorators.py
@@ -19,6 +19,7 @@ from typing import (
     Protocol,
     TypedDict,
     Unpack,
+    final,
     get_origin,
     overload,
 )
@@ -355,6 +356,7 @@ def _post_process[K: ProtoKCell[Any, Any]](
         pp(cell)
 
 
+@final
 class WrappedKCellFunc[**KCellParams, KC: ProtoTKCell[Any]]:
     _f: Callable[KCellParams, KC]
     _f_orig: Callable[KCellParams, ProtoTKCell[Any]]
@@ -655,6 +657,7 @@ class WrappedKCellFunc[**KCellParams, KC: ProtoTKCell[Any]]:
         return self._f_schematic(*args, **kwargs)
 
 
+@final
 class WrappedVKCellFunc[**VKCellParams, VK: VKCell]:
     _f: Callable[VKCellParams, VK]
     _f_orig: Callable[VKCellParams, VKCell]

--- a/src/kfactory/enclosure.py
+++ b/src/kfactory/enclosure.py
@@ -35,6 +35,7 @@ from typing_extensions import TypedDict
 
 from . import kdb
 from .conf import config, logger
+from .exceptions import CrossSectionNamingConflictError
 
 if TYPE_CHECKING:
     from collections.abc import (
@@ -621,6 +622,28 @@ class LayerEnclosure(BaseModel, arbitrary_types_allowed=True, frozen=True):
         """Get name of the Enclosure."""
         return self.__str__()
 
+    @property
+    def is_named(self) -> bool:
+        """Whether an explicit name was given (vs. a derived structural name)."""
+        return self._name is not None
+
+    @property
+    def unnamed_key(self) -> str:
+        """Deterministic structural key, independent of the explicit name.
+
+        This is the same hash an unnamed enclosure is named after. Exposing it on
+        named enclosures as well lets the registry alias the structural signature
+        to a named enclosure.
+        """
+        list_to_hash: list[tuple[str, ...]] = [(str(self.main_layer),)]
+        for layer, layer_section in self.layer_sections.items():
+            list_to_hash.append((str(layer), str(layer_section.sections)))
+        for layer, offset in sorted(
+            self.bbox_sections.items(), key=lambda kv: str(kv[0])
+        ):
+            list_to_hash.append((str(layer), "bbox", str(offset)))
+        return sha1(str(list_to_hash).encode("UTF-8")).hexdigest()[-8:]  # noqa: S324
+
     def minkowski_region(
         self,
         r: kdb.Region,
@@ -986,10 +1009,7 @@ class LayerEnclosure(BaseModel, arbitrary_types_allowed=True, frozen=True):
         """
         if self._name is not None:
             return self._name
-        list_to_hash: list[tuple[str, ...]] = [(str(self.main_layer),)]
-        for layer, layer_section in self.layer_sections.items():
-            list_to_hash.append((str(layer), str(layer_section.sections)))
-        return sha1(str(list_to_hash).encode("UTF-8")).hexdigest()[-8:]  # noqa: S324
+        return self.unnamed_key
 
     def extrude_path(
         self,
@@ -1635,13 +1655,26 @@ class LayerEnclosureModel(RootModel[dict[str, LayerEnclosure]]):
         """Add a new LayerEnclosure."""
         self.root[__key] = __val
 
+    def _canonical_for_unnamed_key(self, unnamed_key: str) -> LayerEnclosure | None:
+        """Return the registered enclosure whose structural signature matches."""
+        for enc in self.root.values():
+            if enc.unnamed_key == unnamed_key:
+                return enc
+        return None
+
     def get_enclosure(
         self,
         enclosure: str | LayerEnclosure | LayerEnclosureSpec,
         kcl: KCLayout,
     ) -> LayerEnclosure:
         if isinstance(enclosure, str):
-            return self[enclosure]
+            if enclosure in self.root:
+                return self.root[enclosure]
+            # Also addressable by the structural (unnamed) key.
+            existing = self._canonical_for_unnamed_key(enclosure)
+            if existing is not None:
+                return existing
+            return self.root[enclosure]
         if isinstance(enclosure, dict):
             if "dsections" in enclosure:
                 enclosure = LayerEnclosure(
@@ -1658,10 +1691,35 @@ class LayerEnclosureModel(RootModel[dict[str, LayerEnclosure]]):
                     kcl=kcl,
                 )
         enclosure = cast("LayerEnclosure", enclosure)
-        if enclosure.name not in self.root:
+        key = enclosure.unnamed_key
+        existing = self._canonical_for_unnamed_key(key)
+
+        if not enclosure.is_named:
+            # Unnamed request: reuse the canonical entry if the signature is known.
+            if existing is not None:
+                return existing
             self.root[enclosure.name] = enclosure
             return enclosure
-        return self.root[enclosure.name]
+
+        # Named request.
+        name = enclosure.name
+        if name in self.root:
+            # The name is already claimed: preserve the existing (lenient) name-keyed
+            # behavior and return the registered enclosure.
+            return self.root[name]
+        if existing is None:
+            self.root[name] = enclosure
+            return enclosure
+        if existing.is_named:
+            raise CrossSectionNamingConflictError(
+                f"Cannot register enclosure {name!r}: an enclosure with the same "
+                f"structural signature is already registered as {existing.name!r}. "
+                "A structure can have at most one name."
+            )
+        # Promote: the named enclosure replaces the existing unnamed one.
+        self.root.pop(existing.name, None)
+        self.root[name] = enclosure
+        return enclosure
 
 
 def _add_section(

--- a/src/kfactory/exceptions.py
+++ b/src/kfactory/exceptions.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
 __all__ = [
     "AsymmetricMirrorRequiredError",
     "CellNameError",
+    "CrossSectionNamingConflictError",
     "CrossSectionSymmetryMismatchError",
     "FactoriesLockedError",
     "InvalidLayerError",
@@ -42,6 +43,16 @@ class FactoriesLockedError(RuntimeError):
 
 class MergeError(ValueError):
     """Raised if two layout's have conflicting cell definitions."""
+
+
+class CrossSectionNamingConflictError(ValueError):
+    """Raised when a second name is registered for an existing structural signature.
+
+    Cross sections and enclosures are canonicalized by their name-independent
+    structural signature. A given signature may have at most one *named* canonical
+    entry; attempting to register a second, differently-named entry for the same
+    signature (or to reuse a name for a different signature) raises this error.
+    """
 
 
 class PortWidthMismatchError(ValueError):

--- a/src/kfactory/kcell.py
+++ b/src/kfactory/kcell.py
@@ -61,9 +61,12 @@ from .checks import (
 from .conf import DEFAULT_TRANS, CheckInstances, ShowFunction, config, logger
 from .cross_section import (
     AsymmetricalCrossSection,
+    AsymmetricCrossSection,
     CrossSection,
+    DAsymmetricCrossSection,
     DCrossSection,
     SymmetricalCrossSection,
+    TAsymmetricCrossSection,
     TCrossSection,
 )
 from .exceptions import LockedError, MergeError
@@ -1719,7 +1722,7 @@ class ProtoTKCell[T: (int, float)](ProtoKCell[T, TKCell], ABC):
                 if not self.is_library_cell():
                     for index in sorted(port_dict.keys()):
                         v = port_dict[index]
-                        xs = self.kcl.get_cross_section(
+                        xs = self.kcl.get_base_cross_section(
                             v["cross_section"], symmetrical=None
                         )
                         trans_: kdb.Trans | None = v.get("trans")
@@ -1756,7 +1759,7 @@ class ProtoTKCell[T: (int, float)](ProtoKCell[T, TKCell], ABC):
                         v = port_dict[index]
                         trans_ = v.get("trans")
                         lib_kcl = kcls[lib_name]
-                        lib_xs = lib_kcl.get_cross_section(
+                        lib_xs = lib_kcl.get_base_cross_section(
                             v["cross_section"], symmetrical=None
                         )
                         cs: SymmetricalCrossSection | AsymmetricalCrossSection
@@ -2363,9 +2366,10 @@ class ProtoTKCell[T: (int, float)](ProtoKCell[T, TKCell], ABC):
         cross_section: str
         | dict[str, Any]
         | Callable[..., CrossSection | DCrossSection]
-        | SymmetricalCrossSection,
+        | SymmetricalCrossSection
+        | AsymmetricalCrossSection,
         **cross_section_kwargs: Any,
-    ) -> TCrossSection[T]: ...
+    ) -> TCrossSection[T] | TAsymmetricCrossSection[T]: ...
 
     @property
     def lvs_equivalent_ports(self) -> list[list[str]] | None:
@@ -2563,29 +2567,21 @@ class DKCell(ProtoTKCell[float], UMGeometricObject, DCreatePort):
         cross_section: str
         | dict[str, Any]
         | Callable[..., CrossSection | DCrossSection]
-        | SymmetricalCrossSection,
+        | SymmetricalCrossSection
+        | AsymmetricalCrossSection,
         **cross_section_kwargs: Any,
-    ) -> DCrossSection:
-        if isinstance(cross_section, str):
-            return DCrossSection(
-                kcl=self.kcl,
-                base=self.kcl.cross_sections.get_cross_section(cross_section),
-            )
-        if isinstance(cross_section, SymmetricalCrossSection):
-            return DCrossSection(kcl=self.kcl, base=cross_section)
+    ) -> DCrossSection | DAsymmetricCrossSection:
         if callable(cross_section):
-            any_cross_section = cross_section(**cross_section_kwargs)  # ty:ignore[call-top-callable]
-            return DCrossSection(kcl=self.kcl, base=any_cross_section._base)  # ty:ignore[unresolved-attribute]
-        if isinstance(cross_section, dict):
+            return self.kcl.get_dcross_section(
+                cross_section(**cross_section_kwargs)  # ty:ignore[call-top-callable]
+            )
+        if isinstance(cross_section, dict) and "settings" in cross_section:
             return DCrossSection(
                 kcl=self.kcl,
                 name=cross_section.get("name"),
                 **cross_section["settings"],
             )
-        raise ValueError(
-            "Cannot create a cross section from "
-            f"{type(cross_section)=} and {cross_section_kwargs=}"
-        )
+        return self.kcl.get_dcross_section(cross_section)
 
     @property
     def library_cell(self) -> DKCell:
@@ -3037,29 +3033,21 @@ class KCell(ProtoTKCell[int], DBUGeometricObject, ICreatePort):
         cross_section: str
         | dict[str, Any]
         | Callable[..., CrossSection | DCrossSection]
-        | SymmetricalCrossSection,
+        | SymmetricalCrossSection
+        | AsymmetricalCrossSection,
         **cross_section_kwargs: Any,
-    ) -> CrossSection:
-        if isinstance(cross_section, str):
-            return CrossSection(
-                kcl=self.kcl,
-                base=self.kcl.cross_sections.get_cross_section(cross_section),
-            )
-        if isinstance(cross_section, SymmetricalCrossSection):
-            return CrossSection(kcl=self.kcl, base=cross_section)
+    ) -> CrossSection | AsymmetricCrossSection:
         if callable(cross_section):
-            any_cross_section = cross_section(**cross_section_kwargs)  # ty:ignore[call-top-callable]
-            return CrossSection(kcl=self.kcl, base=any_cross_section._base)  # ty:ignore[unresolved-attribute]
-        if isinstance(cross_section, dict):
+            return self.kcl.get_icross_section(
+                cross_section(**cross_section_kwargs)  # ty:ignore[call-top-callable]
+            )
+        if isinstance(cross_section, dict) and "settings" in cross_section:
             return CrossSection(
                 kcl=self.kcl,
                 name=cross_section.get("name"),
                 **cross_section["settings"],
             )
-        raise ValueError(
-            "Cannot create a cross section from "
-            f"{type(cross_section)=} and {cross_section_kwargs=}"
-        )
+        return self.kcl.get_icross_section(cross_section)
 
     def __getattr__(self, name: str) -> Any:
         """If KCell doesn't have an attribute, look in the KLayout Cell."""
@@ -3162,6 +3150,27 @@ class VKCell(ProtoKCell[float, TVCell], UMGeometricObject, DCreatePort):
     def __getitem__(self, key: int | str | None) -> DPort:
         """Returns port from instance."""
         return self.ports[key]
+
+    def get_cross_section(
+        self,
+        cross_section: str
+        | dict[str, Any]
+        | Callable[..., CrossSection | DCrossSection]
+        | SymmetricalCrossSection
+        | AsymmetricalCrossSection,
+        **cross_section_kwargs: Any,
+    ) -> DCrossSection | DAsymmetricCrossSection:
+        if callable(cross_section):
+            return self.kcl.get_dcross_section(
+                cross_section(**cross_section_kwargs)  # ty:ignore[call-top-callable]
+            )
+        if isinstance(cross_section, dict) and "settings" in cross_section:
+            return DCrossSection(
+                kcl=self.kcl,
+                name=cross_section.get("name"),
+                **cross_section["settings"],
+            )
+        return self.kcl.get_dcross_section(cross_section)
 
     @property
     def insts(self) -> VInstances:

--- a/src/kfactory/kcell.py
+++ b/src/kfactory/kcell.py
@@ -1719,7 +1719,9 @@ class ProtoTKCell[T: (int, float)](ProtoKCell[T, TKCell], ABC):
                 if not self.is_library_cell():
                     for index in sorted(port_dict.keys()):
                         v = port_dict[index]
-                        xs = self.kcl.get_cross_section(v["cross_section"], kind="any")
+                        xs = self.kcl.get_cross_section(
+                            v["cross_section"], symmetrical=None
+                        )
                         trans_: kdb.Trans | None = v.get("trans")
                         if trans_ is not None:
                             ports[index] = self.create_port(
@@ -1755,7 +1757,7 @@ class ProtoTKCell[T: (int, float)](ProtoKCell[T, TKCell], ABC):
                         trans_ = v.get("trans")
                         lib_kcl = kcls[lib_name]
                         lib_xs = lib_kcl.get_cross_section(
-                            v["cross_section"], kind="any"
+                            v["cross_section"], symmetrical=None
                         )
                         cs: SymmetricalCrossSection | AsymmetricalCrossSection
                         if isinstance(lib_xs, SymmetricalCrossSection):
@@ -2566,7 +2568,8 @@ class DKCell(ProtoTKCell[float], UMGeometricObject, DCreatePort):
     ) -> DCrossSection:
         if isinstance(cross_section, str):
             return DCrossSection(
-                kcl=self.kcl, base=self.kcl.cross_sections[cross_section]
+                kcl=self.kcl,
+                base=self.kcl.cross_sections.get_cross_section(cross_section),
             )
         if isinstance(cross_section, SymmetricalCrossSection):
             return DCrossSection(kcl=self.kcl, base=cross_section)
@@ -3039,7 +3042,8 @@ class KCell(ProtoTKCell[int], DBUGeometricObject, ICreatePort):
     ) -> CrossSection:
         if isinstance(cross_section, str):
             return CrossSection(
-                kcl=self.kcl, base=self.kcl.cross_sections[cross_section]
+                kcl=self.kcl,
+                base=self.kcl.cross_sections.get_cross_section(cross_section),
             )
         if isinstance(cross_section, SymmetricalCrossSection):
             return CrossSection(kcl=self.kcl, base=cross_section)

--- a/src/kfactory/layout.py
+++ b/src/kfactory/layout.py
@@ -208,14 +208,14 @@ class Factories[F: WrappedKCellFunc[Any, Any] | WrappedVKCellFunc[Any, Any]](
             ) from e
 
     @overload
-    def get(self, key: str, /) -> F | None: ...
+    def get(self, key: object, /) -> F | None: ...
 
     @overload
-    def get(self, key: str, /, default: T) -> F | T: ...
+    def get(self, key: object, /, default: T) -> F | T: ...
 
-    def get(self, key: str, /, default: T | None = None) -> F | T | None:
+    def get(self, key: object, /, default: T | None = None) -> F | T | None:
         if key in self._by_name:
-            return self.get_by_name(key)
+            return self.get_by_name(cast("str", key))
         return default
 
     def get_by_path(self, path: str | Path) -> list[F]:
@@ -274,6 +274,9 @@ class KCLayout(
 
     factories: Factories[WrappedKCellFunc[Any, ProtoTKCell[Any]]]
     virtual_factories: Factories[WrappedVKCellFunc[Any, VKCell]]
+    generic_factories: dict[
+        str, Callable[..., ProtoTKCell[Any]] | Callable[..., VKCell]
+    ] = Field(default_factory=dict)
     tkcells: dict[int, TKCell] = Field(default_factory=dict)
     infos: LayerInfos
     layer_stack: LayerStack
@@ -2140,42 +2143,43 @@ class KCLayout(
                     True,
                 )
             )
-        for cross_section in self.cross_sections.cross_sections.values():
-            self.add_meta_info(
-                kdb.LayoutMetaInfo(
-                    f"kfactory:cross_section:{cross_section.name}",
-                    {
-                        "width": cross_section.width,
-                        "layer_enclosure": cross_section.enclosure.name,
-                    },
-                    None,
-                    True,
+        for xs in set(self.cross_sections.cross_sections.values()):
+            if isinstance(xs, AsymmetricalCrossSection):
+                self.add_meta_info(
+                    kdb.LayoutMetaInfo(
+                        f"kfactory:asymmetrical_cross_section:{xs.name}",
+                        {
+                            "layer": xs.layer,
+                            "section_min": xs.section_min,
+                            "section_max": xs.section_max,
+                            "sections": [
+                                {
+                                    "layer": s.layer,
+                                    "section_min": s.section_min,
+                                    "section_max": s.section_max,
+                                }
+                                for s in xs.sections
+                            ],
+                            "radius": xs.radius,
+                            "radius_min": xs.radius_min,
+                            "bbox_sections": xs.bbox_sections,
+                        },
+                        None,
+                        True,
+                    )
                 )
-            )
-        for acs in self.cross_sections.asymmetrical_cross_sections.values():
-            self.add_meta_info(
-                kdb.LayoutMetaInfo(
-                    f"kfactory:asymmetrical_cross_section:{acs.name}",
-                    {
-                        "layer": acs.layer,
-                        "section_min": acs.section_min,
-                        "section_max": acs.section_max,
-                        "sections": [
-                            {
-                                "layer": s.layer,
-                                "section_min": s.section_min,
-                                "section_max": s.section_max,
-                            }
-                            for s in acs.sections
-                        ],
-                        "radius": acs.radius,
-                        "radius_min": acs.radius_min,
-                        "bbox_sections": acs.bbox_sections,
-                    },
-                    None,
-                    True,
+            else:
+                self.add_meta_info(
+                    kdb.LayoutMetaInfo(
+                        f"kfactory:cross_section:{xs.name}",
+                        {
+                            "width": xs.width,
+                            "layer_enclosure": xs.enclosure.name,
+                        },
+                        None,
+                        True,
+                    )
                 )
-            )
 
     def write(
         self,
@@ -2281,7 +2285,7 @@ class KCLayout(
         | DCrossSectionSpec
         | DSymmetricalCrossSection
         | TCrossSection[Any],
-        kind: Literal["symmetric"] = "symmetric",
+        symmetrical: Literal[True],
     ) -> SymmetricalCrossSection: ...
 
     @overload
@@ -2291,47 +2295,38 @@ class KCLayout(
         | AsymmetricalCrossSection
         | DAsymmetricalCrossSection
         | TAsymmetricCrossSection[Any],
-        kind: Literal["asymmetric"],
+        symmetrical: Literal[False],
     ) -> AsymmetricalCrossSection: ...
 
     @overload
     def get_cross_section(
         self,
-        cross_section: str
-        | SymmetricalCrossSection
-        | CrossSectionSpec
-        | DCrossSectionSpec
-        | DSymmetricalCrossSection
-        | TCrossSection[Any]
-        | AsymmetricalCrossSection
-        | DAsymmetricalCrossSection
-        | TAsymmetricCrossSection[Any],
-        kind: Literal["any"],
+        cross_section: Any,
+        symmetrical: None = None,
     ) -> SymmetricalCrossSection | AsymmetricalCrossSection: ...
 
     def get_cross_section(
         self,
         cross_section: Any,
-        kind: Literal["symmetric", "asymmetric", "any"] = "symmetric",
+        symmetrical: bool | None = None,
     ) -> SymmetricalCrossSection | AsymmetricalCrossSection:
         """Get a cross section by name or instance.
 
         Args:
             cross_section: name, spec, or instance.
-            kind: which container to look up. `"symmetric"` (default) accepts
-                symmetric inputs only. `"asymmetric"` accepts asymmetric inputs
-                only. `"any"` accepts either and dispatches by input type; for
-                string names, symmetric is checked first then asymmetric.
+            symmetrical: kind filter. `None` (default) returns either kind,
+                dispatching by input type (string names are looked up directly).
+                `True` returns a symmetric cross section and raises if the resolved
+                one is asymmetric. `False` returns an asymmetric cross section and
+                raises if the resolved one is symmetric.
         """
-        if kind == "symmetric":
+        if symmetrical is True:
             return self.get_symmetrical_cross_section(cross_section)
-        if kind == "asymmetric":
+        if symmetrical is False:
             return self.get_asymmetrical_cross_section(cross_section)
         if isinstance(cross_section, str):
             if cross_section in self.cross_sections.cross_sections:
                 return self.cross_sections.cross_sections[cross_section]
-            if cross_section in self.cross_sections.asymmetrical_cross_sections:
-                return self.cross_sections.asymmetrical_cross_sections[cross_section]
             raise KeyError(
                 f"No cross section named {cross_section!r} (symmetric or asymmetric)."
             )
@@ -2347,6 +2342,7 @@ class KCLayout(
         # spec dicts (CrossSectionSpec / DCrossSectionSpec) are always symmetric
         return self.get_symmetrical_cross_section(cross_section)
 
+    @overload
     def get_icross_section(
         self,
         cross_section: str
@@ -2356,12 +2352,39 @@ class KCLayout(
         | DCrossSection
         | DSymmetricalCrossSection
         | CrossSection,
-    ) -> CrossSection:
-        """Get a cross section by name or specification."""
-        return CrossSection(
-            kcl=self, base=self.cross_sections.get_cross_section(cross_section)
-        )
+        symmetrical: Literal[True],
+    ) -> CrossSection: ...
+    @overload
+    def get_icross_section(
+        self,
+        cross_section: str
+        | AsymmetricalCrossSection
+        | DAsymmetricalCrossSection
+        | TAsymmetricCrossSection[Any],
+        symmetrical: Literal[False],
+    ) -> AsymmetricCrossSection: ...
+    @overload
+    def get_icross_section(
+        self, cross_section: Any, symmetrical: None = None
+    ) -> CrossSection | AsymmetricCrossSection: ...
+    def get_icross_section(
+        self, cross_section: Any, symmetrical: bool | None = None
+    ) -> CrossSection | AsymmetricCrossSection:
+        """Get a dbu cross section wrapper (symmetric or asymmetric, see kwarg)."""
+        if symmetrical is True:
+            return CrossSection(
+                kcl=self, base=self.get_symmetrical_cross_section(cross_section)
+            )
+        if symmetrical is False:
+            return AsymmetricCrossSection(
+                kcl=self, base=self.get_asymmetrical_cross_section(cross_section)
+            )
+        xs = self.get_cross_section(cross_section)
+        if isinstance(xs, AsymmetricalCrossSection):
+            return AsymmetricCrossSection(kcl=self, base=xs)
+        return CrossSection(kcl=self, base=xs)
 
+    @overload
     def get_dcross_section(
         self,
         cross_section: str
@@ -2371,11 +2394,37 @@ class KCLayout(
         | DSymmetricalCrossSection
         | CrossSection
         | DCrossSection,
-    ) -> DCrossSection:
-        """Get a cross section by name or specification."""
-        return DCrossSection(
-            kcl=self, base=self.cross_sections.get_cross_section(cross_section)
-        )
+        symmetrical: Literal[True],
+    ) -> DCrossSection: ...
+    @overload
+    def get_dcross_section(
+        self,
+        cross_section: str
+        | AsymmetricalCrossSection
+        | DAsymmetricalCrossSection
+        | TAsymmetricCrossSection[Any],
+        symmetrical: Literal[False],
+    ) -> DAsymmetricCrossSection: ...
+    @overload
+    def get_dcross_section(
+        self, cross_section: Any, symmetrical: None = None
+    ) -> DCrossSection | DAsymmetricCrossSection: ...
+    def get_dcross_section(
+        self, cross_section: Any, symmetrical: bool | None = None
+    ) -> DCrossSection | DAsymmetricCrossSection:
+        """Get a um cross section wrapper (symmetric or asymmetric, see kwarg)."""
+        if symmetrical is True:
+            return DCrossSection(
+                kcl=self, base=self.get_symmetrical_cross_section(cross_section)
+            )
+        if symmetrical is False:
+            return DAsymmetricCrossSection(
+                kcl=self, base=self.get_asymmetrical_cross_section(cross_section)
+            )
+        xs = self.get_cross_section(cross_section)
+        if isinstance(xs, AsymmetricalCrossSection):
+            return DAsymmetricCrossSection(kcl=self, base=xs)
+        return DCrossSection(kcl=self, base=xs)
 
     def get_iasymmetric_cross_section(
         self,
@@ -2428,6 +2477,61 @@ class KCLayout(
     ]:
         self.routing_strategies[get_function_name(f)] = f
         return f
+
+    @overload
+    def generic_factory[F: Callable[..., ProtoTKCell[Any]] | Callable[..., VKCell]](
+        self, f: F, *, name: str | None = None
+    ) -> F: ...
+    @overload
+    def generic_factory[F: Callable[..., ProtoTKCell[Any]] | Callable[..., VKCell]](
+        self, *, name: str | None = None
+    ) -> Callable[[F], F]: ...
+    def generic_factory[F: Callable[..., ProtoTKCell[Any]] | Callable[..., VKCell]](
+        self,
+        f: F | None = None,
+        *,
+        name: str | None = None,
+    ) -> F | Callable[[F], F]:
+        """Register an arbitrary cell-producing function as a generic factory.
+
+        Generic factories are stored in `KCLayout.generic_factories`, separate
+        from the `factories` / `virtual_factories` registries. They are expected
+        to delegate to one of the real (cached) factories, so they need no cache
+        of their own. On every call the returned cell's `kcl` is checked against
+        this layout.
+
+        Can be used bare (`@kcl.generic_factory`), with a custom name
+        (`@kcl.generic_factory(name="...")`), or as a direct call
+        (`kcl.generic_factory(func, name="...")`).
+
+        Args:
+            f: A callable returning a `(D)KCell` or `VKCell`.
+            name: Name to register under. Defaults to the function's name.
+
+        Returns:
+            The wrapped function (guardrail-checked) registered under `name`.
+        """
+
+        def register(func: F) -> F:
+            factory_name = name or get_function_name(func)
+
+            @functools.wraps(func)
+            def wrapper(*args: Any, **kwargs: Any) -> ProtoTKCell[Any] | VKCell:
+                c = func(*args, **kwargs)
+                if c.kcl is not self:
+                    raise ValueError(
+                        f"generic_factory {factory_name!r} returned a cell from"
+                        f" KCLayout {c.kcl.name!r}, expected {self.name!r}."
+                    )
+                return c
+
+            registered = cast(
+                "Callable[..., ProtoTKCell[Any]] | Callable[..., VKCell]", wrapper
+            )
+            self.generic_factories[factory_name] = registered
+            return cast("F", registered)
+
+        return register if f is None else register(f)
 
 
 ManhattanRoute.model_rebuild()

--- a/src/kfactory/layout.py
+++ b/src/kfactory/layout.py
@@ -2277,7 +2277,7 @@ class KCLayout(
         return self.cross_sections.get_asymmetrical_cross_section(cross_section)
 
     @overload
-    def get_cross_section(
+    def get_base_cross_section(
         self,
         cross_section: str
         | SymmetricalCrossSection
@@ -2289,7 +2289,7 @@ class KCLayout(
     ) -> SymmetricalCrossSection: ...
 
     @overload
-    def get_cross_section(
+    def get_base_cross_section(
         self,
         cross_section: str
         | AsymmetricalCrossSection
@@ -2299,13 +2299,13 @@ class KCLayout(
     ) -> AsymmetricalCrossSection: ...
 
     @overload
-    def get_cross_section(
+    def get_base_cross_section(
         self,
         cross_section: Any,
         symmetrical: None = None,
     ) -> SymmetricalCrossSection | AsymmetricalCrossSection: ...
 
-    def get_cross_section(
+    def get_base_cross_section(
         self,
         cross_section: Any,
         symmetrical: bool | None = None,
@@ -2379,7 +2379,7 @@ class KCLayout(
             return AsymmetricCrossSection(
                 kcl=self, base=self.get_asymmetrical_cross_section(cross_section)
             )
-        xs = self.get_cross_section(cross_section)
+        xs = self.get_base_cross_section(cross_section)
         if isinstance(xs, AsymmetricalCrossSection):
             return AsymmetricCrossSection(kcl=self, base=xs)
         return CrossSection(kcl=self, base=xs)
@@ -2421,7 +2421,7 @@ class KCLayout(
             return DAsymmetricCrossSection(
                 kcl=self, base=self.get_asymmetrical_cross_section(cross_section)
             )
-        xs = self.get_cross_section(cross_section)
+        xs = self.get_base_cross_section(cross_section)
         if isinstance(xs, AsymmetricalCrossSection):
             return DAsymmetricCrossSection(kcl=self, base=xs)
         return DCrossSection(kcl=self, base=xs)

--- a/src/kfactory/routing/electrical.py
+++ b/src/kfactory/routing/electrical.py
@@ -869,7 +869,8 @@ def place_rf_rails(
         SymmetricalCrossSection(
             width=p1.width,
             enclosure=enclosure or LayerEnclosure(sections=[], main_layer=layer_info),
-        )
+        ),
+        symmetrical=True,
     )
     route_start_port = p1.copy()
     route_start_port.name = "route_start"

--- a/src/kfactory/schematic.py
+++ b/src/kfactory/schematic.py
@@ -75,7 +75,12 @@ if TYPE_CHECKING:
 
     from klayout import rdb
 
-    from .cross_section import CrossSection, DCrossSection
+    from .cross_section import (
+        AsymmetricCrossSection,
+        CrossSection,
+        DAsymmetricCrossSection,
+        DCrossSection,
+    )
 
 __all__ = [
     "Constraint",
@@ -1120,7 +1125,13 @@ class TSchematic[T: (int, float)](BaseModel, extra="forbid"):
         self,
         name: str,
         cell: KCell,
-        cross_sections: Mapping[str, CrossSection | DCrossSection],
+        cross_sections: Mapping[
+            str,
+            CrossSection
+            | DCrossSection
+            | AsymmetricCrossSection
+            | DAsymmetricCrossSection,
+        ],
     ) -> BasePort:
         """Materialize a schematic-level port on `cell`.
 
@@ -1550,7 +1561,14 @@ class TSchematic[T: (int, float)](BaseModel, extra="forbid"):
             str, Callable[..., KCell] | Callable[..., DKCell] | Callable[..., VKCell]
         ]
         | None = None,
-        cross_sections: Mapping[str, CrossSection | DCrossSection] | None = None,
+        cross_sections: Mapping[
+            str,
+            CrossSection
+            | DCrossSection
+            | AsymmetricCrossSection
+            | DAsymmetricCrossSection,
+        ]
+        | None = None,
         routing_strategies: dict[
             str,
             Callable[
@@ -2256,7 +2274,7 @@ class TSchematic[T: (int, float)](BaseModel, extra="forbid"):
             if isinstance(factory, WrappedKCellFunc):
                 is_schematic_inst = factory.schematic_driven()
                 if is_schematic_inst:
-                    _schematic = factory._f_schematic(**settings)  # ty:ignore[call-top-callable, call-non-callable]
+                    _schematic = factory._f_schematic(**settings)  # ty:ignore[call-non-callable]
                     port_positions = _schematic.get_port_positions(factories=factories)
                     port_directions: dict[str | None, float] = {}
                     for port_name in port_positions["right"]:
@@ -2287,7 +2305,7 @@ class TSchematic[T: (int, float)](BaseModel, extra="forbid"):
                     if isinstance(factory, WrappedKCellFunc):
                         is_schematic_inst = factory.schematic_driven()
                         if is_schematic_inst:
-                            _schematic = factory._f_schematic(**inst.settings)  # ty:ignore[call-top-callable, call-non-callable]
+                            _schematic = factory._f_schematic(**inst.settings)  # ty:ignore[call-non-callable]
                             inst_ports = _schematic.get_port_positions(
                                 factories=factories
                             )
@@ -2362,7 +2380,7 @@ class TSchematic[T: (int, float)](BaseModel, extra="forbid"):
                 if isinstance(factory, WrappedKCellFunc):
                     is_schematic_inst = factory.schematic_driven()
                     if is_schematic_inst:
-                        _schematic = factory._f_schematic(**inst.settings)  # ty:ignore[call-non-callable, call-top-callable]
+                        _schematic = factory._f_schematic(**inst.settings)  # ty:ignore[call-non-callable]
                         inst_ports = _schematic.get_port_positions(factories=factories)
                         found = False
 
@@ -2525,10 +2543,10 @@ def _get_instance_orientation[T: (int, float)](
             continue
         orientation = _get_instance_orientation(
             inst,
-            schematic,
+            schematic,  # ty:ignore[invalid-argument-type]
             visited_instances_,
             get_port_orientation_f=get_port_orientation_f,
-            instance_connections=instance_connections,
+            instance_connections=instance_connections,  # ty:ignore[invalid-argument-type]
         )
         if orientation is not None:
             for connection in instance_connections[instance]:
@@ -2810,7 +2828,10 @@ def _place_island[T: (int, float)](
     placed_insts: set[str],
     placed_ports: set[str],
     schematic: TSchematic[T],
-    cross_sections: Mapping[str, CrossSection | DCrossSection],
+    cross_sections: Mapping[
+        str,
+        CrossSection | DCrossSection | AsymmetricCrossSection | DAsymmetricCrossSection,
+    ],
     factories: Mapping[
         str, Callable[..., KCell] | Callable[..., DKCell] | Callable[..., VKCell]
     ]
@@ -3068,7 +3089,10 @@ def _get_and_place_insts_and_ports[T: (int, float)](
     schematic: TSchematic[T],
     instances: dict[str, Instance | VInstance],
     placed_island_insts: set[str],
-    cross_sections: Mapping[str, CrossSection | DCrossSection],
+    cross_sections: Mapping[
+        str,
+        CrossSection | DCrossSection | AsymmetricCrossSection | DAsymmetricCrossSection,
+    ],
 ) -> bool:
     placeable_insts, placeable_ports = _get_placeable(
         placed_insts=placed_insts,

--- a/src/kfactory/session_cache.py
+++ b/src/kfactory/session_cache.py
@@ -157,10 +157,15 @@ def save_session(
         }
         with (kcl_dir / "factories.pkl").open("wb") as f:
             _dump(factory_infos, f)
+        _xs = set(kcl.cross_sections.cross_sections.values())
         with (kcl_dir / "cross_sections.pkl").open("wb") as f:
-            pickle.dump(kcl.cross_sections.cross_sections, f)
+            pickle.dump(
+                {x.name: x for x in _xs if isinstance(x, SymmetricalCrossSection)}, f
+            )
         with (kcl_dir / "asymmetrical_cross_sections.pkl").open("wb") as f:
-            pickle.dump(kcl.cross_sections.asymmetrical_cross_sections, f)
+            pickle.dump(
+                {x.name: x for x in _xs if isinstance(x, AsymmetricalCrossSection)}, f
+            )
 
     with (kcls_dir / "../kcl_dependencies.json").resolve().open("wt") as f:
         json.dump({k: list(v) for k, v in kcl_dependencies.items()}, f)
@@ -223,11 +228,13 @@ def load_kcl(kcl_path: Path) -> None:
     xs_path = kcl_path / "cross_sections.pkl"
     if xs_path.is_file():
         with xs_path.open("rb") as f:
-            kcl.cross_sections.cross_sections = pickle.load(f)  # noqa: S301
+            for xs in pickle.load(f).values():  # noqa: S301
+                kcl.cross_sections.get_cross_section(xs)
     axs_path = kcl_path / "asymmetrical_cross_sections.pkl"
     if axs_path.is_file():
         with axs_path.open("rb") as f:
-            kcl.cross_sections.asymmetrical_cross_sections = pickle.load(f)  # noqa: S301
+            for axs in pickle.load(f).values():  # noqa: S301
+                kcl.cross_sections.get_asymmetrical_cross_section(axs)
 
     loaded_kcl.read(kcl_path / "cells.gds.gz")
     invalid_factories: set[str] = set()

--- a/src/kfactory/utils/difftest.py
+++ b/src/kfactory/utils/difftest.py
@@ -498,5 +498,5 @@ def read_top_cell(arg0: pathlib.Path) -> kf.DKCell:
 
     if hasattr(kcl, "cross_sections"):
         for cross_section in set(kcl.cross_sections.cross_sections.values()):
-            kf.kcl.get_cross_section(cross_section, symmetrical=None)
+            kf.kcl.get_base_cross_section(cross_section, symmetrical=None)
     return kcell

--- a/src/kfactory/utils/difftest.py
+++ b/src/kfactory/utils/difftest.py
@@ -497,6 +497,6 @@ def read_top_cell(arg0: pathlib.Path) -> kf.DKCell:
     kcell = kcl.dkcells[kcl.top_cell().name]
 
     if hasattr(kcl, "cross_sections"):
-        for cross_section in kcl.cross_sections.cross_sections.values():
-            kf.kcl.get_symmetrical_cross_section(cross_section)
+        for cross_section in set(kcl.cross_sections.cross_sections.values()):
+            kf.kcl.get_cross_section(cross_section, symmetrical=None)
     return kcell

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,6 +73,20 @@ def wg_enc(kcl: kf.KCLayout, layers: Layers) -> kf.LayerEnclosure:
 
 
 @pytest.fixture
+def sym_enc() -> Callable[..., kf.LayerEnclosure]:
+    """Build a fixed-structure enclosure, optionally named."""
+
+    def _make(name: str | None = None) -> kf.LayerEnclosure:
+        return kf.LayerEnclosure(
+            sections=[(kf.kdb.LayerInfo(2, 0, "S"), 500)],
+            main_layer=kf.kdb.LayerInfo(1, 0, "WG"),
+            name=name,
+        )
+
+    return _make
+
+
+@pytest.fixture
 def straight_factory_dbu(
     layers: Layers, wg_enc: kf.LayerEnclosure, kcl: kf.KCLayout
 ) -> Callable[..., kf.KCell]:

--- a/tests/test_cross_section.py
+++ b/tests/test_cross_section.py
@@ -510,21 +510,21 @@ def test_get_cross_section_kind_switch() -> None:
         )
     )
 
-    assert kcl.get_cross_section(scs) is scs
-    assert kcl.get_cross_section("wg1000") is scs
-    assert kcl.get_cross_section(scs, symmetrical=True) is scs
-    assert kcl.get_cross_section(acs, symmetrical=False) is acs
-    assert kcl.get_cross_section("aw500", symmetrical=False) is acs
-    assert kcl.get_cross_section(scs, symmetrical=None) is scs
-    assert kcl.get_cross_section(acs, symmetrical=None) is acs
-    assert kcl.get_cross_section("wg1000", symmetrical=None) is scs
-    assert kcl.get_cross_section("aw500", symmetrical=None) is acs
+    assert kcl.get_base_cross_section(scs) is scs
+    assert kcl.get_base_cross_section("wg1000") is scs
+    assert kcl.get_base_cross_section(scs, symmetrical=True) is scs
+    assert kcl.get_base_cross_section(acs, symmetrical=False) is acs
+    assert kcl.get_base_cross_section("aw500", symmetrical=False) is acs
+    assert kcl.get_base_cross_section(scs, symmetrical=None) is scs
+    assert kcl.get_base_cross_section(acs, symmetrical=None) is acs
+    assert kcl.get_base_cross_section("wg1000", symmetrical=None) is scs
+    assert kcl.get_base_cross_section("aw500", symmetrical=None) is acs
     # any with a wrapper resolves to its base
     ixs = kcl.get_iasymmetric_cross_section(acs)
-    assert kcl.get_cross_section(ixs, symmetrical=None) is acs
+    assert kcl.get_base_cross_section(ixs, symmetrical=None) is acs
     # unknown name under "any" raises
     with pytest.raises(KeyError):
-        kcl.get_cross_section("does_not_exist", symmetrical=None)
+        kcl.get_base_cross_section("does_not_exist", symmetrical=None)
 
 
 def test_metadata_uses_separate_prefix_for_asymmetric() -> None:

--- a/tests/test_cross_section.py
+++ b/tests/test_cross_section.py
@@ -1,5 +1,6 @@
 import pickle
 import tempfile
+from collections.abc import Callable
 from pathlib import Path
 
 import pytest
@@ -7,6 +8,7 @@ import pytest
 import kfactory as kf
 from kfactory.exceptions import (
     AsymmetricMirrorRequiredError,
+    CrossSectionNamingConflictError,
     CrossSectionSymmetryMismatchError,
 )
 
@@ -105,7 +107,7 @@ def test_cross_section_name_conflict_across_kinds() -> None:
     kcl.get_symmetrical_cross_section(
         kf.SymmetricalCrossSection(width=1000, enclosure=enc, name="shared")
     )
-    with pytest.raises(ValueError, match="symmetric"):
+    with pytest.raises(ValueError, match="different structural signature"):
         kcl.get_asymmetrical_cross_section(
             kf.AsymmetricalCrossSection(
                 layer=layer, section_min=-250, section_max=250, name="shared"
@@ -118,7 +120,7 @@ def test_cross_section_name_conflict_across_kinds() -> None:
             layer=layer, section_min=-250, section_max=250, name="shared"
         )
     )
-    with pytest.raises(ValueError, match="asymmetric"):
+    with pytest.raises(ValueError, match="different structural signature"):
         kcl2.get_symmetrical_cross_section(
             kf.SymmetricalCrossSection(width=1000, enclosure=enc, name="shared")
         )
@@ -139,7 +141,7 @@ def test_asymmetrical_cross_section_registration() -> None:
         section_max=300,
         name="asym_test",
     )
-    with pytest.raises(ValueError, match="already an asymmetrical cross_section"):
+    with pytest.raises(ValueError, match="different structural signature"):
         kcl.get_asymmetrical_cross_section(different)
 
 
@@ -315,7 +317,7 @@ def test_asymmetrical_cross_section_gds_roundtrip() -> None:
         kcl_r = kf.KCLayout("ASYM_GDS_R")
         kcl_r.read(path)
 
-    assert "asym_test" in kcl_r.cross_sections.asymmetrical_cross_sections
+    assert "asym_test" in kcl_r.cross_sections.cross_sections
     restored = kcl_r.get_asymmetrical_cross_section("asym_test")
     assert restored == acs
 
@@ -485,7 +487,7 @@ def test_asymmetric_wrapper_construct_from_scratch() -> None:
         name="acs1",
     )
     # builds and registers a base under the hood
-    assert "acs1" in kcl.cross_sections.asymmetrical_cross_sections
+    assert "acs1" in kcl.cross_sections.cross_sections
     # constructing a second wrapper with the same args returns equal wrapper
     ixs2 = kf.AsymmetricCrossSection(kcl=kcl, base=ixs.base)
     assert ixs == ixs2
@@ -510,19 +512,19 @@ def test_get_cross_section_kind_switch() -> None:
 
     assert kcl.get_cross_section(scs) is scs
     assert kcl.get_cross_section("wg1000") is scs
-    assert kcl.get_cross_section(scs, kind="symmetric") is scs
-    assert kcl.get_cross_section(acs, kind="asymmetric") is acs
-    assert kcl.get_cross_section("aw500", kind="asymmetric") is acs
-    assert kcl.get_cross_section(scs, kind="any") is scs
-    assert kcl.get_cross_section(acs, kind="any") is acs
-    assert kcl.get_cross_section("wg1000", kind="any") is scs
-    assert kcl.get_cross_section("aw500", kind="any") is acs
+    assert kcl.get_cross_section(scs, symmetrical=True) is scs
+    assert kcl.get_cross_section(acs, symmetrical=False) is acs
+    assert kcl.get_cross_section("aw500", symmetrical=False) is acs
+    assert kcl.get_cross_section(scs, symmetrical=None) is scs
+    assert kcl.get_cross_section(acs, symmetrical=None) is acs
+    assert kcl.get_cross_section("wg1000", symmetrical=None) is scs
+    assert kcl.get_cross_section("aw500", symmetrical=None) is acs
     # any with a wrapper resolves to its base
     ixs = kcl.get_iasymmetric_cross_section(acs)
-    assert kcl.get_cross_section(ixs, kind="any") is acs
+    assert kcl.get_cross_section(ixs, symmetrical=None) is acs
     # unknown name under "any" raises
     with pytest.raises(KeyError):
-        kcl.get_cross_section("does_not_exist", kind="any")
+        kcl.get_cross_section("does_not_exist", symmetrical=None)
 
 
 def test_metadata_uses_separate_prefix_for_asymmetric() -> None:
@@ -557,7 +559,7 @@ def test_metadata_uses_separate_prefix_for_asymmetric() -> None:
         kcl_r.read(path)
 
     assert "wg1000" in kcl_r.cross_sections.cross_sections
-    assert "aw500" in kcl_r.cross_sections.asymmetrical_cross_sections
+    assert "aw500" in kcl_r.cross_sections.cross_sections
 
 
 def test_connect_asym_to_asym_requires_mirror_when_misaligned() -> None:
@@ -680,3 +682,148 @@ def test_asym_connect_check_ignores_input_mirror_flag_when_use_mirror_false() ->
         ia.connect("o1", ib, "o1", mirror=True, use_mirror=False)
     # With existing mirror=True and mirror=False, effective is M90 — passes.
     ia.connect("o1", ib, "o1", mirror=False, use_mirror=False)
+
+
+# --- Named/unnamed canonicalization ---------------------------------------
+
+
+def test_symmetric_unnamed_resolves_to_named(
+    kcl: kf.KCLayout, sym_enc: Callable[..., kf.LayerEnclosure]
+) -> None:
+    enc = kcl.get_enclosure(sym_enc("wgenc"))
+    named = kcl.get_symmetrical_cross_section(
+        kf.SymmetricalCrossSection(width=1000, enclosure=enc, name="A")
+    )
+    assert named.is_named
+    unnamed = kcl.get_symmetrical_cross_section(
+        kf.SymmetricalCrossSection(width=1000, enclosure=enc)
+    )
+    assert unnamed is named
+    assert unnamed.name == "A"
+
+
+def test_symmetric_named_promotes_unnamed(
+    kcl: kf.KCLayout, sym_enc: Callable[..., kf.LayerEnclosure]
+) -> None:
+    enc = kcl.get_enclosure(sym_enc("wgenc"))
+    unnamed = kcl.get_symmetrical_cross_section(
+        kf.SymmetricalCrossSection(width=1000, enclosure=enc)
+    )
+    assert not unnamed.is_named
+    auto_name = unnamed.name
+    named = kcl.get_symmetrical_cross_section(
+        kf.SymmetricalCrossSection(width=1000, enclosure=enc, name="B")
+    )
+    assert named.name == "B"
+    again = kcl.get_symmetrical_cross_section(
+        kf.SymmetricalCrossSection(width=1000, enclosure=enc)
+    )
+    assert again is named
+    # The canonical (auto) name now aliases the promoted named entry.
+    assert kcl.cross_sections.cross_sections[auto_name] is named
+
+
+def test_symmetric_naming_conflict(
+    kcl: kf.KCLayout, sym_enc: Callable[..., kf.LayerEnclosure]
+) -> None:
+    enc = kcl.get_enclosure(sym_enc("wgenc"))
+    a1 = kcl.get_symmetrical_cross_section(
+        kf.SymmetricalCrossSection(width=1000, enclosure=enc, name="A")
+    )
+    # Idempotent re-registration of the same named cross section.
+    a2 = kcl.get_symmetrical_cross_section(
+        kf.SymmetricalCrossSection(width=1000, enclosure=enc, name="A")
+    )
+    assert a1 is a2
+    # A second, different name for the same signature raises.
+    with pytest.raises(CrossSectionNamingConflictError):
+        kcl.get_symmetrical_cross_section(
+            kf.SymmetricalCrossSection(width=1000, enclosure=enc, name="C")
+        )
+
+
+def test_enclosure_unnamed_resolves_to_named(
+    kcl: kf.KCLayout, sym_enc: Callable[..., kf.LayerEnclosure]
+) -> None:
+    named = kcl.get_enclosure(sym_enc("encA"))
+    unnamed = kcl.get_enclosure(sym_enc())
+    assert unnamed is named
+    # Addressable by the structural (unnamed) key string too.
+    assert kcl.get_enclosure(named.unnamed_key) is named
+
+
+def test_enclosure_named_promotes_unnamed(
+    kcl: kf.KCLayout, sym_enc: Callable[..., kf.LayerEnclosure]
+) -> None:
+    unnamed = kcl.get_enclosure(sym_enc())
+    assert not unnamed.is_named
+    auto_key = unnamed.name
+    named = kcl.get_enclosure(sym_enc("encB"))
+    assert named.is_named
+    assert named.name == "encB"
+    again = kcl.get_enclosure(sym_enc())
+    assert again is named
+    assert auto_key not in kcl.layer_enclosures.root
+
+
+def test_enclosure_naming_conflict(
+    kcl: kf.KCLayout, sym_enc: Callable[..., kf.LayerEnclosure]
+) -> None:
+    kcl.get_enclosure(sym_enc("encA"))
+    with pytest.raises(CrossSectionNamingConflictError):
+        kcl.get_enclosure(sym_enc("encC"))
+
+
+def test_cross_section_enclosure_resolution_unifies(
+    kcl: kf.KCLayout, sym_enc: Callable[..., kf.LayerEnclosure]
+) -> None:
+    # With the enclosure canonicalized (named), a cross section built on the named
+    # enclosure and one built on a fresh, structurally-identical unnamed enclosure
+    # resolve to the same canonical cross section (the unnamed enclosure
+    # canonicalizes to the named one first).
+    enc_named = kcl.get_enclosure(sym_enc("encN"))
+    xs_named_enc = kcl.get_symmetrical_cross_section(
+        kf.SymmetricalCrossSection(width=1000, enclosure=enc_named)
+    )
+    xs_via_unnamed = kcl.get_symmetrical_cross_section(
+        kf.SymmetricalCrossSection(width=1000, enclosure=sym_enc())
+    )
+    assert xs_via_unnamed is xs_named_enc
+
+
+def test_radius_excluded_from_name_but_conflicts_on_registration(
+    kcl: kf.KCLayout, sym_enc: Callable[..., kf.LayerEnclosure]
+) -> None:
+    # radius is excluded from the structural name/identity ...
+    a = kf.SymmetricalCrossSection(width=1000, enclosure=sym_enc(), radius=10_000)
+    b = kf.SymmetricalCrossSection(width=1000, enclosure=sym_enc(), radius=5_000)
+    assert a == b  # geometry-equal; radius is metadata
+    assert a.auto_name() == b.auto_name()
+
+    enc = kcl.get_enclosure(sym_enc("wgenc"))
+    first = kcl.get_symmetrical_cross_section(
+        kf.SymmetricalCrossSection(width=1000, enclosure=enc, radius=10_000)
+    )
+    # Same radius → idempotent.
+    assert (
+        kcl.get_symmetrical_cross_section(
+            kf.SymmetricalCrossSection(width=1000, enclosure=enc, radius=10_000)
+        )
+        is first
+    )
+    # ... but re-registering the same profile with a *different* radius conflicts
+    # (override the radius at route time instead).
+    with pytest.raises(CrossSectionNamingConflictError):
+        kcl.get_symmetrical_cross_section(
+            kf.SymmetricalCrossSection(width=1000, enclosure=enc, radius=5_000)
+        )
+
+
+def test_asymmetric_unnamed_resolves_to_named(kcl: kf.KCLayout) -> None:
+    named = kcl.get_asymmetrical_cross_section(_make_asym("named_asym"))
+    assert named.is_named
+    # Same structure, no explicit name (auto-named) → resolves to the named one.
+    unnamed = _make_asym(name="")
+    assert not unnamed.is_named
+    resolved = kcl.get_asymmetrical_cross_section(unnamed)
+    assert resolved is named

--- a/tests/test_generic_factories.py
+++ b/tests/test_generic_factories.py
@@ -1,0 +1,78 @@
+"""Tests for `KCLayout.generic_factories` and the `@kcl.generic_factory` decorator."""
+
+import pytest
+
+import kfactory as kf
+from tests.conftest import Layers
+
+
+def test_generic_factory_registration_and_delegation(
+    kcl: kf.KCLayout, layers: Layers, wg_enc: kf.LayerEnclosure
+) -> None:
+    real_straight = kf.factories.straight.straight_dbu_factory(kcl=kcl)
+
+    @kcl.generic_factory
+    def my_straight(length: int) -> kf.KCell:
+        return real_straight(
+            width=500, length=length, layer=layers.WG, enclosure=wg_enc
+        )
+
+    # Registered under the function name and retrievable.
+    assert "my_straight" in kcl.generic_factories
+    assert kcl.generic_factories["my_straight"] is my_straight
+
+    # Delegation works: calling forwards to the cached real factory.
+    c = kcl.generic_factories["my_straight"](length=10_000)
+    assert isinstance(c, kf.KCell)
+    assert c.kcl is kcl
+    # Same args -> cached cell from the underlying factory.
+    assert my_straight(length=10_000) is c
+
+
+def test_generic_factory_guardrail_rejects_foreign_kcl(
+    kcl: kf.KCLayout, layers: Layers
+) -> None:
+    # The global default layout is a *different* layout than the fixture `kcl`.
+    other_straight = kf.factories.straight.straight_dbu_factory(kcl=kf.kcl)
+
+    @kcl.generic_factory
+    def foreign(length: int) -> kf.KCell:
+        # Builds a cell owned by `kf.kcl`, not by `kcl`.
+        return other_straight(width=500, length=length, layer=layers.WG)
+
+    with pytest.raises(ValueError, match="returned a cell from KCLayout"):
+        foreign(length=10_000)
+
+
+def test_generic_factories_independent_of_other_registries(
+    kcl: kf.KCLayout, layers: Layers
+) -> None:
+    real_straight = kf.factories.straight.straight_dbu_factory(kcl=kcl)
+
+    @kcl.generic_factory
+    def only_generic(length: int) -> kf.KCell:
+        return real_straight(width=500, length=length, layer=layers.WG)
+
+    assert "only_generic" in kcl.generic_factories
+    assert "only_generic" not in kcl.factories
+    assert "only_generic" not in kcl.virtual_factories
+
+
+def test_generic_factory_custom_name(kcl: kf.KCLayout, layers: Layers) -> None:
+    real_straight = kf.factories.straight.straight_dbu_factory(kcl=kcl)
+
+    # Decorator-with-name form.
+    @kcl.generic_factory(name="wg")
+    def my_straight(length: int) -> kf.KCell:
+        return real_straight(width=500, length=length, layer=layers.WG)
+
+    assert "wg" in kcl.generic_factories
+    assert "my_straight" not in kcl.generic_factories
+    assert isinstance(kcl.generic_factories["wg"](length=10_000), kf.KCell)
+
+    # Direct-call form with a name.
+    def another(length: int) -> kf.KCell:
+        return real_straight(width=500, length=length, layer=layers.WG)
+
+    kcl.generic_factory(another, name="wg2")
+    assert "wg2" in kcl.generic_factories

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -1,5 +1,5 @@
 import functools
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
@@ -294,4 +294,4 @@ def test_kclayout_clear_drop_layers(kcl: kf.KCLayout, layers: Layers) -> None:
     assert len(kcl.kcells) == 0
     assert len(list(kcl.layout.each_cell())) == 0
     assert kcl.infos == kf.LayerInfos()
-    assert len(list(kcl.layers)) == 0
+    assert len(list(cast("Any", kcl.layers))) == 0

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -150,7 +150,7 @@ def test_metainfo_read_cell(straight: kf.KCell) -> None:
             " for ports, info, and settings. Therefore proceed at your own risk."
         )
         for cs in straight.kcl.cross_sections.cross_sections.values():
-            kcl.get_symmetrical_cross_section(cs)
+            kcl.get_cross_section(cs)
         kcell.read(t.name)
         kf.config.logfilter.regex = ""
 

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -150,7 +150,7 @@ def test_metainfo_read_cell(straight: kf.KCell) -> None:
             " for ports, info, and settings. Therefore proceed at your own risk."
         )
         for cs in straight.kcl.cross_sections.cross_sections.values():
-            kcl.get_cross_section(cs)
+            kcl.get_base_cross_section(cs)
         kcell.read(t.name)
         kf.config.logfilter.regex = ""
 

--- a/tests/test_schematic.py
+++ b/tests/test_schematic.py
@@ -865,7 +865,7 @@ def test_schematic_function_get_port_positions(
         """
         c = kcl.kcell()
 
-        xs = c.kcl.get_icross_section(cross_section)
+        xs = c.kcl.get_icross_section(cross_section, symmetrical=True)
         width = c.kcl.to_um(xs.width)
         radius = c.kcl.to_um(xs.radius)
         assert radius is not None, "Radius of cross section must not be None"
@@ -945,7 +945,7 @@ def test_schematic_function_get_port_positions(
             resolution: Angle resolution for the backbone.
         """
         c = kcl.kcell()
-        xs = c.kcl.get_icross_section(cross_section)
+        xs = c.kcl.get_icross_section(cross_section, symmetrical=True)
 
         width = c.kcl.to_um(xs.width)
         radius = c.kcl.to_um(xs.radius)
@@ -1015,7 +1015,7 @@ def test_schematic_function_get_port_positions(
             enclosure: Definition of slab/excludes. [dbu]
         """
         c = kcl.kcell()
-        xs = c.kcl.get_icross_section(cross_section)
+        xs = c.kcl.get_icross_section(cross_section, symmetrical=True)
 
         length_ = c.kcl.to_dbu(length)
 

--- a/uv.lock
+++ b/uv.lock
@@ -79,15 +79,15 @@ wheels = [
 
 [[package]]
 name = "beautifulsoup4"
-version = "4.14.3"
+version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "soupsieve" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c3/b0/1c6a16426d389813b48d95e26898aff79abbde42ad353958ad95cc8c9b21/beautifulsoup4-4.14.3.tar.gz", hash = "sha256:6292b1c5186d356bba669ef9f7f051757099565ad9ada5dd630bd9de5fa7fb86", size = 627737, upload-time = "2025-11-30T15:08:26.084Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/65/318323f98dbee45d42dff61d8f047181bc6f2268a9068cfad035a46be5af/beautifulsoup4-4.15.0.tar.gz", hash = "sha256:288e3ca7d54b06f2ac191970bc275c1939cb46d450b255bf6718b04aa37ab4f7", size = 632571, upload-time = "2026-06-07T16:44:20.453Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl", hash = "sha256:0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb", size = 107721, upload-time = "2025-11-30T15:08:24.087Z" },
+    { url = "https://files.pythonhosted.org/packages/88/c6/92fcd42f1ba33e1184263f25bfabf3d27c383410470f169e4b8163bf9c17/beautifulsoup4-4.15.0-py3-none-any.whl", hash = "sha256:d6f88de62e1d4e38ecb1077eb9724cd0eff29d2a08ca16a401e9b9e93f117cf9", size = 109924, upload-time = "2026-06-07T16:44:21.566Z" },
 ]
 
 [[package]]
@@ -124,14 +124,14 @@ wheels = [
 
 [[package]]
 name = "bleach"
-version = "6.3.0"
+version = "6.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "webencodings" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/07/18/3c8523962314be6bf4c8989c79ad9531c825210dd13a8669f6b84336e8bd/bleach-6.3.0.tar.gz", hash = "sha256:6f3b91b1c0a02bb9a78b5a454c92506aa0fdf197e1d5e114d2e00c6f64306d22", size = 203533, upload-time = "2025-10-27T17:57:39.211Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/48/3c/e12ac860709702bd5ebeb9b56a4fe334f1001246ee1b8f2b7ee28912df7d/bleach-6.4.0.tar.gz", hash = "sha256:4202482733d85cedd04e59fcb2f89f4e4c7c385a78d3c3c23c30446843a37452", size = 204857, upload-time = "2026-06-05T13:01:13.734Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cd/3a/577b549de0cc09d95f11087ee63c739bba856cd3952697eec4c4bb91350a/bleach-6.3.0-py3-none-any.whl", hash = "sha256:fe10ec77c93ddf3d13a73b035abaac7a9f5e436513864ccdad516693213c65d6", size = 164437, upload-time = "2025-10-27T17:57:37.538Z" },
+    { url = "https://files.pythonhosted.org/packages/58/9d/40b6267367182187139a4000b82a3b287d84d745bccd808e75d916920e9d/bleach-6.4.0-py3-none-any.whl", hash = "sha256:4b6b6a54fff2e69a3dde9d21cc6301220bee3c3cb792187d11403fd795031081", size = 165109, upload-time = "2026-06-05T13:01:12.504Z" },
 ]
 
 [package.optional-dependencies]
@@ -483,11 +483,11 @@ wheels = [
 
 [[package]]
 name = "distlib"
-version = "0.4.1"
+version = "0.4.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/86/b2/d6fc3f2347f43dada79e5ff118493e8109c98400a0e29a1d5264a3aa479b/distlib-0.4.1.tar.gz", hash = "sha256:c3804d0d2d4b5fcd44036eb860cb6660485fcdf5c2aba53dc324d805837ea65b", size = 610526, upload-time = "2026-06-02T11:17:40.691Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/02/bd72be9134d25ed783ecbbc38a539ffaefbf90c78418c7fb7229600dbac7/distlib-0.4.3.tar.gz", hash = "sha256:f152097224a0ae24be5a0f6bae1b9359af82133bce63f98a95f86cae1aede9ed", size = 615141, upload-time = "2026-06-12T08:04:52.847Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/25/18/3497c4fa83a76dcb154923fd2075522e8dd6995ecee4093c00ae18160046/distlib-0.4.1-py2.py3-none-any.whl", hash = "sha256:9c2c552c68cbadc619f2d0ed3a69e27c351a3f4c9baa9ffb7df9e9cdc3d19a97", size = 469216, upload-time = "2026-06-02T11:17:38.779Z" },
+    { url = "https://files.pythonhosted.org/packages/02/08/9c41fb51ab5b43eb21674aff13df270e8ba6c4b29c8624e328dc7a9482af/distlib-0.4.3-py2.py3-none-any.whl", hash = "sha256:4b0ce306c966eb73bc3a7b6abad017c556dadd92c44701562cd528ac7fde4d5b", size = 470628, upload-time = "2026-06-12T08:04:50.506Z" },
 ]
 
 [[package]]
@@ -555,11 +555,11 @@ wheels = [
 
 [[package]]
 name = "filelock"
-version = "3.29.1"
+version = "3.29.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1f/f9/f38573ed5844586db374d085911740a501ccfa373b455fc9413f09f85237/filelock-3.29.1.tar.gz", hash = "sha256:d97e6b1b9757569626c58caa07dc4beb1613f4a2938b1e8cc81afca398906c9e", size = 59335, upload-time = "2026-06-03T15:19:04.053Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e6/dc/be6cbe99670cd6e4ad387123647cb08e0c32975e223f82551e914c5568a6/filelock-3.29.4.tar.gz", hash = "sha256:10cdb3656fc44541cdf30652a93fb10ec6b05325620eb316bd26893e4201538a", size = 63028, upload-time = "2026-06-13T16:12:00.744Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4c/a0/614c5fe402fd88951df45f4dda2fa3b4e17a99ecd92340771929169b3b95/filelock-3.29.1-py3-none-any.whl", hash = "sha256:85199dfd706869641b72b2e8955d5416a4b2b7dc4b0e8e6d97b4cc1299a6983b", size = 40750, upload-time = "2026-06-03T15:19:02.959Z" },
+    { url = "https://files.pythonhosted.org/packages/13/37/a065dc3bd6e49423a6532c642ca7378d3f467b1ef44c2800c937af7f9739/filelock-3.29.4-py3-none-any.whl", hash = "sha256:dac1648087d5115554850d113e7dd8c83ab2d38e3435dde2d4f163847e57b767", size = 42757, upload-time = "2026-06-13T16:11:59.582Z" },
 ]
 
 [[package]]
@@ -710,7 +710,7 @@ wheels = [
 
 [[package]]
 name = "ipython"
-version = "9.14.0"
+version = "9.14.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -725,9 +725,9 @@ dependencies = [
     { name = "stack-data" },
     { name = "traitlets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/21/c2/c0064cf15d026501a1ef70e42efd9c3f818663089399aacc5e37a82901c1/ipython-9.14.0.tar.gz", hash = "sha256:6f27ff0f1d9ea050e0551f71568bc4b34d8aba579e8f111c5b4175f44ac6b4aa", size = 4432601, upload-time = "2026-05-29T15:13:24.611Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e2/23/3a27530575643c8bb7bfc757a28e2e7ef80092afbf59a2bc5716320b6602/ipython-9.14.1.tar.gz", hash = "sha256:f913bf74df06d458e46ced84ca506c23797590d594b236fe60b14df213291e7b", size = 4433457, upload-time = "2026-06-05T08:12:34.921Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/a3/9e59340f02c1dc8f8c0a05b09244712b8609eb5439f9996e887e2b82f452/ipython-9.14.0-py3-none-any.whl", hash = "sha256:8fd984a3372c14b12790b084ba6b5cff5678c0cb063244a0034f06a51f20d6c2", size = 627457, upload-time = "2026-05-29T15:13:22.942Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/22/58818a63eaf8982b67632b1bc20585c811611b15a8da19d6012323dc76a5/ipython-9.14.1-py3-none-any.whl", hash = "sha256:5d4a9ecaa3b10e6e5f269dd0948bdb58ca9cb851899cd23e07c320d3eb11613c", size = 627770, upload-time = "2026-06-05T08:12:33.045Z" },
 ]
 
 [[package]]
@@ -832,7 +832,7 @@ wheels = [
 
 [[package]]
 name = "jupyter-client"
-version = "8.8.0"
+version = "8.9.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jupyter-core" },
@@ -840,10 +840,11 @@ dependencies = [
     { name = "pyzmq" },
     { name = "tornado" },
     { name = "traitlets" },
+    { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/05/e4/ba649102a3bc3fbca54e7239fb924fd434c766f855693d86de0b1f2bec81/jupyter_client-8.8.0.tar.gz", hash = "sha256:d556811419a4f2d96c869af34e854e3f059b7cc2d6d01a9cd9c85c267691be3e", size = 348020, upload-time = "2026-01-08T13:55:47.938Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/dc/5512503b088997c2250b8bf18258fba9d9ce5ead641183700960d3c9d342/jupyter_client-8.9.1.tar.gz", hash = "sha256:a58f730dd9e728ba16ba1d62ebccf7ffe1ebbdbce4e95cfae941b7321ae1f4fa", size = 359256, upload-time = "2026-06-09T13:15:01.033Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2d/0b/ceb7694d864abc0a047649aec263878acb9f792e1fec3e676f22dc9015e3/jupyter_client-8.8.0-py3-none-any.whl", hash = "sha256:f93a5b99c5e23a507b773d3a1136bd6e16c67883ccdbd9a829b0bbdb98cd7d7a", size = 107371, upload-time = "2026-01-08T13:55:45.562Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/6f/56d39bf385c5c27988aebaf0c18a2a17e960575740100973511018bd904e/jupyter_client-8.9.1-py3-none-any.whl", hash = "sha256:0b7a295bc46e8751e9adae84781f726c851c1d911bd793edc4a3bde942e3da81", size = 109828, upload-time = "2026-06-09T13:14:58.835Z" },
 ]
 
 [[package]]
@@ -895,7 +896,7 @@ wheels = [
 
 [[package]]
 name = "kfactory"
-version = "3.0.0rc3"
+version = "3.0.0rc4"
 source = { editable = "." }
 dependencies = [
     { name = "aenum" },
@@ -1448,16 +1449,16 @@ python = [
 
 [[package]]
 name = "mkdocstrings-python"
-version = "2.0.3"
+version = "2.0.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "griffelib" },
     { name = "mkdocs-autorefs" },
     { name = "mkdocstrings" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/29/33/c225eaf898634bdda489a6766fc35d1683c640bffe0e0acd10646b13536d/mkdocstrings_python-2.0.3.tar.gz", hash = "sha256:c518632751cc869439b31c9d3177678ad2bfa5c21b79b863956ad68fc92c13b8", size = 199083, upload-time = "2026-02-20T10:38:36.368Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/b4/5fed370d8ebd96e4e399460a7146ae989263f16588b05a6facd6dbd51e60/mkdocstrings_python-2.0.4.tar.gz", hash = "sha256:58c73c5d358e64e9b1673447663f4a2f8a8941e392e225fc0a0c893758cc452f", size = 199219, upload-time = "2026-06-05T08:13:01.819Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/32/28/79f0f8de97cce916d5ae88a7bee1ad724855e83e6019c0b4d5b3fabc80f3/mkdocstrings_python-2.0.3-py3-none-any.whl", hash = "sha256:0b83513478bdfd803ff05aa43e9b1fca9dd22bcd9471f09ca6257f009bc5ee12", size = 104779, upload-time = "2026-02-20T10:38:34.517Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/e3/00ec594aef5f55522e6d373bc2ac53e53a8f5e9ae32f2d6854b0de4270f3/mkdocstrings_python-2.0.4-py3-none-any.whl", hash = "sha256:fd87c173e1e719a85997b6d4f852cdc55f36710e0ed08da3a7bd9abe79c9db00", size = 104790, upload-time = "2026-06-05T08:13:00.393Z" },
 ]
 
 [[package]]
@@ -1471,7 +1472,7 @@ wheels = [
 
 [[package]]
 name = "nbclient"
-version = "0.10.4"
+version = "0.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jupyter-client" },
@@ -1479,9 +1480,9 @@ dependencies = [
     { name = "nbformat" },
     { name = "traitlets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/56/91/1c1d5a4b9a9ebba2b4e32b8c852c2975c872aec1fe42ab5e516b2cecd193/nbclient-0.10.4.tar.gz", hash = "sha256:1e54091b16e6da39e297b0ece3e10f6f29f4ac4e8ee515d29f8a7099bd6553c9", size = 62554, upload-time = "2025-12-23T07:45:46.369Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/28/a5/b3bae4b590c0cbcada2c63a34f7580024e834a8ba213e949a2f906705787/nbclient-0.11.0.tar.gz", hash = "sha256:04a134a5b087f2c5887f228aca155db50169b8cd9334dee6942c8e927e56081a", size = 62535, upload-time = "2026-06-05T07:52:41.746Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/83/a0/5b0c2f11142ed1dddec842457d3f65eaf71a0080894eb6f018755b319c3a/nbclient-0.10.4-py3-none-any.whl", hash = "sha256:9162df5a7373d70d606527300a95a975a47c137776cd942e52d9c7e29ff83440", size = 25465, upload-time = "2025-12-23T07:45:44.51Z" },
+    { url = "https://files.pythonhosted.org/packages/36/c9/94d73e5a01c5b926c3fa2496e97d7a8dc28ed5a77c0b2ed712f1a62e6694/nbclient-0.11.0-py3-none-any.whl", hash = "sha256:ef7fa0d59d6e1d41103933d8a445a18d5de860ca6b613b87b8574accdb3c2895", size = 25288, upload-time = "2026-06-05T07:52:40.115Z" },
 ]
 
 [[package]]
@@ -1954,53 +1955,53 @@ wheels = [
 
 [[package]]
 name = "pygit2"
-version = "1.19.2"
+version = "1.19.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cffi" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3a/a4/10ce00feef5c43eddacab19ae6610c4d4ef3ab77e544e9ee938772cd1c17/pygit2-1.19.2.tar.gz", hash = "sha256:cbeb3dbca9ca6ee3d5ea5d02f5e844c2d6084a2d5d6621e3e06aa2b11c645bfd", size = 803448, upload-time = "2026-03-29T14:57:27.565Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a6/44/415aa93422b4bfc21a6448acb7e16280d5f33a9a3fae38a384e37b046ae4/pygit2-1.19.3.tar.gz", hash = "sha256:a543e6d4ebb43825564935758dc234e770016fed673b84370d46ae9580558831", size = 810489, upload-time = "2026-06-13T08:06:04.982Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d5/2d/4fdeb7c6e044588cef9f0fca8b93fbc40fcdb2dfc64367999f45e88c0e7e/pygit2-1.19.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:cf479077d48a60b09569a5bb50866d8609f434f8982058594b0d2e2950bd6fce", size = 5704810, upload-time = "2026-03-29T14:56:15.671Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/d8/926415c996ca283c4f7ccf63322ea23135ff17ecd1d2faaba704f6b4d883/pygit2-1.19.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6e6e7eb5fb49203735627b8e1d410afe19e7d610c9a9733c11084fabd17f0920", size = 5696366, upload-time = "2026-03-29T14:56:17.241Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/5e/c0329db9c980552c5c853dc1e429d13d55c691749db0540ef6bc77c04a98/pygit2-1.19.2-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1a810da2d108d6bd16115c72a1c3d69fa1528ef927719bdfc94d2cdbc4198288", size = 6035334, upload-time = "2026-03-29T14:56:19.555Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/39/e08003a59a4d58bbba923d1c2be683a84b7b30c7270a19ff3ea02f9558df/pygit2-1.19.2-cp312-cp312-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d0b8ae5a822afb2771cbacf7c75140e663bc801c44eaaf2e4017f850cb27227c", size = 4636920, upload-time = "2026-03-29T14:56:20.93Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/3c/d3a9ed478add4cd77403416897459750ef2f6a06d8febe452ba03f5b7a27/pygit2-1.19.2-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:330430b6c1a3e6d45d1f5f950734d37d849c07924b5b0475cd995a7e541e6ab1", size = 5798652, upload-time = "2026-03-29T14:56:22.773Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/15/5440f00005db1769062ecc9fab7059ac7ae89217a06e1976734f53c2d040/pygit2-1.19.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:7b7f165d1ddfa1e0f205c1115ee10f5fea700fd3584c727b0d61a57192238449", size = 6041142, upload-time = "2026-03-29T14:56:24.618Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/5b/b9f9979a56606a661c0cff24c7aa6f5b1ad34118e116b7d67295be42aaad/pygit2-1.19.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e46ec6a97a5c43704473e42a926f7f20f9934ceef4f4891660313f573c4f0ab8", size = 5769220, upload-time = "2026-03-29T14:56:26.423Z" },
-    { url = "https://files.pythonhosted.org/packages/30/81/9594e604eb19ae02f6a2023840e25574b0abcfc8d58c03cf96c59dd4ba72/pygit2-1.19.2-cp312-cp312-win32.whl", hash = "sha256:6b4de5469e88e7b069143f7a5d6336a4b3e7d911de4633ef18c113e416feb948", size = 946691, upload-time = "2026-03-29T14:56:27.813Z" },
-    { url = "https://files.pythonhosted.org/packages/35/2d/c9bcdaef8f57ba0cdf129a6823f95cadd8ead002f38fba3465732c7517a8/pygit2-1.19.2-cp312-cp312-win_amd64.whl", hash = "sha256:f064748202928f4e882501521229e378e0b7b69b0e7c433cdb2626d007745973", size = 1164290, upload-time = "2026-03-29T14:56:29.13Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/d4/6e9c98d227a8e816e2ffc7304f733e8b924afd8198b16888972fedbe05bd/pygit2-1.19.2-cp312-cp312-win_arm64.whl", hash = "sha256:222f439d751799dc74c3fa75f187abdbc415d12f9a091efa66f0c9ff51893d32", size = 969330, upload-time = "2026-03-29T14:56:30.363Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/77/c925eee8496961729f029a4edda67485c7637248c0e730e0b41122357be5/pygit2-1.19.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:df207f93a33851a110dec70108e3f2a1c69578932919fd356303eda83a5624db", size = 5704802, upload-time = "2026-03-29T14:56:31.635Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/fc/d46428b7ea0ce7bd3cac73b73206a2cba50580f54b58bd704d8755d5658c/pygit2-1.19.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ae884cd53e29b3d831f5261f36048a8d5db5642dc98cd63530810e7fd9c9e60d", size = 5696329, upload-time = "2026-03-29T14:56:33.343Z" },
-    { url = "https://files.pythonhosted.org/packages/35/05/a3bb39095ef31e140cbeb30abbd08fafb13ed70b656a9de095fac74a1ff5/pygit2-1.19.2-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0bd4059964531d20aaf4577b3761590df9cc7c9e2395df5d33f0552224331b76", size = 6036095, upload-time = "2026-03-29T14:56:34.836Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/cb/36ebd241351bd1ced1f126bf0b21fbb6c0d48ce36122512cc51cde83d10b/pygit2-1.19.2-cp313-cp313-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c3befcccc7b3b62e45da2cc1ce4095964f7606d3d15b43dc667c6ef2a2ada20d", size = 4637435, upload-time = "2026-03-29T14:56:36.292Z" },
-    { url = "https://files.pythonhosted.org/packages/36/35/779d6b8e9df0cc3236f675af5fc37e4047e1a6ab96f9c72ef5b5ed8d888b/pygit2-1.19.2-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1cf08b54553f997f6f60a7918504e22e7baa4ba2fbb11d1e1cb6c0a45ac7e04b", size = 5799881, upload-time = "2026-03-29T14:56:38.04Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/fa/cb361f4bd5342fa01a0f83b04eff8873a09771183bcb6e29947078577119/pygit2-1.19.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d7f630e5a763f01b4be6e2374c487086229c8f7392a2e5591d29095c5e481da4", size = 6042342, upload-time = "2026-03-29T14:56:39.523Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/6f/b9ea61266eb7d568ea17d8fec63dc766ebecec23860b4e5ac5bcfbbe15d7/pygit2-1.19.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6166845f41d4f6be3353997022d64035fe3df348c8e34d7d30c5f95817fbcab4", size = 5770452, upload-time = "2026-03-29T14:56:41.306Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/bb/403532429072a61d5498d17ddf6be3258953e73b6499f70a2b4e1345bb84/pygit2-1.19.2-cp313-cp313-win32.whl", hash = "sha256:5bebea045102e87dea142242298d4dd668d0227f76042f98efb1c5d5dd3db21e", size = 946658, upload-time = "2026-03-29T14:56:42.613Z" },
-    { url = "https://files.pythonhosted.org/packages/01/08/6f37fb23514da02345889d7be7cea899d2a348fa4871492ea9a8837e70e4/pygit2-1.19.2-cp313-cp313-win_amd64.whl", hash = "sha256:7bbfeb680821001a5c1b6959da1eae906806c90c9992ae4564d3ea83a27bb19f", size = 1164264, upload-time = "2026-03-29T14:56:43.753Z" },
-    { url = "https://files.pythonhosted.org/packages/90/b9/d11220d5f0cfc92895b02814ab36ac94edbf46ae1b9dc3077c457d03d718/pygit2-1.19.2-cp313-cp313-win_arm64.whl", hash = "sha256:033d489186145cf67b2c60840d2a308f6b1e9d641de12417c447f9829dacde70", size = 969348, upload-time = "2026-03-29T14:56:44.892Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/1b/1a935baeb29958d7e50a52c7a963ce5963f24fa8a5024e1082d43b07a770/pygit2-1.19.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:f5effee3f4ad0d9c89b34ebecf1acee26f6b117ef3c51345ad022bd521fd8dca", size = 5706909, upload-time = "2026-03-29T14:56:46.249Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/86/4bb6f196b13bd7ed825f4e931fb7152a36d01e8de24c8de44425702ad18c/pygit2-1.19.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1ed09804dc6b6de0be07a71443122fd7b6458f8466d1134003c2dea55af886fc", size = 5696293, upload-time = "2026-03-29T14:56:48.173Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/64/d674b3f854cecf53bccbc21a095734759cd3599624578ed3c78602eb22a3/pygit2-1.19.2-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2d114aa066e718d5ef3401b366dcb0b37b549c3b3b139f5f0042bd7059a4b0f7", size = 6038057, upload-time = "2026-03-29T14:56:50.118Z" },
-    { url = "https://files.pythonhosted.org/packages/64/eb/2ce41735e27ee0f28f786aae62ea371f3beec0ef38d1712a2910421386c4/pygit2-1.19.2-cp314-cp314-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c1becc06071acfdd5ae8523aaeab6d4b0930b2bcb08f5eb878e052e61275000b", size = 4641475, upload-time = "2026-03-29T14:56:51.581Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/8d/35f6096c42caefb715ca29e991279b493275c0051a3c83081099644d3f4a/pygit2-1.19.2-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:06d2db3bdbf2906eb17112adb14a2fe6e34c1b2bce39c91819f59208d4e56665", size = 5801738, upload-time = "2026-03-29T14:56:53.043Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/31/dbbaa7a433008fec9046cc293c012ae5d5a31e66321e1fb05d64ae131e54/pygit2-1.19.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8a7e99e5dfc8d3ed8f849b9688bc3fb1bdc86f34af28159140a8d1e18b703dd8", size = 6043074, upload-time = "2026-03-29T14:56:54.774Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/33/b34266efba6917081dafb50976155c2d31cd377f277e67348a810245c4b4/pygit2-1.19.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7659d59eba6c4a706978237d02e8d719f960843df749256f1656c938c1f4142b", size = 5770986, upload-time = "2026-03-29T14:56:56.796Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/ab/813f3af50987020cd90e810da147ebef16a61003b9af995070ec338634ba/pygit2-1.19.2-cp314-cp314-win32.whl", hash = "sha256:e551908dfd93d471c0b08cfcddbe4924417865aae6ac90d20f3815c9483b0a82", size = 967943, upload-time = "2026-03-29T14:56:58.196Z" },
-    { url = "https://files.pythonhosted.org/packages/22/00/24df5ac51a316e36a07bbf9e4c91fade523b9e80a84d5c9e7acd10b22248/pygit2-1.19.2-cp314-cp314-win_amd64.whl", hash = "sha256:eb1fd8538372230f8a471a5f3629901bc2fc7df992853d97bedc8fa269a9caf3", size = 1194774, upload-time = "2026-03-29T14:56:59.721Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/ee/274a91b28864fd9c5cdd2949b4d7e0909fd6a89785a46308de098d3a22cd/pygit2-1.19.2-cp314-cp314-win_arm64.whl", hash = "sha256:3cc461245b70be45a936e925744e67a45f6b0ee970aeb8e7a385dd7fe9f40877", size = 996677, upload-time = "2026-03-29T14:57:01.013Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/22/3c05a56918e6fda5deb53aeb7436959a8880f4cc436a76771771479693de/pygit2-1.19.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:cb686bc81dfe5b13937047643fddb1dd253dae33b4a9ca62858c49ed294e05be", size = 5710172, upload-time = "2026-03-29T14:57:02.672Z" },
-    { url = "https://files.pythonhosted.org/packages/59/eb/2fdd485c01b478c77dd2e949b424a61c70a8750ffb13c5035fe3edf6a8f6/pygit2-1.19.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5ec3538d81963bd05dd16c0de75938a9173966e1c853ad7848ebcb60bcfe21b0", size = 5699256, upload-time = "2026-03-29T14:57:04.401Z" },
-    { url = "https://files.pythonhosted.org/packages/51/f4/f0608bb369da15f2973dfb33e7b7cba4c9bc8164e6a01e3f15e65e85efef/pygit2-1.19.2-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d02ebb50ea082d9631bbfda12787eb5324b8880a72cb8e3b9f11e9b323ad5781", size = 6096321, upload-time = "2026-03-29T14:57:06.33Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/1b/816d3700dc8bcc9028c5f81b190f2d770d1cb9cd2ccdd39939d0b6730718/pygit2-1.19.2-cp314-cp314t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8a3643e4dd569c2909e88586659f617f70315680ca3c619cd8ff9e9c28726c25", size = 4696179, upload-time = "2026-03-29T14:57:08.552Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/a6/0fc82f07c4dfee5856626c5d4b422c32e14cac0204eb1e9558ac0d717b07/pygit2-1.19.2-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:697e3684cb4ef2bfc084623c3f680d5ae8b4c8afca31a35a731b7b70204d9f83", size = 5853368, upload-time = "2026-03-29T14:57:10.449Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/60/0393786d7810b7f83def3738cb9be1a735cf6b555dc219d90f46010b87b1/pygit2-1.19.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:173165b54a2affed918302193f12dd369bec981b1d77904cdcd76b966a824e15", size = 6099319, upload-time = "2026-03-29T14:57:12.166Z" },
-    { url = "https://files.pythonhosted.org/packages/13/ad/22e30e630a147e10a912e085c4cb816a0dc39bee8d39493b40101f3da4c7/pygit2-1.19.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ff32adce1a48d76b10e790b36784f6cb5ef40699b758c8b84f7f53f13b13d237", size = 5822074, upload-time = "2026-03-29T14:57:13.84Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/08/71ea683386887a1aab8f9b8c282b6df7ce7fae45fc7c9959719c78baebba/pygit2-1.19.2-cp314-cp314t-win32.whl", hash = "sha256:637d7c023f6623da35cf02cd1091f260c709730dd615367f4524ec8d771d0898", size = 972866, upload-time = "2026-03-29T14:57:15.26Z" },
-    { url = "https://files.pythonhosted.org/packages/da/67/efbde3954bdcbadfb61d183badd9a3e730c4ad94ed10966abe0b177abe0c/pygit2-1.19.2-cp314-cp314t-win_amd64.whl", hash = "sha256:2805a8abd546e38298ce5daf33e444960e483acce68cbfb5d338e72ad5bc3503", size = 1201537, upload-time = "2026-03-29T14:57:16.72Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/0c/28ae2c74038d1c51092f525658986a261f1963ec96528e7b41e721387343/pygit2-1.19.2-cp314-cp314t-win_arm64.whl", hash = "sha256:376a0d2c27c082f6bd8b97fd8ffc1939f16dfe8374ec846deee9b11151b37b8a", size = 997795, upload-time = "2026-03-29T14:57:17.878Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/9c/9bc9a8d727b2ae8ae77306ecfb77a5dcf836da4997d4f7053c893f8e0d11/pygit2-1.19.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d696ee240cc8b84e747b04443d85768c859ef0b88abe4a3505dc0b8e2a953ca0", size = 5708797, upload-time = "2026-06-13T08:05:00.097Z" },
+    { url = "https://files.pythonhosted.org/packages/63/7e/9099ea2f90791549185f8ac737a8b448e05cf3882cc79928a380be9bf38c/pygit2-1.19.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:86318a704bef836067fa9ac06c56591738d548dcdf2ea24ec227257e3f8115f8", size = 5700295, upload-time = "2026-06-13T08:05:01.676Z" },
+    { url = "https://files.pythonhosted.org/packages/39/84/e9610f041dc43699fca8af55050f9bf9fe0d340ab9902ab8e3fa67bece23/pygit2-1.19.3-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dc3ddb3e5d16cf662d2d0faeb53259e31ae584cc990cd76df909beeb4a36736a", size = 6036822, upload-time = "2026-06-13T08:05:03.473Z" },
+    { url = "https://files.pythonhosted.org/packages/64/bd/419ec17df3f1f1182de8c8fe800b698ff2a489cc50ec2d34990092bf3d61/pygit2-1.19.3-cp312-cp312-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:73820fb34339fe3c52731d1c46c298a3239ee75b61bc3a2d9b45f8b8873acc47", size = 4638181, upload-time = "2026-06-13T08:05:05.145Z" },
+    { url = "https://files.pythonhosted.org/packages/90/5f/aecca9c7f4ffdc1facc4b2402ea40073848e67c8c607a5f0698e1e8a61e4/pygit2-1.19.3-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:20f6ad50608f51b053bf6c321ae2c31cc57f15e4131a4609261c44e29bdae7cb", size = 5799910, upload-time = "2026-06-13T08:05:06.48Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/2a/e131af7752f75f70e04f7f3ae724481d0e2db9c6c688a2081ffb5948657e/pygit2-1.19.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b2c63c7a371dbd5825e5fb7069b759c79aa5dec97806d49cb2c9f9a8a373209d", size = 6042766, upload-time = "2026-06-13T08:05:08.052Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/a5/978ee5233379b2aa725c290a7cc3baca9b141f4fc37d55d9a473631b529b/pygit2-1.19.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:977eb52cd4134ff60d3faa168327a03f8724278c38bfcd347d8e3a11041ee9cd", size = 5771434, upload-time = "2026-06-13T08:05:09.398Z" },
+    { url = "https://files.pythonhosted.org/packages/26/33/7c506492fffe3e92d9e911fae43a4b4a3dee43682b71b7793d586c25acfc/pygit2-1.19.3-cp312-cp312-win32.whl", hash = "sha256:14a2734d793d2d937d3bfc9d35b280ec83fc97a91b1934b1013554d41e6d3d70", size = 945030, upload-time = "2026-06-13T08:05:11.187Z" },
+    { url = "https://files.pythonhosted.org/packages/82/ff/57ad08d1e87ae6e4208f80923ce1a6ea8a03ea776376e39d64816637b168/pygit2-1.19.3-cp312-cp312-win_amd64.whl", hash = "sha256:a7caeaf46aaa8e51c512af9ac1377f388e4836c9d042e134bbc5e22519fbd1bf", size = 1254825, upload-time = "2026-06-13T08:05:12.315Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/cf/476c217a4ab3c9b4abf2506fb1135e54b19d205ce7ddecb1d961bf93a9dc/pygit2-1.19.3-cp312-cp312-win_arm64.whl", hash = "sha256:2aafa010e3ac227913f398c8a680bce419e396dfe651685fffb779ed1c109a00", size = 969650, upload-time = "2026-06-13T08:05:13.438Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/12/1e0f0fc54a24ddfdabb0da0bafb3237c82b5628a8c5258ba66fb8d39b5b2/pygit2-1.19.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:9238bf7a8a953f4faedcbe90eb097b760a2709c7e7ab38edcf18dc2d0ce9dcff", size = 5708790, upload-time = "2026-06-13T08:05:14.755Z" },
+    { url = "https://files.pythonhosted.org/packages/82/12/9093b7b81de7fe869f6ae51319a05b9f0a8b2567674e0d61fd54aacb833f/pygit2-1.19.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7f999a4995504a6c14443de9481b7c6c54802663fe80c7504e1b946348f43786", size = 5700256, upload-time = "2026-06-13T08:05:16.363Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/07/a5133f79cf86e8a0cadf9f424cdd5b912ba47410c7254c0237b6e5290ddb/pygit2-1.19.3-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0918bc9b7597f243aa4b9c785912ae853e9aee4f572bcd5c9c591fcb703542f7", size = 6037556, upload-time = "2026-06-13T08:05:17.823Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/fc/3aa049d88eaa51f14f1fbfc0b70ac4c2362d3306dbeb8d1e5e3ca301e1dc/pygit2-1.19.3-cp313-cp313-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:18403fee0171867be5fc1c1415bcd5d5a7fab51299bdd44bcf467c22a868fd22", size = 4638864, upload-time = "2026-06-13T08:05:19.325Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/b7/5e772367db14f800048fa2a0981abd45baae6dcd8b83453da6ac0f92cead/pygit2-1.19.3-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cacece712337029092a98cf1af8d244e92fa8b36e5a64d7e14212ff73ea821e8", size = 5801146, upload-time = "2026-06-13T08:05:20.748Z" },
+    { url = "https://files.pythonhosted.org/packages/07/79/075b37b9a971cc7df9721add0e03cded83cab9e7d9736a80820357b2a972/pygit2-1.19.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:49d7c494bdaa5a8da366e4c4b7c822e52bd33bb6f22c67f8585b5396e91f8ac7", size = 6043951, upload-time = "2026-06-13T08:05:22.232Z" },
+    { url = "https://files.pythonhosted.org/packages/94/76/72e13c487d013f21f97690f0662cb03533d91aad39e0c7c4c8cd3e4453d0/pygit2-1.19.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2bbe74fbe553c6f991512391822c27c9321e3a0b45cab872f45c8d458393eee3", size = 5772767, upload-time = "2026-06-13T08:05:23.487Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/24/5ba37f80fcb303bcf1a3813631e5b5dddfbac771cce7efc0b03428f4fa2e/pygit2-1.19.3-cp313-cp313-win32.whl", hash = "sha256:3ab184751ca7a92007dbd8ae4ae4ac3b7228ef60ae2d2e18129b44bbe5c0aa4c", size = 945026, upload-time = "2026-06-13T08:05:25.053Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/48/4ae19f2e4dc8ff2ddc2fd64de7fd1d26aeb2b453069d6c9ee251dd567983/pygit2-1.19.3-cp313-cp313-win_amd64.whl", hash = "sha256:522d9c6ab9206880dceaae5516720c0f0df706859d2ba97f49adcaeea2d661bd", size = 1254793, upload-time = "2026-06-13T08:05:26.174Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/7b/473ca9e35dfd82c758b700a6cf4ecc107b849674e91ab219383063ebb12f/pygit2-1.19.3-cp313-cp313-win_arm64.whl", hash = "sha256:c77d5a1334ca3f1432c83457e03be8759d8e9040e0d25c59c738f2318545654a", size = 969666, upload-time = "2026-06-13T08:05:27.351Z" },
+    { url = "https://files.pythonhosted.org/packages/99/15/ec8a777b497853edab4e150c9ea46019b6c709b3c2b06fd06454a1aaa8c6/pygit2-1.19.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:214140f2201474e9d8e3889e5635e323aa90a58e6ae224a9de56be83d3e9b747", size = 5710849, upload-time = "2026-06-13T08:05:28.71Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/be/a8c449fba4c70239d6e9d0023b1fdd783c2dbb52872fef9c4de1652e930a/pygit2-1.19.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:46fc9fd234b2a38176625af6bfd2dbad99ab937379a980761c59a343bdff4910", size = 5700188, upload-time = "2026-06-13T08:05:30.466Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/19/8e92b4008324137878e9f9e130b4e349956d2a2b719521b8ce45aad6a0de/pygit2-1.19.3-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:eb9f46b561ee53f22cb479e7fdefd7b8ae478d12656436a48166c2ad81a3c021", size = 6039510, upload-time = "2026-06-13T08:05:31.892Z" },
+    { url = "https://files.pythonhosted.org/packages/90/8f/baf3a0944f54acc27ceaa22b47ca52cd64c8bb1ec69473f80d3f4bafe54d/pygit2-1.19.3-cp314-cp314-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9f393932fadd8e74f26d7ebb58da649e7a188d9156b732dd6c9f0dfc273d4430", size = 4643029, upload-time = "2026-06-13T08:05:33.385Z" },
+    { url = "https://files.pythonhosted.org/packages/69/1b/0b045e74fe01b29af28a5d54a9c89693db97e7e6cbd700f8086f4294e85e/pygit2-1.19.3-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c9521a9b45de3affd82618e94f7e5116685e695e65fcbf67b2f1e44a086c0f4a", size = 5803099, upload-time = "2026-06-13T08:05:34.873Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/d2/0d4eb93b7088316b9885b9c29b6a971009a20bf93aebd5762d3b809d72bf/pygit2-1.19.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:241f0fcd2aaf025e9fb5e1887eac5f244cb6b0a6e83dc27d673fa634ab0e0ee3", size = 6044603, upload-time = "2026-06-13T08:05:36.191Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/8a/5a486a8aa9a1aa6a1ed5189b71b1b96e92bd164cc3e4d010e285032a2662/pygit2-1.19.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c1729caee68cdf35c0cdb913de3850724438e4bdf480742da4f21a3e86d83662", size = 5773603, upload-time = "2026-06-13T08:05:37.605Z" },
+    { url = "https://files.pythonhosted.org/packages/94/ff/e6a5da1fe3b104fc153160bfe56a85298a6c81b5411ee8de97e4039d3a2f/pygit2-1.19.3-cp314-cp314-win32.whl", hash = "sha256:2c300d234ef15e4c557a7e9ac880163606b364d0d4e20ddbf1204b4ee9f9b61c", size = 965699, upload-time = "2026-06-13T08:05:39.151Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/a1/a8f21afe574f22fde3d04fb102c4e75b5a1077fa1ea1ee3f7b072aa8f858/pygit2-1.19.3-cp314-cp314-win_amd64.whl", hash = "sha256:0ff9f187b01d6629c14ad069b100e147093b70279496984faa012783c5832b66", size = 1288277, upload-time = "2026-06-13T08:05:40.315Z" },
+    { url = "https://files.pythonhosted.org/packages/95/65/f5268ac09c91f25e349a658cd9722b3528b1c4d6b18aab7472132e067912/pygit2-1.19.3-cp314-cp314-win_arm64.whl", hash = "sha256:cdfbf879ee0d468d7929eb26e35db7442b56a411af1d5b7d28e858cccf71598a", size = 997247, upload-time = "2026-06-13T08:05:41.629Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/98/9825e08b78a58bc99e979e322b8c776e6a4b49dcebf68471b650bf97e1ed/pygit2-1.19.3-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:79a3b565e20bbbbf21d29de1675a18e0e556545a2c738f38c0ac0435269f56bd", size = 5714170, upload-time = "2026-06-13T08:05:43.326Z" },
+    { url = "https://files.pythonhosted.org/packages/82/00/8836f806512ac0a9e8613b2b446a0fe2578834c01c2234ca6d6f2abd6751/pygit2-1.19.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:828856512070cda223c19046b02af50135a5b0efa274a80fbf7c82d773f8e89f", size = 5703231, upload-time = "2026-06-13T08:05:44.997Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/9b/117fcbd26d30729e9f46889747823e51cb5597d191c100da298faa79bb90/pygit2-1.19.3-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:eec2b1d50bf52d2139d3d478d6d5f5ee56103da4a6dbd786344e8a85254dd07b", size = 6097836, upload-time = "2026-06-13T08:05:46.269Z" },
+    { url = "https://files.pythonhosted.org/packages/70/8c/c1fa28b4e3064ef0e06e49af3cbcbf50b62f36fab3f9832c15cd46d0a175/pygit2-1.19.3-cp314-cp314t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:dbfa10f22670e7fef13bf249c32aebcafe23115790155d6b71efafb9aa7d4cba", size = 4697771, upload-time = "2026-06-13T08:05:47.629Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/c5/1d72a285fe794e2ce87ebe4b107c7cc713917e6e62b24264580b966740ea/pygit2-1.19.3-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d22c2940bde27f9ffe095aac87e7c8b8a9c787f91782c7463387d39a2592d04c", size = 5854885, upload-time = "2026-06-13T08:05:48.988Z" },
+    { url = "https://files.pythonhosted.org/packages/60/ac/250da1cff67e38af607792ed98a49c64b5980d5332d5f26c1882f722cefe/pygit2-1.19.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:0ed9f15b4b0b80191669fdf5b702b697ffbc245d24995befa80e46bef3aea25e", size = 6100802, upload-time = "2026-06-13T08:05:50.395Z" },
+    { url = "https://files.pythonhosted.org/packages/33/fc/1208276e01868b7ec1eb4c108dedabee114e24809eecf08820f9a52c3435/pygit2-1.19.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:40f1253e042d0a5dfed16eec92b5b28a529c2873f4ee77ca60d1ea7b79a14600", size = 5824124, upload-time = "2026-06-13T08:05:51.787Z" },
+    { url = "https://files.pythonhosted.org/packages/03/3a/04d44e2ff972a8a7846d48ae288f717a058331d6e056a652cafbcd7f6867/pygit2-1.19.3-cp314-cp314t-win32.whl", hash = "sha256:245d627a8ae3f35dafd9ce5b35538ddb5ba0c3fe6be8d2f9aa410f93a9184b83", size = 968784, upload-time = "2026-06-13T08:05:53.107Z" },
+    { url = "https://files.pythonhosted.org/packages/40/89/d42e745838fa0d9072bf425adf5b590b521b7a196d3b92f40951af9e4514/pygit2-1.19.3-cp314-cp314t-win_amd64.whl", hash = "sha256:8d2e3044ac1b09ef9120deb1896a56423c6dd17eb5ac4012c3c49dd590ee4910", size = 1291338, upload-time = "2026-06-13T08:05:54.546Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/10/61513d337a9241e9ce54edfd8fc1d8f2b0f36cbfa37de227ded0ffdbdc96/pygit2-1.19.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ef2790c9ff7e7673d7262e9e059c5af86c09197037073fd004d22a63e4151291", size = 998330, upload-time = "2026-06-13T08:05:55.888Z" },
 ]
 
 [[package]]
@@ -2144,15 +2145,15 @@ wheels = [
 
 [[package]]
 name = "python-discovery"
-version = "1.4.0"
+version = "1.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
     { name = "platformdirs" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a6/12/38c1a0b1e64806780c9563e3fc9f6e472251839662587cfbe9bfaf2ae10a/python_discovery-1.4.0.tar.gz", hash = "sha256:eb8bc7daad3c226c147e45bb4e970a1feb1bf4048ee178e6db59e197b8010ce3", size = 68455, upload-time = "2026-05-28T01:15:37.639Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/1a/cbbaf13b730abb0a16b964d984e19f2fe520c21a4dc664051359a3f5a9e7/python_discovery-1.4.2.tar.gz", hash = "sha256:8f3746c4b4968d22afbb97d36e1a0e5b66e6c0f297290f2e95f05b9b8bf18690", size = 70277, upload-time = "2026-06-11T16:10:42.383Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c8/8d/3d316429f65029532bb1e28ff77b797d86b5ac3915bb44ca4e19aa283d43/python_discovery-1.4.0-py3-none-any.whl", hash = "sha256:26ed78d703e234879a66244c7d4114563fb13ec5cd30a2d1357e5fb4850782da", size = 33217, upload-time = "2026-05-28T01:15:36.573Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/82/a70006589557f267f15bd384c0642ad49f0d97b690c3a05b166b9dcbad3b/python_discovery-1.4.2-py3-none-any.whl", hash = "sha256:475803f53b7b2ed6e490e27373f9d8340f7d2eebf9acdaf645d7d714c97bb500", size = 33886, upload-time = "2026-06-11T16:10:41.192Z" },
 ]
 
 [[package]]
@@ -2636,27 +2637,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.16"
+version = "0.15.17"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a6/bd/5f7ec371001337d8fa61701c186ff8b613ecac1651848c5950f4c4d5f2e9/ruff-0.15.16.tar.gz", hash = "sha256:d05e78d38c78caf020b03789e25106c93017db5a0cb6e2819885018c61343b78", size = 4714267, upload-time = "2026-06-04T16:33:09.974Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/a9/3abdf488f1bf3d24c699415e454ed554a6350d5d89ce183be1ee0a3361ac/ruff-0.15.17.tar.gz", hash = "sha256:2ec446937fd16c8c4de2674a209cc5af64d9c6f17d21fbf1151054fa0bcf5219", size = 4743346, upload-time = "2026-06-11T17:54:47.663Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/42/53ef1c3953f157956db9bf7861e3bc50b9b887ce93300aa48cdba8336fe6/ruff-0.15.16-py3-none-linux_armv6l.whl", hash = "sha256:6ac3c0b3969cc6cf6b158c4e2f8f682acb58e7d700d8a44b65ecdc72d66ab0b2", size = 10709025, upload-time = "2026-06-04T16:32:51.935Z" },
-    { url = "https://files.pythonhosted.org/packages/93/9a/a79159346f19134a956607754e57d8d128f7a4c00f4ad2f7514d224c172c/ruff-0.15.16-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:197c207ed75ffba54a0dec23db4aa939a27a3053073e085e0042433cbdc58e4a", size = 11063550, upload-time = "2026-06-04T16:32:42.24Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/72/3ce2ac000a5299ec238e01f51397b3b653c93b077d9b1bfe8715bb895f20/ruff-0.15.16-py3-none-macosx_11_0_arm64.whl", hash = "sha256:3a39fec45ab316cc23e7558f23fea4a70403ddb5648ea9a4a3854a16973d0071", size = 10421345, upload-time = "2026-06-04T16:32:37.251Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/c2/cc7fad3ec9169373f5b6a18f1917b91080feec40c3f9658334a1d28e2f03/ruff-0.15.16-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ba93191d79003116b95128c9d306e045200fdbd0bccb782b110f3cd1d4abc5cf", size = 10757217, upload-time = "2026-06-04T16:32:54.722Z" },
-    { url = "https://files.pythonhosted.org/packages/69/d2/3474009eaa0a65b31fa7152a2fad5e2f050c640ceb1e6b02ee6922e94c82/ruff-0.15.16-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c6ee4b90520630120ef032aa5cc10db483852dff950e78b1d717e2993a61ac8d", size = 10507035, upload-time = "2026-06-04T16:33:05.343Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/81/b7ae6ccbd11f0c8dc3d5d67fc4be9b57ff57ca86ba56152021378e1277f2/ruff-0.15.16-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4e4215bc938bc3c8215c1472c1aa437e310fee20cd427335fec9d7e609563628", size = 11255291, upload-time = "2026-06-04T16:32:49.49Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/e1/46e526f1a7cc90857ce6ddf25fbb77eb6568651ac38d71b033af07076dd5/ruff-0.15.16-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7c8d26be963b090f10e29abc8b3e74a2a321f6fa34e02424e30b5af89350ecbb", size = 12124922, upload-time = "2026-06-04T16:33:07.821Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/da/5c791b088b596b24d0deb967fa28ae02ad751a140c0b9ea81c5ab915d6c0/ruff-0.15.16-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f198cf4123602a2280ed46c307bcbafe41758d6fee5b456b6b6058ca1514b3b4", size = 11332186, upload-time = "2026-06-04T16:33:02.971Z" },
-    { url = "https://files.pythonhosted.org/packages/72/11/5da87abe20047c8962361473923ebb2f62b595250126aadfad8c20649c1e/ruff-0.15.16-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bb27515fa6240fb586ae82b901a59e67d24acff86f2190b433dc542fe0435aeb", size = 11373541, upload-time = "2026-06-04T16:32:47.007Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/2a/8554754c23a854ae3fd6b507e36ad61ddb121e298c6d5d617dec94ed0f14/ruff-0.15.16-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:a267c46ba1593fc26b8eecbea050b39d40c0b6bb7781ee11c90a02cd10032951", size = 11353014, upload-time = "2026-06-04T16:32:34.795Z" },
-    { url = "https://files.pythonhosted.org/packages/62/25/62ea41529ec89f742ea3fed9cb1059c72877ec7cf9b9e99ac9cf3294d1d9/ruff-0.15.16-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:528c68f39a91498a8d50e91ff5985df3d105782bab49cc378e73ac26bff083e8", size = 10737467, upload-time = "2026-06-04T16:32:26.348Z" },
-    { url = "https://files.pythonhosted.org/packages/90/17/334d3ad9de4d40f9dd58fdd09e35ce64553bb501e2f19a839e2fb6be14fc/ruff-0.15.16-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:7ed55c58950df60589a9a7a5d2f8fa5f54ebd287163be805adfe6ee95a9de123", size = 10521910, upload-time = "2026-06-04T16:32:32.54Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/bd/3ac7c6ae77a885c1004b3dda2446ea401768d24f851c14b4ad4b24f6639c/ruff-0.15.16-py3-none-musllinux_1_2_i686.whl", hash = "sha256:d482feaf51512b50f9790ceb417a56a61dd1e9d9bf967662b9ed27c01b34f53a", size = 10979190, upload-time = "2026-06-04T16:32:57.492Z" },
-    { url = "https://files.pythonhosted.org/packages/33/d7/609546e6a413c3f216fbf2a50c928f97c80939154f6a0503114094a86191/ruff-0.15.16-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:1e15bc8c94513dae2a40cc9ef07c94fdd4ecc9e29dabebeebe170f952322c9e3", size = 11477014, upload-time = "2026-06-04T16:32:44.687Z" },
-    { url = "https://files.pythonhosted.org/packages/74/0d/f2cd247ad32633a5c36e97141a2c21b11c6279f7957bc2ff360b1e08fddd/ruff-0.15.16-py3-none-win32.whl", hash = "sha256:580378f7bd4aa25f72e74aa54948a9622f142b1e509521dd10902e886681cc1e", size = 10735541, upload-time = "2026-06-04T16:32:30.145Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/9e/02e845ef151b1dee585e55c4739f8e1734ae1d9f1221dff65761c162208b/ruff-0.15.16-py3-none-win_amd64.whl", hash = "sha256:408256017284eddf98fff77b29aa4fb30f586042d535b2d9befc6512f400aaec", size = 11843403, upload-time = "2026-06-04T16:32:39.76Z" },
-    { url = "https://files.pythonhosted.org/packages/15/19/016553f86f207450aebebc2b2b5088d086b901cc8186c02ac4284db3bd88/ruff-0.15.16-py3-none-win_arm64.whl", hash = "sha256:8cd61783afb39638a7133ef0d2dfb1e91277593962f81b5a8423eb0b888a6121", size = 11134555, upload-time = "2026-06-04T16:33:00.136Z" },
+    { url = "https://files.pythonhosted.org/packages/db/4d/e11259f5da07cb6afb2d074c31bf09da9671993f7329d4f15d2fdc458301/ruff-0.15.17-py3-none-linux_armv6l.whl", hash = "sha256:d9feddb927fc68bd295f5eebc587a7e42cfaf9b65f60ca4a2386febff575da8f", size = 10856677, upload-time = "2026-06-11T17:54:49.533Z" },
+    { url = "https://files.pythonhosted.org/packages/29/3e/772d679e1a0dc058e58875bd2c0cb713a0530877b4a76fee3c7966df0d49/ruff-0.15.17-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:25805a226d741c47d274a35ad5c10a7dde175fcddfa511d7cf3da0a21eb3eab7", size = 11223443, upload-time = "2026-06-11T17:55:00.573Z" },
+    { url = "https://files.pythonhosted.org/packages/68/58/bd41f7688b2fd5623012605130ed70e60aa7f2244baa3d5066bdd61530c8/ruff-0.15.17-py3-none-macosx_11_0_arm64.whl", hash = "sha256:f6ad73b14c2d18a3bf8ad7cb6974294d7f613a7898604826058e6ac64918ef4d", size = 10566458, upload-time = "2026-06-11T17:55:07.52Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/5b/733371013fcf1ec339e477ece6ab42bfe10bdd9bba8ee88a9516aa56bfc0/ruff-0.15.17-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6ba0c1e4f95bcb3869d0d30cbd5917071ef2e28665abfec970cdab0492c713ed", size = 10914483, upload-time = "2026-06-11T17:55:05.501Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/cc/6f24251cc0252f7239391ccb85833f320efad14ebe5b443943f37ced6332/ruff-0.15.17-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:81647960f10bff57d2e51cadd0c3950fe598400c852863a038720ef5b8cca91e", size = 10647497, upload-time = "2026-06-11T17:54:57.733Z" },
+    { url = "https://files.pythonhosted.org/packages/68/dd/0d10c17ce1a1624d6fc3156309c3f834fdb5dfaad026ec90c85684f3990e/ruff-0.15.17-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0e01a84ddbc8c16c23055ba3924476850f1bbc1917cebbb9376665a63e74260d", size = 11416967, upload-time = "2026-06-11T17:54:51.461Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/91/556bfb156f6144f355e831c23db00b2fc4120f86b3ce81cc5f7fd2df51f3/ruff-0.15.17-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:84fe9f653152f8f294f9f7e03bf3a453d8b4a27f7a59c78c8666167f2b17b96c", size = 12335770, upload-time = "2026-06-11T17:54:45.793Z" },
+    { url = "https://files.pythonhosted.org/packages/88/82/8b5999aa13355e926f06d9f42a32dcca862f623bf0363785ff89d607dffd/ruff-0.15.17-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c0fe88a7676e7a05b73174d4d4a59cb2ac21ff8263583f87a81a6018475a978", size = 11575441, upload-time = "2026-06-11T17:54:32.661Z" },
+    { url = "https://files.pythonhosted.org/packages/11/93/f10377bb04109ca0e8cbc483ff1982c54b6d418210041776f93e8cdc7fa9/ruff-0.15.17-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ecfc3c7878fff94633ab0348524e093f9ce3243080416dd7d14f8ba400174719", size = 11557614, upload-time = "2026-06-11T17:54:34.698Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/a6/eeeae7f7d5493df41649ab3db92f086b2d0a30199e4efdf8e3dd7a033f24/ruff-0.15.17-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:b8461180b22420b1bdc289909410930761629fddf2a5aaf60fae1ab26cedc4c4", size = 11544450, upload-time = "2026-06-11T17:54:39.042Z" },
+    { url = "https://files.pythonhosted.org/packages/32/88/5991ce565129a24dd4a00db1254b3b5db2e53018cbe4018ea5a89738e727/ruff-0.15.17-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:6eccbe50a038b503e7140b441aa9c7fc8c1f36edf23ebef9f4165c2f28f568b7", size = 10892524, upload-time = "2026-06-11T17:55:09.432Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/1d/0fdd248313425f55223968af04b0a42125466a8d88d21c1d99c6af0a51e8/ruff-0.15.17-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:382fc0521025f5a8ad447d8bdd523545d0d7646adb718eb1c2dac5065ec27c0f", size = 10659573, upload-time = "2026-06-11T17:54:36.824Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/0e/072e8260deb9461062ce9311ced27a8e541229a6ffd483013dd37661e43e/ruff-0.15.17-py3-none-musllinux_1_2_i686.whl", hash = "sha256:456d41fcd1b2777ad63f09a6e7121d43f7b688bbc76a800c10f7f8fb1f912c3f", size = 11127818, upload-time = "2026-06-11T17:55:03.124Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/b4/55060a34163121498014696b5f656db5b8c6963768f227dbf0d76b311073/ruff-0.15.17-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:b1a04bcc94ae6194e9db05d16ad31f298a7194bfbcb08258bbe589cee1d587b8", size = 11655901, upload-time = "2026-06-11T17:54:53.562Z" },
+    { url = "https://files.pythonhosted.org/packages/49/71/9b29d6b87cef468d697f43c6a91e3fae4a80185779d7d5a4ef27d173439f/ruff-0.15.17-py3-none-win32.whl", hash = "sha256:596065960ab1ff593f744220c9fe6580eda00a95003cffa9f4048bb5b1bf0392", size = 10925574, upload-time = "2026-06-11T17:54:55.723Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/b2/8fc77f3723228836fa5d12497eb71c808f83782e10d058d2b15cfa14640b/ruff-0.15.17-py3-none-win_amd64.whl", hash = "sha256:6769e5fa1710b179b92e0bfa5a51735b35baea9013dadb06d5f44cbcf9547084", size = 12058788, upload-time = "2026-06-11T17:54:41.042Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/c7/c53e8dbff9c9dc4b7928773421ae294a5d28fcb8dcda1a089579d3a7e510/ruff-0.15.17-py3-none-win_arm64.whl", hash = "sha256:f3be1fbb34bcdfd146240d8fb92a709d4c2c8191348580a3c044ec60fa0b4456", size = 11355275, upload-time = "2026-06-11T17:54:43.635Z" },
 ]
 
 [[package]]
@@ -2873,14 +2874,14 @@ wheels = [
 
 [[package]]
 name = "tinycss2"
-version = "1.4.0"
+version = "1.5.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "webencodings" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7a/fd/7a5ee21fd08ff70d3d33a5781c255cbe779659bd03278feb98b19ee550f4/tinycss2-1.4.0.tar.gz", hash = "sha256:10c0972f6fc0fbee87c3edb76549357415e94548c1ae10ebccdea16fb404a9b7", size = 87085, upload-time = "2024-10-24T14:58:29.895Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/ae/2ca4913e5c0f09781d75482874c3a95db9105462a92ddd303c7d285d3df2/tinycss2-1.5.1.tar.gz", hash = "sha256:d339d2b616ba90ccce58da8495a78f46e55d4d25f9fd71dfd526f07e7d53f957", size = 88195, upload-time = "2025-11-23T10:29:10.082Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e6/34/ebdc18bae6aa14fbee1a08b63c015c72b64868ff7dae68808ab500c492e2/tinycss2-1.4.0-py3-none-any.whl", hash = "sha256:3a49cf47b7675da0b15d0c6e1df8df4ebd96e9394bb905a5775adb0d884c5289", size = 26610, upload-time = "2024-10-24T14:58:28.029Z" },
+    { url = "https://files.pythonhosted.org/packages/60/45/c7b5c3168458db837e8ceab06dc77824e18202679d0463f0e8f002143a97/tinycss2-1.5.1-py3-none-any.whl", hash = "sha256:3415ba0f5839c062696996998176c4a3751d18b7edaaeeb658c9ce21ec150661", size = 28404, upload-time = "2025-11-23T10:29:08.676Z" },
 ]
 
 [[package]]
@@ -2948,19 +2949,19 @@ wheels = [
 
 [[package]]
 name = "tornado"
-version = "6.5.6"
+version = "6.5.7"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/50/57/6d7303a77ae439d9189108f76c0c4fd89ee5e2cc8387bffb55232565c4ed/tornado-6.5.6.tar.gz", hash = "sha256:9a365179fe8ff6b8766f602c0f67c185d778193e9bdd828b19f0b6ed7764177d", size = 518139, upload-time = "2026-05-27T15:35:54.646Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/64/24/95ec527ad67b76d59299e5465b3935d05e4294b7e0290a3924b7487df30b/tornado-6.5.7.tar.gz", hash = "sha256:66c513a76cda70d53907bc27cf1447557699c2e95aa48ba27a442ff61c3ddfc2", size = 519252, upload-time = "2026-06-08T17:34:51.232Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/0d/b4f481e18c5a51864e6d12b9a05ecf72919696680b747c958c3fc1f4fbae/tornado-6.5.6-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:65fcfaafb079435c2c19dc9e07c0f1cf0fa9051759ed0a7d0a3ba7ea7f64919c", size = 447737, upload-time = "2026-05-27T15:35:38.122Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/9c/5430c39fcab1144d35860f457b15e9c08b4bc7ac86764354204e983d6183/tornado-6.5.6-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:38bc01b4acacded2de63ae78023548e41ebe6fbed3ec05a796d7ae3ad893887e", size = 445899, upload-time = "2026-05-27T15:35:40.519Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/79/fa7e14a2f939c807a8d30619b4eb604eab219601b78792516ebe22d40cf9/tornado-6.5.6-cp39-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b942e6a137fda31ff54bf8e6e2c8d1c37f1f50583f3ed53fb840b53b9601d104", size = 448964, upload-time = "2026-05-27T15:35:42.106Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/71/bd67d5f5199f937dafe03a49a37989f60f600ff6fef34c79412a829d97bd/tornado-6.5.6-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8666946e70171b8c3f1fc9b7876fac492e84822c4c7f3746f4e8f8bc9ac92a79", size = 449935, upload-time = "2026-05-27T15:35:43.906Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/a4/c24388c9cf5b3c3a513b56a158af9f23092c9a2810d789e294310797df21/tornado-6.5.6-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1c34cfab7ad6d104f052f55de06d39bbafc5885cfeb4da688803308dbcfa90b7", size = 449767, upload-time = "2026-05-27T15:35:45.793Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/eb/6a07ad550c3f7b37244bd0becdf293ec3d3e961783d8b720a97df50de1b2/tornado-6.5.6-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:385f35e4e22fb52551dfcda4cdc8c30c61c2c001aef5ddad99cdfe116952efd3", size = 449174, upload-time = "2026-05-27T15:35:47.485Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/84/3469e098dccdb6763130e06aacd786bb4363fca7b590a55c101ddf34ed30/tornado-6.5.6-cp39-abi3-win32.whl", hash = "sha256:db475f1b67b2809b10bb16264829087724ca8d24fe4ed47f7b8675cae453ef86", size = 450230, upload-time = "2026-05-27T15:35:49.322Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/3c/273a04e0b9dd9016f1685cca0c1c8795a71ac88a34a8c889a0b443483226/tornado-6.5.6-cp39-abi3-win_amd64.whl", hash = "sha256:6739bf1e8eb09230f1280ddbd3236f0309db70f2c551a8dbc40f62babdf82f79", size = 450667, upload-time = "2026-05-27T15:35:51.194Z" },
-    { url = "https://files.pythonhosted.org/packages/02/98/0cffe22a224f60c5fb1e3aa0b76f9da2e1ca78b0e9545e3d077c68ce60a7/tornado-6.5.6-cp39-abi3-win_arm64.whl", hash = "sha256:2543597b24a695d72338a9a77818362d72387c03ae173f1f169eadc5c91466ac", size = 449690, upload-time = "2026-05-27T15:35:52.902Z" },
+    { url = "https://files.pythonhosted.org/packages/02/dc/c7043cab6fed8ae159fc1923ce829ada35c4dbd797d408a43858ffaf9639/tornado-6.5.7-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:148b2eb15c2c765a50796172c1e499649b35f30d2e3c3d3e15913cfa56bfb163", size = 448543, upload-time = "2026-06-08T17:34:38.052Z" },
+    { url = "https://files.pythonhosted.org/packages/92/4f/090b1431e5a43df696feceffc268c5383cc079ecb5f08ce58f917109aafe/tornado-6.5.7-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:9da38de27f1da3b78a966f0dae12b5a1ea9afe72ca805d84ff06508272ddf100", size = 446707, upload-time = "2026-06-08T17:34:39.594Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d8/ef374952fd5da67d4463122c2b8e5a96536ec10b4b339254c6dcde81d01c/tornado-6.5.7-cp39-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:8d759e71906ee783f8867b93bf26a265743da4c1e2f4a018464c1ba019862972", size = 449774, upload-time = "2026-06-08T17:34:41.204Z" },
+    { url = "https://files.pythonhosted.org/packages/35/37/d434c73f4c6e014b745b9b37085f34f40c022f007efff3d7fe65991899f3/tornado-6.5.7-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8a46347a18f23fb92b396beebe0fb78f61dda0cc302445202c16203d8a18848b", size = 450745, upload-time = "2026-06-08T17:34:42.531Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/2b/56b9aff361d7f1ab728a805ec7d7ea835f8807afa9f5cc690ea0e630efb9/tornado-6.5.7-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7778b30bef919231265e91c69963ce0f49a1e9c07ac900bbe75b19ce2575ba92", size = 450578, upload-time = "2026-06-08T17:34:43.787Z" },
+    { url = "https://files.pythonhosted.org/packages/02/30/a7444fb23aa76860a14198fab96ac79f1866b0a6e19e26c4381b0938e50f/tornado-6.5.7-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e726f0c75da7726eec023aa62751ff8878bd2737e34fbdd33b1ae5897d2200f5", size = 449985, upload-time = "2026-06-08T17:34:45.326Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/42/5f0e56c01e8d9d36f4e23f367b85ae6cae0c1ecddd5e6977d8388ad27488/tornado-6.5.7-cp39-abi3-win32.whl", hash = "sha256:f8de3bf12d3efdd0cbe7c8887868198f8a91415e3f29fcf258d9b8eb7b1d9ae4", size = 451047, upload-time = "2026-06-08T17:34:46.784Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/a4/b393076ffb21b469eec5b328a0534cf03a3b90bfc6b1f09507cdd075d938/tornado-6.5.7-cp39-abi3-win_amd64.whl", hash = "sha256:de942f843533a039ef9fa3d9c88c7cd8a7c94553fb5ad0154270989b3d99a2c4", size = 451485, upload-time = "2026-06-08T17:34:48.248Z" },
+    { url = "https://files.pythonhosted.org/packages/71/2e/7b1c769803121b809112cf9a00681c472eae1d80e32d7ec0e0bd61d0d0e1/tornado-6.5.7-cp39-abi3-win_arm64.whl", hash = "sha256:ff934fce95643af5f11efdae618eaa73d469dc588641e5c8d19295a0c65c4796", size = 450506, upload-time = "2026-06-08T17:34:49.702Z" },
 ]
 
 [[package]]
@@ -2974,27 +2975,27 @@ wheels = [
 
 [[package]]
 name = "ty"
-version = "0.0.43"
+version = "0.0.49"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0d/37/4ec04de0659b93be37d956dfceca13b1ecab9c959f28d8a1d5e514603f36/ty-0.0.43.tar.gz", hash = "sha256:ea4cff50548f2a1877e848d3abe9e293cde8ab94757a7eb93fc0d4013f98be8e", size = 5798429, upload-time = "2026-06-04T00:52:10.013Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/8d/37cb91808069509d43a2a11743e12f1e854fd808dbef2203309d256718cd/ty-0.0.49.tar.gz", hash = "sha256:0a027bd0c9c75d035641a365d087ad883446057f9be0b9826251c2aecafbf145", size = 5884753, upload-time = "2026-06-12T03:08:20.221Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/db/74/1916026a78f20019a2f03adbd6fb4430ddb7ce1e52c2e17a90856a6d192e/ty-0.0.43-py3-none-linux_armv6l.whl", hash = "sha256:3bf70f5446480562bf6c9f639df4b5cb60716b8f8d1a6b8e5811d5c7eccd8bf2", size = 11598153, upload-time = "2026-06-04T00:52:20.646Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/af/58bb0089d2635216c8fa6612dd486a3f986d0ab1c46a41527ab95e57f0e3/ty-0.0.43-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:7184741f8b15425a1bc64b950ad005cb353573288ac0e8a04f5481ceb3832596", size = 11357811, upload-time = "2026-06-04T00:52:24.683Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/9c/32c6b14f3feddf87b59c7a50709e2b3da408258f2f583f05575f77bc8f7b/ty-0.0.43-py3-none-macosx_11_0_arm64.whl", hash = "sha256:8c306379ca9a35f6ae5270fe9bda7af4b46d91822725a2586d78c8b9b5493b62", size = 10772024, upload-time = "2026-06-04T00:52:14.312Z" },
-    { url = "https://files.pythonhosted.org/packages/09/fa/98aa4a74bd00cd5efc424923cd1daffbf1e40a0338041cafb203379d746f/ty-0.0.43-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d624b884c9c1fd244ad2a5f026364e7162a22b3f537025941ada2e363e676414", size = 11291034, upload-time = "2026-06-04T00:52:37.249Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/db/4de086c38ce96dcada2bd451f43171d2c237f96d8ed19a1ea8fe51bb8ef4/ty-0.0.43-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:281fc4c00fbc196045141faa085055bddc58846b04a2800204701415a1b9c6aa", size = 11364724, upload-time = "2026-06-04T00:52:33.138Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/d3/e3cd8e3233a6fd8362a49aa025b79e9f40151a2a86d811ace154c6eb7445/ty-0.0.43-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f57d6cc28de89024b48d1788e4758c05299d5749d4a51c02e71ac655ec23d9a5", size = 11890555, upload-time = "2026-06-04T00:52:22.711Z" },
-    { url = "https://files.pythonhosted.org/packages/80/7b/6f46d444e8241606bbde098df3dca93f2ec0b834a42055db85ee7d33646f/ty-0.0.43-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0a1d6ad6c5e7792c7eac0a01e550f2c2004462e01a64a91ea1636aba6fef6e71", size = 12450968, upload-time = "2026-06-04T00:52:28.94Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/e1/79fbe51f2e4b9d8347f2013cd7ed0b63f3b499038c02dc0357e9b28a3a47/ty-0.0.43-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:66d474395d7635fb618bdbb58b4e3360259a2056d0a5621b82754b9da2cd8a04", size = 12064187, upload-time = "2026-06-04T00:52:12.039Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/3f/c758a3a8df5b90d331f2b60c8f16021ee64d75e78f99d67cc4efc9bf5f4b/ty-0.0.43-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2663a0003a8b60fb98db7f6f6e673df80b21d0fe3a9868a26fb06b4e049b6fc4", size = 11943208, upload-time = "2026-06-04T00:52:31.14Z" },
-    { url = "https://files.pythonhosted.org/packages/54/5f/f516442749cf1b45ca6720a5d41df2738a486ed9ace774c03d515db89084/ty-0.0.43-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:d5a6c352d374d889189d5ec82b54b26a5885f769f7b7787f7f875500dcb8673e", size = 12143572, upload-time = "2026-06-04T00:52:18.457Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/bf/0d83c7f43bf4c10f3678bfe7d938e51c445298c7b923f155c5204730c2df/ty-0.0.43-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e7dbbeedfad3ca250d74fcc355fa9ab6b38d2a17f22d6304f615716939dbbb27", size = 11279355, upload-time = "2026-06-04T00:52:26.726Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/de/a6c978bef6d9e949f79f4782d9e4ee4df0893713e73b055d84c1a5116b9a/ty-0.0.43-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:24b18a0273ee46154996cfcfa27438f851f440c925587ec200df6f98dffe67d3", size = 11408412, upload-time = "2026-06-04T00:52:35.282Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/b1/d13857c23867f0f76b92e38e5841c64ca5e76dc5d4bf27f52cb81d8ab685/ty-0.0.43-py3-none-musllinux_1_2_i686.whl", hash = "sha256:2ef681951520d692b7e9c0b5e56aacf4f98ccae47cf6ffccaf2c7b6b33dc226e", size = 11541709, upload-time = "2026-06-04T00:52:16.451Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/f1/cd6afc6f6a687e238bf5e12189f7920e81a0bdef6c3dba4c784ef140f7d9/ty-0.0.43-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:2af105de7437143aa4676b28016b5bee661aaaa4eff52be5867fb25119641ceb", size = 12041266, upload-time = "2026-06-04T00:52:43.541Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/ba/51ca7c3335da2b8d0a3e477fa4986be9f4a53b05bfab862967d8d2e6ca60/ty-0.0.43-py3-none-win32.whl", hash = "sha256:e4773115b0d6486ee30f1657fc8bdffe7e3a3f5300ab77ef2495da6e83e4694f", size = 10858724, upload-time = "2026-06-04T00:52:07.843Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/29/5d80453e5f7c520145fa058851da87230dbd7ca761a7675447a9fe504e0b/ty-0.0.43-py3-none-win_amd64.whl", hash = "sha256:48d3545094a4ae6395492c7e6ac90550fce969e0ed2815fbf8c5da9756676b7d", size = 11976157, upload-time = "2026-06-04T00:52:41.438Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/ed/befe5a543e5b95e754ed38ee95239e44efda9bc5f578db4ac1bc8dd758d6/ty-0.0.43-py3-none-win_arm64.whl", hash = "sha256:740ca33d7f75f655a4e7d475bc42dfb825c13219bb073fad30fcc04d35790c74", size = 11308680, upload-time = "2026-06-04T00:52:39.233Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/de/9237c6a96356612dd0393db1e94cf21f903616adf3a3701bf3da6e4adc92/ty-0.0.49-py3-none-linux_armv6l.whl", hash = "sha256:12c0c4310b936d762a8586c210b53d4fa4bb361a04429afa89bf84b922e5e065", size = 11834671, upload-time = "2026-06-12T03:07:53.062Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/15/daf5a14a5e07012277d450c75325c94614e2acfec4c620c881486118c410/ty-0.0.49-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:737bfdc2caf9712a8580944dcdc80a450a37a4f2bc83c8fa9b7433b374f9e471", size = 11589570, upload-time = "2026-06-12T03:08:25.779Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/58/30bdf98436488aca25f0763bf7f92a061528d42461b686453029e845e4c5/ty-0.0.49-py3-none-macosx_11_0_arm64.whl", hash = "sha256:ab90c1baf3b1701d282fce4b02fa552a962d109f8972c46ef6b22429503bfea4", size = 10985236, upload-time = "2026-06-12T03:08:36.664Z" },
+    { url = "https://files.pythonhosted.org/packages/22/45/ece503e4a1396e13a1a9a0cde51afe476a6506a1d557eeadf8ad45c83bc0/ty-0.0.49-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b4ce8ecf6ba6fc79bd137cc0557a754f7e5f2dfe9436412551d480d680e248ad", size = 11504302, upload-time = "2026-06-12T03:08:01.664Z" },
+    { url = "https://files.pythonhosted.org/packages/17/dc/5d09333d289dfbca1804eaade125c9e8a1a992a2a592a8b80c5e9b589ca9/ty-0.0.49-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:10d85c6865c984e78661e0bd20b180514b4a289739224e84816e342bdf381e04", size = 11626629, upload-time = "2026-06-12T03:08:06.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/36/155f41c9dd7237c4b609211f29f77755a139ee6218605dadc7fe21d5e3c8/ty-0.0.49-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1d96a67a206619e01fa92f35a22267ec634bba62be24b1d0e947020cc179995b", size = 12074481, upload-time = "2026-06-12T03:08:09.643Z" },
+    { url = "https://files.pythonhosted.org/packages/96/4c/998ee13cd5045f1f8b36982de7343163832ac53f27debe01b0de0e8bd968/ty-0.0.49-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3de9f648564e0a66344ef397770387cb0d093735f8679d2c5a08a4741e79814d", size = 12678042, upload-time = "2026-06-12T03:08:39.319Z" },
+    { url = "https://files.pythonhosted.org/packages/85/c9/9a505aba85c41ce54cbcaa14f8d79aa084b86151d2d70df11c4655b92898/ty-0.0.49-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5779179ab397d15f8c9dbb8f506ec1b1745f54eac639982f76ef3ce538943b50", size = 12316194, upload-time = "2026-06-12T03:08:18.023Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/b8/ded37fb93503294abbc83c36470bb1413bea05048b745881d4470b518a06/ty-0.0.49-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:792d4974e93cc09bd32f934586080bbbe21b8e777099cb521cb2de18b68a49f0", size = 12145507, upload-time = "2026-06-12T03:07:56.505Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/07/392e80d78f02445f695b815bb9eb0fffacda68b03faee38c900f7b990815/ty-0.0.49-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:727bda86deb136073e525c2e78d60e38aedcce5d80579170844a52bbf7c1440d", size = 12365967, upload-time = "2026-06-12T03:08:12.553Z" },
+    { url = "https://files.pythonhosted.org/packages/50/d3/31b0c2a7fbedd3373e389cb1d81b8d2128f6f868fafb46557736a6f9aca8/ty-0.0.49-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:4f2fc2bc4a8d2ff1cca59fd94772cabdfec4062d47a0b3a0784be46d94d0540b", size = 11475283, upload-time = "2026-06-12T03:08:28.334Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/5b/329e101638920b468a3bb63059c9f66ef99b44aac501222c44832a507321/ty-0.0.49-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:3724bd9badef333321578b6a941fbc571ebf49141ec2356a8590fbe4c9aa588d", size = 11645343, upload-time = "2026-06-12T03:08:15.246Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/76/c897e615e32f80ca81c8c1bc49b9a1f72ff9e3cfea0f8345ba505fe28472/ty-0.0.49-py3-none-musllinux_1_2_i686.whl", hash = "sha256:166c6eb52ee4af3c5a9bb267d165d93000daa55c6758cd8ff3199741fb75917d", size = 11725585, upload-time = "2026-06-12T03:08:33.915Z" },
+    { url = "https://files.pythonhosted.org/packages/59/e1/fdb42ee239f618800842681af5bb8598117e74512c10974a8b7b9086a898/ty-0.0.49-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:91e81d832c287b05782ee32eb1b801f62c1fa08df37d589d2b88c3f1d51c9731", size = 12237261, upload-time = "2026-06-12T03:08:31.105Z" },
+    { url = "https://files.pythonhosted.org/packages/98/0f/a2d6a5fc9d0786cbeb3c200786da4e18c203589be3984bb5def83ca92320/ty-0.0.49-py3-none-win32.whl", hash = "sha256:7186af5ca9829d1f5d8916bcf767b8e819bfbf61b1b8ec843bb3fc699cb502e1", size = 11100789, upload-time = "2026-06-12T03:07:59.092Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/9d/473ac8bc57b5a2d121da893bf9dd74a118efb19a01d711df1a6e397f05cc/ty-0.0.49-py3-none-win_amd64.whl", hash = "sha256:ae2142fc126a01effcca0c222908b0e6654b5ba1266d4e4d406e4866aef8e1d1", size = 12204644, upload-time = "2026-06-12T03:08:04.327Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/a2/8959249da951ba3977fee20e688d28678b8a1d30a9ed4464228a85d45853/ty-0.0.49-py3-none-win_arm64.whl", hash = "sha256:75d5e2e7649765f31f4bed6c8adb149a75b18edd3fa6336dac4d0efc1a66466f", size = 11558965, upload-time = "2026-06-12T03:08:23.012Z" },
 ]
 
 [[package]]
@@ -3168,33 +3169,33 @@ wheels = [
 
 [[package]]
 name = "uv"
-version = "0.11.19"
+version = "0.11.21"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/67/f0/6254502aebfdc0a9df6069269a126dd58252ac29d2d6cdf4777cea3e90b5/uv-0.11.19.tar.gz", hash = "sha256:f56f5bf853626a30423052d7ee00bf5cc940a08347d6ee7ede96862d084054a5", size = 4213580, upload-time = "2026-06-03T22:37:15.976Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/f9/f45bb1c251962ee614afd58ccd3dc06ada7869d04987efc2858a81cc4e0f/uv-0.11.21.tar.gz", hash = "sha256:083882c73373a16de4c136d54e3386a52388dead5048a07505e25578b157182f", size = 4259001, upload-time = "2026-06-11T18:18:26.468Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1a/73/be32c2f6ba30fa9d8b3baceb478107cc23722d4aaab87145a332e4985185/uv-0.11.19-py3-none-linux_armv6l.whl", hash = "sha256:c729f56ffef9b945053412c839695e8a0b13758aa15b7763e95a7dd539a6f522", size = 23620003, upload-time = "2026-06-03T22:37:53.017Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/ed/3aefe4a4ca4ac9204c6745670dbe12f4add69194d40f5abd1c7bd45ba9af/uv-0.11.19-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:a98495b9dd67287d8c1a0786f98cb037a50f0ee6c3d648572edaa7137aabc277", size = 23183211, upload-time = "2026-06-03T22:37:20.699Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/eb/5d1469f9e709d56066f292978711fbf1f805b7fb46f901d3c1f260fd9908/uv-0.11.19-py3-none-macosx_11_0_arm64.whl", hash = "sha256:7fdd881cd6d80782afcf8c1d446dd15a42985167fd812b763d38ba1e4a8d944d", size = 21754003, upload-time = "2026-06-03T22:37:05.027Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/93/109b5ee6678f54492f94fdef74149643eaa1f2f4716906a2a10816b31247/uv-0.11.19-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:7222f45b5541551057bfc2e3021f113800704f665c119fdf3ea700c6c4859b21", size = 23518832, upload-time = "2026-06-03T22:37:28.794Z" },
-    { url = "https://files.pythonhosted.org/packages/08/0c/8c59bbcf78e94ca9994256920efa99d1c4dc9d0b966eb62ebba075585a16/uv-0.11.19-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.musllinux_1_1_armv7l.whl", hash = "sha256:2e0e0b8ad59ec56f1440d6e4313b64a1d8119275dcec73d19eef33c43f99428c", size = 23163128, upload-time = "2026-06-03T22:37:23.226Z" },
-    { url = "https://files.pythonhosted.org/packages/89/d6/69caf9e6f11c84b5fb92df190b46fbecb7dc6645ae891c6ed66d7aaaa310/uv-0.11.19-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f4aa17ffd719daf37b7a6265efd3ee4922a8ddaabaf0406d2b28c7e5ce2f20ff", size = 23164395, upload-time = "2026-06-03T22:37:18.11Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/83/0c2242b77c51ac33a0ddd8b06790429a0b8b9623974c9594ab2b0070ec47/uv-0.11.19-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:32d7988c0dfb6f90941f201c871a4478e96e4f2a32bdb2256d62a78ee20593fc", size = 24541708, upload-time = "2026-06-03T22:37:08.093Z" },
-    { url = "https://files.pythonhosted.org/packages/54/10/b1404fc52c0eddc3655f57a8b76e79dcf8dd02568382272f17e2fa68c4bb/uv-0.11.19-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2d663bacb97e2e8412d1c26eace28c7ebbde9d6f5d7d78760fafd114d693817f", size = 25575501, upload-time = "2026-06-03T22:37:47.526Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/17/4cda5994195ba9ce1f6971d40d5f2ceec58e2a79030d9052b3bf322557b1/uv-0.11.19-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:574f5dd4f31666661ea6386d3b91c5f0e8b84a8cae98ebba447c4674f2e6a4c7", size = 24827200, upload-time = "2026-06-03T22:37:34.039Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/74/2bd8b51e1d76210fd424ae55ec3f34ded5a10eeff3dd38aeb03c816a0af2/uv-0.11.19-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:731d9fab8db5d41590af64236d03f8069c8da665fd0f9493b85985f19c86cd90", size = 24872664, upload-time = "2026-06-03T22:37:11.301Z" },
-    { url = "https://files.pythonhosted.org/packages/06/b1/44b0764f656bbdd0728118610a63f2feddd9cbe450f974d80c5bb56aad34/uv-0.11.19-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:301fd78309fc545c2cec2bfcc61a6bbdde876856c6d2041502737cf44085c178", size = 23617890, upload-time = "2026-06-03T22:37:44.796Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/25/312fa33cd4c34e7618f86cad0c9fdb312d8fef2e7fc61944c1a2f1bf1256/uv-0.11.19-py3-none-manylinux_2_31_riscv64.musllinux_1_1_riscv64.whl", hash = "sha256:62b0b35a51d3034ff30ecd0f381e9bbc20d5b335754f54b098da29424d551ceb", size = 24267220, upload-time = "2026-06-03T22:37:39.425Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/25/13856aeff9e14c98ee3e1ceae4d209301cbdeabde93abcd758433601dc82/uv-0.11.19-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:65e932720daed1af1f720a0ff5f9b33ee5f7ad97488dcceceb85154fc1323b82", size = 24376177, upload-time = "2026-06-03T22:37:50.276Z" },
-    { url = "https://files.pythonhosted.org/packages/45/7d/590b3ab420e03504cf658d2981e1fcb4af60f3858d42da1d4d8740141dd9/uv-0.11.19-py3-none-musllinux_1_1_i686.whl", hash = "sha256:8f90b6687a480d154595aa619fb836a9a20d00ce37293db8099aad924f2b18f9", size = 23808336, upload-time = "2026-06-03T22:37:26.086Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/8e/40acebd4ea419c870930580623e8367e23d810a0ecb8cc2f44d852a27293/uv-0.11.19-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:28b0d612a766eb25756dbaa315433b726e93affa467d29a2682cc317547952ba", size = 25080747, upload-time = "2026-06-03T22:37:13.886Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/d3/4037b2acb2bb73b1a3ee47a1d23864ecc503f5840387afd29f621d4fd2ec/uv-0.11.19-py3-none-win32.whl", hash = "sha256:aa6a7e8d07b33ad22f4732848ebb1d9486503973c248d6e632c06ce4339fe347", size = 22459533, upload-time = "2026-06-03T22:37:36.741Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/43/f374fad7ad94e4a8c47cf09f00d803c76c6cc7f225668c41f4e2fb5de000/uv-0.11.19-py3-none-win_amd64.whl", hash = "sha256:480fc34a8d0967af6a90b3f99a6e5687cd5c6e29528de96bec04d6e305a59363", size = 25143888, upload-time = "2026-06-03T22:37:42.169Z" },
-    { url = "https://files.pythonhosted.org/packages/18/98/d2db53ae036528b0a9407529ef175ee200b01f626c9c160978784c8af870/uv-0.11.19-py3-none-win_arm64.whl", hash = "sha256:50e4d4796ca1a6da359a4f723a0fea86640c381d3ff4fa759a41badd7cb52dee", size = 23601290, upload-time = "2026-06-03T22:37:31.393Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/a5/1c863b931f3aba6e07547929b8cb45875038de00678bfd2fbabcd76faeef/uv-0.11.21-py3-none-linux_armv6l.whl", hash = "sha256:48c36eb170a5e7a668c1d13d2c8edeb017a3e6484c224f1521b540a6bda9e50b", size = 23747368, upload-time = "2026-06-11T18:19:21.724Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/8c/66d22f9152a014fbb17b1308394efe274e860b8beb4933f051396f96dd9f/uv-0.11.21-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:88d8283f6ea9f0cdbb7717e6e08e916c32a8b8b7e11c72fcc6426a4c4eeb89e0", size = 22992460, upload-time = "2026-06-11T18:18:33.543Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/f7/31d62c17837c9ae79cc6d5351fc5d54e8926e78b0315b4b6c187e0d1d50d/uv-0.11.21-py3-none-macosx_11_0_arm64.whl", hash = "sha256:9c11169a049ec8bf9ddc6a9f55fba9a240942ec8005faaaf4393f00ff7a4c16e", size = 21762931, upload-time = "2026-06-11T18:18:41.155Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/04/c5503fc1015095db71c280526f45537f3bb06855ce281ff1761b85d149bf/uv-0.11.21-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:00193e4e077c27ee3d66da356744dbf0b3aa59356dfbd9a9efb1dc8469af8ad7", size = 23716032, upload-time = "2026-06-11T18:19:17.03Z" },
+    { url = "https://files.pythonhosted.org/packages/13/ac/46132335772fcdc38e5b5ec76701a8df8e3707605909b5fed46783689501/uv-0.11.21-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.musllinux_1_1_armv7l.whl", hash = "sha256:870f48082df673016f465b068f40ad5aa7d2d3cfbcfb4e73724630684003a2ab", size = 23330010, upload-time = "2026-06-11T18:19:00.825Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d4/cfa1ea36706c32006dea9bf0a819b56c22af8270ea3a2b57562ce96c2d45/uv-0.11.21-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:af08e0d8f43da43bc68930aee56ca5f38ccfbc79d45b6e8a7d5051f1e975684f", size = 23339731, upload-time = "2026-06-11T18:18:52.395Z" },
+    { url = "https://files.pythonhosted.org/packages/96/c5/b34d3cdf05a069c583ef368e6db90242f842d7eb26b246981b3ca8799c27/uv-0.11.21-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4530761c565f3a519a68f36628ee51f2b467b66573e2023e9073641219b60d23", size = 24657820, upload-time = "2026-06-11T18:19:25.62Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b9/89b4e3909111c14311d4a1551afb37f0669587dc1f4ae7e26ec5baea6c09/uv-0.11.21-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:66906cfa7c29c2cf4ea5117cf5614b0b83078ff669e664e2187071fcb24c85c1", size = 25744586, upload-time = "2026-06-11T18:19:09.311Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/7b/51d53d9fb1aaf38a613c2d20b40583ee2aa47fc000724a00aecbd5e61431/uv-0.11.21-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:525ef0eb56ff982357a321eca953307d824ab6f58473630c69521e8085f12b0a", size = 24990030, upload-time = "2026-06-11T18:18:29.618Z" },
+    { url = "https://files.pythonhosted.org/packages/de/70/3347f736911b73df1f31c0823d6502891f3c49fdeb157fe8060b18c08d1c/uv-0.11.21-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b9ecdefa81db7e966d1655988cad6f840316228381dd69131ebc4ae9362bbccd", size = 25110133, upload-time = "2026-06-11T18:19:13.307Z" },
+    { url = "https://files.pythonhosted.org/packages/61/b5/b92538042d78550626ec7ac98b525bcb81ded8605c7ca9d6e35a1454ba71/uv-0.11.21-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:4ed98ff3165bf7b339692d0df918b87e6d36eb0bed5183466330d27d5730d57b", size = 23755172, upload-time = "2026-06-11T18:18:19.189Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1a/5c8993f95d4384baeaf00b96df0111af3c941a34e4466cde0d52b0b6ad99/uv-0.11.21-py3-none-manylinux_2_31_riscv64.musllinux_1_1_riscv64.whl", hash = "sha256:0e7916874f125a6f6af4cddd95f892ef19a4bb65c146afea7e544b0f98c63d02", size = 24468447, upload-time = "2026-06-11T18:19:04.572Z" },
+    { url = "https://files.pythonhosted.org/packages/66/2c/d4db24f9aeab8fce106633cd0388df4c0cf9f0991a2b5d9f58d061a031f7/uv-0.11.21-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:05e2f2e0fbf7c423f8287011ba0d2d69464f26a5f13b33df05cd491fbe5a910a", size = 24564716, upload-time = "2026-06-11T18:19:29.559Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/53/c61711e81f9f8d34dd020340ace968499b2539d3bb4ac09d39339df54a9d/uv-0.11.21-py3-none-musllinux_1_1_i686.whl", hash = "sha256:b756dd2b368d7cc4aeb48249d06e1250bfcf81f0313ff7d7ec2ccafcd3ee4c93", size = 23917742, upload-time = "2026-06-11T18:18:57.187Z" },
+    { url = "https://files.pythonhosted.org/packages/84/21/210a5562a6a0eddfbe4890eb48e67f167be0307e75f029ca46b8f6386e5d/uv-0.11.21-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:88668a27959df9188ff72b0314f6b14f6acf6090964bb0748974239183ecb51c", size = 25330418, upload-time = "2026-06-11T18:18:37.383Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/3c/81979463de0278facaa59ed3940b9c62f25a68d737d1a6f11cc3f922fba3/uv-0.11.21-py3-none-win32.whl", hash = "sha256:a00c78f3eea6db7967d98a505b01b7d80354517c7ff34f51701949f39c7b53e6", size = 22633520, upload-time = "2026-06-11T18:18:44.992Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/51/e682e060813424467f14ae964dd7022f8fc537fea5803b5aab0ba1eca9cc/uv-0.11.21-py3-none-win_amd64.whl", hash = "sha256:d956ba9470d5267cc0ea3d7572cac3bf045bc78adad5b031b5558c6df13d2e19", size = 25291878, upload-time = "2026-06-11T18:18:23.832Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/ef/8b1d92f9501963ef8694bb17ad80ba9926d049240d2da0a4f879aa37f3e2/uv-0.11.21-py3-none-win_arm64.whl", hash = "sha256:f64a851e429e6afb96f3a0b688995757ed3697bf1078509e2da8220ffc9805cd", size = 23715885, upload-time = "2026-06-11T18:18:48.596Z" },
 ]
 
 [[package]]
 name = "virtualenv"
-version = "21.4.2"
+version = "21.4.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "distlib" },
@@ -3202,9 +3203,9 @@ dependencies = [
     { name = "platformdirs" },
     { name = "python-discovery" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e1/0d/4e93c8e6d1001a75763f87d8f5ecda8ebc7f4aa2153dddfaf4ae8892821a/virtualenv-21.4.2.tar.gz", hash = "sha256:38e6ee0a555615c0ea9da2ac7e9998fe8dc3b911dd33ad8eaad2020957653b0c", size = 7613326, upload-time = "2026-05-31T17:01:22.827Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4b/50/7564c805bb8966d9771caaba8a143fa5e57c848ce4e7fdf2d55a1feb2ead/virtualenv-21.4.3.tar.gz", hash = "sha256:938ff0fd3f4e0f0d3a025f67a3d2f25e3c3aabbcd5857ea6170619138d72d141", size = 7644454, upload-time = "2026-06-11T16:47:04.843Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bf/c4/557dc082be035381b85fdb2b74e21d3d21b57750b74f2b47a32f3a639ff9/virtualenv-21.4.2-py3-none-any.whl", hash = "sha256:854210ca524a1a4d0d744734f4acbc721c3ffe163b85bbf5d56d14d5ae2f0fae", size = 7594079, upload-time = "2026-05-31T17:01:20.735Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/8d/84b0d07c6b5f685f85ddf6c87a59d3a8a895a3dfd89e759666fabe951b94/virtualenv-21.4.3-py3-none-any.whl", hash = "sha256:75f4127d4067397c64f38579ce918fec6bf9ca2cd4f48685e82952cc3c035840", size = 7625544, upload-time = "2026-06-11T16:47:01.78Z" },
 ]
 
 [[package]]
@@ -3233,11 +3234,11 @@ wheels = [
 
 [[package]]
 name = "wcwidth"
-version = "0.7.0"
+version = "0.8.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2c/ee/afaf0f85a9a18fe47a67f1e4422ed6cf1fe642f0ae0a2f81166231303c52/wcwidth-0.7.0.tar.gz", hash = "sha256:90e3a7ea092341c44b99562e75d09e4d5160fe7a3974c6fb842a101a95e7eed0", size = 182132, upload-time = "2026-05-02T16:04:12.653Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/b4/51fe890511f0f242d07cb1ebe6a5b6db417262b9d2568b460347c57d95cc/wcwidth-0.8.1.tar.gz", hash = "sha256:faf5b4a5366a72dc49cad48cdf21f52bdf63bdda995178e483ba247ff79089b9", size = 1466072, upload-time = "2026-06-08T05:57:23.146Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/41/52/e465037f5375f43533d1a80b6923955201596a99142ed524d77b571a1418/wcwidth-0.7.0-py3-none-any.whl", hash = "sha256:5d69154c429a82910e241c738cd0e2976fac8a2dd47a1a805f4afed1c0f136f2", size = 110825, upload-time = "2026-05-02T16:04:11.033Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/6e/95b0e537de1f4d4301f76f944642c6da50d1511cc7b3d64dc418a66c7509/wcwidth-0.8.1-py3-none-any.whl", hash = "sha256:f453740b1e4a4f3291faa37944c555d71056c4da08d59809b307ef4feba695c8", size = 323092, upload-time = "2026-06-08T05:57:21.413Z" },
 ]
 
 [[package]]
@@ -3290,7 +3291,7 @@ wheels = [
 
 [[package]]
 name = "zensical"
-version = "0.0.44"
+version = "0.0.45"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -3302,20 +3303,20 @@ dependencies = [
     { name = "pyyaml" },
     { name = "tomli" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/86/44/e8c891e607708ed6e2b38620948f0715d13cb378f9525caab84aaf4dfb6c/zensical-0.0.44.tar.gz", hash = "sha256:7452eb2a88e2e42e9a9d7861c5ee6a3b4413766a5c737aa6dc840dab344d46aa", size = 3934771, upload-time = "2026-06-04T17:30:53.326Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/d1/ecb1889fd2208b2d577e6ff952d9bee201302eec7966b5b61cc64adfd8f5/zensical-0.0.45.tar.gz", hash = "sha256:315bce4ab0470338dd3588add38fb325f840856c375722e6802bd58a06446266", size = 3935947, upload-time = "2026-06-09T11:23:32.349Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/0f/08c503dff4077c66a99f00556d02f16bd1c67790e43cdd256499d6cab251/zensical-0.0.44-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:f7d562b231129356c1ac0a05147d48da759111b671be5c2d4ff6765639550606", size = 12702807, upload-time = "2026-06-04T17:30:18.476Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/01/88806c9e8ca6caa246dd9c5c3e15a8d25015c0862820e32b5cfd5cf01d56/zensical-0.0.44-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:534c5303b7f3e4e842a2aa21cd6afe1a19b89a62cda22bff64a8932d988c1e2a", size = 12575802, upload-time = "2026-06-04T17:30:21.617Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/21/bc55faf26e5a5e6d8b9216b9efba8a5f2b8c1db09d123b077696e5286fd9/zensical-0.0.44-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3255e14e648571eba1fc51b5d638e5738b96579acc2fd346ae94bb00ca1a37b9", size = 12944141, upload-time = "2026-06-04T17:30:24.532Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/62/27f934e443894174cddd1cc1d99fb296e0657611a21fdceb4e071a1207ac/zensical-0.0.44-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:83b167831e181451d266aedad66bf4d199b8ee3147439261c4193bcea09fd8b2", size = 12916341, upload-time = "2026-06-04T17:30:28.134Z" },
-    { url = "https://files.pythonhosted.org/packages/18/65/aaa4f0630cb5cd5083176e45af9221bcabfc304af961a5c180f64b5a4dde/zensical-0.0.44-cp310-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7556f3a824b45302e29ec2145b2f8c52ca9df3c6c7f2ac40bc7ce3d39f090f01", size = 13277072, upload-time = "2026-06-04T17:30:31.916Z" },
-    { url = "https://files.pythonhosted.org/packages/04/03/542ee91da33ec16fefcb5bf5fee40e29bfb15193adade6e729a2d3089982/zensical-0.0.44-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9d27ca2de859241fe13871f252c488b5aabcf757772973ba6e57db6be1cdee55", size = 12977180, upload-time = "2026-06-04T17:30:34.508Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/71/4a20eb41b312e458e111119a2902ab402bd60320ea1c029ef1f4839c35ad/zensical-0.0.44-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:062c8a4071f75b25bcbe66c95d8984b967ed43ea9eeb3fd79374b4409618f93d", size = 13122478, upload-time = "2026-06-04T17:30:37.44Z" },
-    { url = "https://files.pythonhosted.org/packages/67/90/d01e1fbe39ca687cbd076d1eeee9a2ac70b255d18a0f178ec9c0465ae349/zensical-0.0.44-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:17252630f2e4294ae8852b1616b6d87bdafb4d7608d2eb75f6d5ded043bd05ff", size = 13188163, upload-time = "2026-06-04T17:30:40.218Z" },
-    { url = "https://files.pythonhosted.org/packages/08/bf/34a2080dcc131dba174f4247e2309113d9fcdaad0f1bd5bd4e0891d87991/zensical-0.0.44-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:4d0dba5a44634bff9d0661ca212d602c126efdb1d7a122c6a389630d17a5c15c", size = 13330242, upload-time = "2026-06-04T17:30:42.684Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/81/d752314525b6309657f5bf52b5f4414884df7b1175dc4ad6aaac5e2f5f1d/zensical-0.0.44-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:f7ef005280c62a7cfa258583ff68b443bd5e460da9f996f7c671251403dcdb4a", size = 13261108, upload-time = "2026-06-04T17:30:45.516Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/08/cd69f37e43619f5613612d2e6b1eeee2842101c29b2db9fdde501716086d/zensical-0.0.44-cp310-abi3-win32.whl", hash = "sha256:b844e28292e9ea93e5dcca229773c027fd3931419d581e1af4fd5ff310679237", size = 12261668, upload-time = "2026-06-04T17:30:48.217Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/4d/261244d82be63383482717651befa9971255a6c1399bae61d6c14a117dd9/zensical-0.0.44-cp310-abi3-win_amd64.whl", hash = "sha256:912219e11af23081a7b6bc13e81131bdeacd6bb3516b9508c6b52d8b23aa8208", size = 12502071, upload-time = "2026-06-04T17:30:51.02Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/fd/6b84115e3bbe6b76ebb1265e8ff2161c0bc88dcd6499eaf29c61a66421e9/zensical-0.0.45-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:c4cb2e11132f02ae824e246e016e073458e12e9de1eaf86fd39f01890d41204c", size = 12698844, upload-time = "2026-06-09T11:22:56.537Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/dc/4ddf05d77c1455c32cb26da71f2a19d355927a45a3db5b26fb258a07ce8f/zensical-0.0.45-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:799a01de2102b5f731744ad31bdbc464d0c07d484e67ba148f6923679afa6ce6", size = 12571590, upload-time = "2026-06-09T11:23:00.192Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/53/60c6cc7b2ce8b1a83eb87bff3f7289447995552fd9a30ca76ffba22ca9d5/zensical-0.0.45-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6201e79ea8a64bd3ced3f05ef4b1529da0e675d67b1395987c0ba942e4e10dc4", size = 12939590, upload-time = "2026-06-09T11:23:02.721Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/1e/e9217ed75dba323a6f9a4eee28eb40416eff99932cd0ee6c394bf07b9ead/zensical-0.0.45-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:854aaf500e4a3ce64adea1faa7a1820c7cf9a4f66be1043e4e9ba727fe9cf2b5", size = 12911669, upload-time = "2026-06-09T11:23:05.407Z" },
+    { url = "https://files.pythonhosted.org/packages/71/3c/6fc9fe2334bb4460a8a8d732e23a30d2ddc2ecf63c2eb3487d9e7405e70d/zensical-0.0.45-cp310-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a80c57fd50fc60415914388286ac10a7d8b6f70b8ca7235597d09fb12c3171b0", size = 13267643, upload-time = "2026-06-09T11:23:07.915Z" },
+    { url = "https://files.pythonhosted.org/packages/be/f9/5696114af4ede5f1bd01e641a4ff24ee8ca49810bfaa28e5be12d930c0ef/zensical-0.0.45-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58c3510f69e08b6ed8bb9596fc9393e4687f90394aa0ef2d6118b1375ad97be5", size = 12972147, upload-time = "2026-06-09T11:23:12.069Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/9e/5c6acde480c43f8c993b13260925df8db31d51ab8a9977618e9efdd98d45/zensical-0.0.45-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:01c484bb2ee85e98e21e24b397ff52ffc31101f7485935eee5d3afa6cca6cc08", size = 13117360, upload-time = "2026-06-09T11:23:15.155Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/31/ea21f102049b35a8fe5218c5331857a15eeb60deb1bb21823a4c0701e274/zensical-0.0.45-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:3654b708830303759e866a58a60c483cd2a1c56a44acdaae5bbb341a3f40ebce", size = 13185593, upload-time = "2026-06-09T11:23:18.166Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/97/6ded39fe27fa8a292d17d9af713b018e4919315233b60fa4b4b0aca737a6/zensical-0.0.45-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:c4da1c37eca1474b487def0ef40d7ac2aff31a9d7a029cb7479ef7c354437361", size = 13326882, upload-time = "2026-06-09T11:23:21.027Z" },
+    { url = "https://files.pythonhosted.org/packages/79/80/075975032a9e20f319c0134f8ca659d295ee4908f15ab212702a2728247f/zensical-0.0.45-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:f8a1966c186feebd3b795f9d420000bfd582e16eefdd9bc7a286d878faabae52", size = 13253961, upload-time = "2026-06-09T11:23:23.99Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/6a/0eab0eb311af6a07cde15ca58d5d720cbfa02cd509e4c7fb5fa20cda0b46/zensical-0.0.45-cp310-abi3-win32.whl", hash = "sha256:a1dd63a5efb8d0e5f2fadf862f02771a279dc5cbe9a982700194650065758f01", size = 12257083, upload-time = "2026-06-09T11:23:26.769Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/cd/b117e749c60b1d1e16b8450db1355f69f38376f783b8c6c8815202988933/zensical-0.0.45-cp310-abi3-win_amd64.whl", hash = "sha256:1f2c0e69839ce4274bde34d18139d3b0d96bbf02b245ada46243590c9eedebc1", size = 12498335, upload-time = "2026-06-09T11:23:29.702Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Summary

## 1. `generic_factories` — register arbitrary functions as factories
  - **`layout.py`**: new `KCLayout.generic_factories: dict[str, Callable[..., ProtoTKCell[Any]] | Callable[..., VKCell]]`, plus a `@kcl.generic_factory` decorator (usable bare, with `name=`, or as a direct call) that registers a cell-producing function and wraps it with a 
  guardrail raising if the returned cell's `.kcl` isn't this layout.
  - **`tests/test_generic_factories.py`**: registration/delegation, the foreign-`kcl` guardrail, custom name, and independence from `factories` / `virtual_factories`.

## 2. Cross-section / enclosure rework (the bulk)
  - **Single registry**: `CrossSectionModel` now holds **one** `cross_sections: dict[str, SymmetricalCrossSection | AsymmetricalCrossSection]` (dropped the separate `asymmetrical_cross_sections` dict). One unified `_register`; cross-kind name uniqueness is automatic.
  - **Canonical naming**: every entry is keyed by its geometry-derived `auto_name()` **and**, when named, its explicit name. Existence is a single `get(auto_name())`. Unnamed entries resolve to a structurally-identical named one; registering a name promotes an unnamed
  canonical; a second name for one signature raises.
  - **bbox → enclosure**: `bbox_sections` removed as a `SymmetricalCrossSection` field; now a read-only property delegating to the enclosure. The enclosure's structural hash now folds in `bbox_sections`, so `auto_name()` is a complete key. Asymmetric `auto_name()` is now a
  SHA1 over its geometry.
  - **radius as metadata**: excluded from `auto_name()`, `__eq__`, and `__hash__`. Re-registering the same profile with a *different* radius raises (override radius at routing time instead).
  - **`__eq__`**: cross-kind comparisons return `False`; wrapper (`CrossSection`/`DCrossSection`/asymmetric) comparisons compare bases.
  - **New error**: `CrossSectionNamingConflictError` in `exceptions.py`.
  - **`symmetrical` kwarg**: `get_cross_section` / `get_icross_section` / `get_dcross_section` gained `symmetrical: bool | None = None` (replacing the old `kind` literal) — `None` = either kind, `True` = symmetric (raise otherwise), `False` = asymmetric (raise otherwise), 
  via overloads.
  - **Consumers updated** for the single registry: serialization in `layout.py` (one loop, de-aliased via `set()`), `session_cache.py` (split into two pkls on dump, load both back), `utils/difftest.py`, `schematic.py` (iterates all kinds; map type widened), `kcell.py`.

## 3. Type / lint hygiene
  - **`decorators.py`**: `@final` on `WrappedKCellFunc` / `WrappedVKCellFunc` so `isinstance` narrowing is clean (fixed the `schematic_driven` diagnostics, removed redundant `# ty: ignore`s).
  - **`Factories.get`**: key widened to `object` to satisfy `Mapping.get`'s LSP contract.
  - Test/conftest updates (`sym_enc` factory fixture, etc.).
    - decorators.py: @final on WrappedKCellFunc/WrappedVKCellFunc so isinstance narrowing is clean (fixed the schematic_driven diagnostics, removed redundant # ty: ignores).
    - Factories.get: key widened to object to satisfy Mapping.get's LSP contract.
    - Test/conftest updates (sym_enc factory fixture, etc.).