### PR TITLE
update taper and virtual cells to cross section bases

### DIFF
--- a/src/kfactory/cells/taper.py
+++ b/src/kfactory/cells/taper.py
@@ -1,10 +1,23 @@
 r"""Tapers, linear only.
 
+A linear taper transitions between two cross sections (two core widths). The slabs
+and excludes are part of the cross sections, or can be given for the legacy
+``(width1, width2, layer, enclosure)`` call via a
+[`LayerEnclosure`][kfactory.enclosure.LayerEnclosure].
+
 TODO: Non-linear tapers.
 
 """
 
+from typing import overload
+
 from .. import KCell, kdb
+from ..cross_section import (
+    CrossSection,
+    CrossSectionSpecDict,
+    DCrossSection,
+    DCrossSectionSpecDict,
+)
 from ..enclosure import LayerEnclosure
 from ..factories.taper import taper_factory
 from ..typings import um
@@ -13,13 +26,51 @@ from . import demo
 __all__ = ["taper", "taper_dbu"]
 
 taper_dbu = taper_factory(kcl=demo)
+"""Cross-section-first taper factory on the default KCLayout (length in dbu)."""
 
 
+@overload
 def taper(
+    *,
     width1: um,
     width2: um,
     length: um,
     layer: kdb.LayerInfo,
+    enclosure: LayerEnclosure | None = None,
+) -> KCell: ...
+@overload
+def taper(
+    *,
+    cross_section1: str
+    | CrossSection
+    | DCrossSection
+    | CrossSectionSpecDict
+    | DCrossSectionSpecDict,
+    cross_section2: str
+    | CrossSection
+    | DCrossSection
+    | CrossSectionSpecDict
+    | DCrossSectionSpecDict,
+    length: um,
+) -> KCell: ...
+def taper(
+    *,
+    length: um,
+    cross_section1: str
+    | CrossSection
+    | DCrossSection
+    | CrossSectionSpecDict
+    | DCrossSectionSpecDict
+    | None = None,
+    cross_section2: str
+    | CrossSection
+    | DCrossSection
+    | CrossSectionSpecDict
+    | DCrossSectionSpecDict
+    | None = None,
+    width1: um | None = None,
+    width2: um | None = None,
+    layer: kdb.LayerInfo | None = None,
     enclosure: LayerEnclosure | None = None,
 ) -> KCell:
     r"""Linear Taper [um].
@@ -39,13 +90,29 @@ def taper(
             \_   │
               \__│ Slab/Exclude
 
+    Either pass two cross sections (``cross_section1``/``cross_section2``) or the
+    legacy ``width1``/``width2``/``layer``/``enclosure``.
+
     Args:
-        width1: Width of the core on the left side. [um]
-        width2: Width of the core on the right side. [um]
         length: Length of the taper. [um]
-        layer: Main layer of the taper.
-        enclosure: Definition of the slab/exclude.
+        cross_section1: Cross section of the left side.
+        cross_section2: Cross section of the right side.
+        width1: Width of the core on the left side. [um] (legacy; requires ``layer``)
+        width2: Width of the core on the right side. [um] (legacy; requires ``layer``)
+        layer: Main layer of the taper. (legacy)
+        enclosure: Definition of the slab/exclude. (legacy)
     """
+    if cross_section1 is not None and cross_section2 is not None:
+        return taper_dbu(
+            cross_section1=cross_section1,
+            cross_section2=cross_section2,
+            length=demo.to_dbu(length),
+        )
+    if width1 is None or width2 is None or layer is None:
+        raise ValueError(
+            "Provide cross_section1 and cross_section2, or width1, width2 and layer"
+            " (legacy call)."
+        )
     return taper_dbu(
         width1=demo.to_dbu(width1),
         width2=demo.to_dbu(width2),

--- a/src/kfactory/decorators.py
+++ b/src/kfactory/decorators.py
@@ -732,6 +732,21 @@ class WrappedVKCellFunc[**VKCellParams, VK: VKCell]:
         lvs_equivalent_ports: list[list[str]] | None = None,
         ports: PortsDefinition | None = None,
         tags: Sequence[str] | None = None,
+        type_serializers: Sequence[tuple[type | UnionType, Callable[[Any], Any]]] = (
+            (
+                SymmetricalCrossSection
+                | CrossSection
+                | DCrossSection
+                | AsymmetricalCrossSection
+                | AsymmetricCrossSection
+                | DAsymmetricCrossSection,
+                attrgetter("name"),
+            ),
+        ),
+        type_hints_serializer: dict[
+            type | UnionType | TypeAliasType, Callable[[Any], Any]
+        ]
+        | None = None,
     ) -> None:
         self.kcl = kcl
         self.output_type = output_type
@@ -741,6 +756,18 @@ class WrappedVKCellFunc[**VKCellParams, VK: VKCell]:
 
         # Pre-compute static signature metadata once at decoration time
         sig_params = SignatureParams(sig)
+        # Resolve annotations to concrete types for the type-hint serializers (see
+        # the equivalent block in ``WrappedKCellFunc``); an unresolvable hint simply
+        # opts out of hint-based serialization rather than breaking decoration.
+        try:
+            hints = get_type_hints(f)
+        except Exception:
+            hints = {}
+        if type_hints_serializer is None:
+            type_hints_serializer = cast(
+                "dict[type | UnionType | TypeAliasType, Callable[[Any], Any]]",
+                {CrossSectionSpec: kcl_cross_section_serializer(kcl=kcl)},
+            )
 
         @functools.wraps(f)
         def wrapper_autocell(
@@ -758,7 +785,16 @@ class WrappedVKCellFunc[**VKCellParams, VK: VKCell]:
 
                 return cell_
 
-        @cached(cache=cache, lock=RLock())
+        @cached(
+            cache=cache,
+            lock=RLock(),
+            key=get_keys_function(
+                hints=hints,
+                drop_args=drop_params,
+                serialize_types=type_serializers,
+                serialize_hints=type_hints_serializer,
+            ),
+        )
         def wrapped_cell(**params: Any) -> VK:
 
             _params_to_original(params)

--- a/src/kfactory/factories/taper.py
+++ b/src/kfactory/factories/taper.py
@@ -1,5 +1,24 @@
 """Taper definitions [dbu].
 
+A linear taper transitions between two cross sections (two core widths) over a
+given length::
+
+           __
+         _/  │ Slab/Exclude
+       _/  __│
+     _/  _/  │
+    │  _/    │
+    │_/      │
+    │_       │ Core
+    │ \\_     │
+    │_  \\_   │
+      \\_  \\__│
+        \\_   │
+          \\__│ Slab/Exclude
+
+The slabs and excludes are part of the cross sections the taper is built from, or
+can be given for the legacy ``(width1, width2, layer, enclosure)`` call.
+
 TODO: Non-linear tapers
 """
 
@@ -9,12 +28,18 @@ from typing import TYPE_CHECKING, Any, Protocol, Unpack, cast, overload
 
 from .. import kdb
 from ..conf import logger
+from ..cross_section import (
+    AnyCrossSectionInput,
+    AsymmetricalCrossSection,
+    CrossSectionSpecDict,
+    DCrossSectionSpecDict,
+)
 from ..kcell import KCell
 from ..layout import CellKWargs, KCLayout  # noqa: TC001
 from ..port import rename_by_direction, rename_clockwise
 from ..settings import Info
 from ..typings import KC, KC_co, MetaData, dbu
-from .utils import _is_additional_info_func
+from .utils import _is_additional_info_func, cross_section_from_width
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -25,12 +50,25 @@ __all__ = ["taper_factory"]
 
 
 class TaperFactory(Protocol[KC_co]):
+    __name__: str
+
     def __call__(
         self,
-        width1: dbu,
-        width2: dbu,
+        *,
         length: dbu,
-        layer: kdb.LayerInfo,
+        cross_section1: str
+        | AnyCrossSectionInput
+        | CrossSectionSpecDict
+        | DCrossSectionSpecDict
+        | None = None,
+        cross_section2: str
+        | AnyCrossSectionInput
+        | CrossSectionSpecDict
+        | DCrossSectionSpecDict
+        | None = None,
+        width1: dbu | None = None,
+        width2: dbu | None = None,
+        layer: kdb.LayerInfo | None = None,
         enclosure: LayerEnclosure | None = None,
     ) -> KC_co:
         r"""Linear Taper [dbu].
@@ -48,12 +86,20 @@ class TaperFactory(Protocol[KC_co]):
                 \_   │
                   \__│ Slab/Exclude
 
+        Either pass two cross sections (``cross_section1``/``cross_section2``) or the
+        legacy ``width1``/``width2``/``layer``/``enclosure`` (all dbu) which is
+        normalized into a pair of symmetric cross sections.
+
         Args:
-            width1: Width of the core on the left side. [dbu]
-            width2: Width of the core on the right side. [dbu]
             length: Length of the taper. [dbu]
-            layer: Main layer of the taper.
-            enclosure: Definition of the slab/exclude.
+            cross_section1: Cross section of the left side.
+            cross_section2: Cross section of the right side.
+            width1: Width of the core on the left side. [dbu] (legacy; requires
+                ``layer``)
+            width2: Width of the core on the right side. [dbu] (legacy; requires
+                ``layer``)
+            layer: Main layer of the taper. (legacy)
+            enclosure: Definition of the slab/exclude. (legacy)
         """
         ...
 
@@ -114,12 +160,19 @@ def taper_factory(
             \_   │
               \__│ Slab/Exclude
 
+    The returned function is the generic interface: it accepts either two cross
+    sections (``cross_section1``/``cross_section2``) or the legacy
+    ``width1``/``width2``/``layer``/``enclosure`` (all dbu), normalized into a pair
+    of symmetric cross sections.
+
     Args:
         kcl: The KCLayout which will be owned
         additional_info: Add additional key/values to the
             [`KCell.info`][kfactory.settings.Info]. Can be a static dict
-            mapping info name to info value. Or can a callable which takes the straight
+            mapping info name to info value. Or can a callable which takes the taper
             functions' parameters as kwargs and returns a dict with the mapping.
+        output_type: The type of the returned cell.
+        port_type: Type of the ports the taper gets.
         cell_kwargs: Additional arguments passed as `@kcl.cell(**cell_kwargs)`.
     """
     _additional_info: dict[str, MetaData] = {}
@@ -144,6 +197,8 @@ def taper_factory(
             cell_kwargs["ports"] = {"left": ["o1"], "right": ["o2"]}
         elif kcl.rename_function == rename_by_direction:
             cell_kwargs["ports"] = {"left": ["W0"], "right": ["E0"]}
+    cell_kwargs.setdefault("basename", "taper")
+    basename = cell_kwargs["basename"]
 
     if output_type is not None:
         cell = kcl.cell(output_type=output_type, **cell_kwargs)
@@ -151,35 +206,12 @@ def taper_factory(
         cell = kcl.cell(output_type=cast("type[KC]", KCell), **cell_kwargs)
 
     @cell
-    def taper(
-        width1: dbu,
-        width2: dbu,
+    def _taper(
+        cross_section1: str | AnyCrossSectionInput,
+        cross_section2: str | AnyCrossSectionInput,
         length: dbu,
-        layer: kdb.LayerInfo,
-        enclosure: LayerEnclosure | None = None,
     ) -> KCell:
-        r"""Linear Taper [um].
-
-                   __
-                 _/  │ Slab/Exclude
-               _/  __│
-             _/  _/  │
-            │  _/    │
-            │_/      │
-            │_       │ Core
-            │ \_     │
-            │_  \_   │
-              \_  \__│
-                \_   │
-                  \__│ Slab/Exclude
-
-        Args:
-            width1: Width of the core on the left side. [dbu]
-            width2: Width of the core on the right side. [dbu]
-            length: Length of the taper. [dbu]
-            layer: Main layer of the taper.
-            enclosure: Definition of the slab/exclude.
-        """
+        """Linear taper defined by two cross sections."""
         c = kcl.kcell()
         if length < 0:
             logger.critical(
@@ -188,21 +220,35 @@ def taper_factory(
                 " lengths."
             )
             length = -length
-        if width1 < 0:
-            logger.critical(
-                f"Negative widths are not allowed {width1} as ports"
-                " will be inverted. Please use a positive number. Forcing positive"
-                " lengths."
-            )
-            width1 = -width1
 
-        if width2 < 0:
-            logger.critical(
-                f"Negative widths are not allowed {width2} as ports"
-                " will be inverted. Please use a positive number. Forcing positive"
-                " lengths."
+        xs1 = kcl.get_base_cross_section(cross_section1)
+        xs2 = kcl.get_base_cross_section(cross_section2)
+        if isinstance(xs1, AsymmetricalCrossSection) or isinstance(
+            xs2, AsymmetricalCrossSection
+        ):
+            raise NotImplementedError(
+                "Tapers do not support asymmetric cross sections yet (the straight"
+                " edge of the taper is ambiguous for an off-center profile). Got"
+                f" {xs1.name!r} -> {xs2.name!r}."
             )
-            width2 = -width2
+        # The taper applies a single, constant enclosure (and core layer) along its
+        # length via minkowski; a differing enclosure between the two cross sections
+        # (slab/exclude sections, bbox sections, or main layer) cannot be represented
+        # and would be silently taken from cross_section1 only. ``LayerEnclosure``
+        # equality is structural (its name normalizes to a geometry hash) and includes
+        # the main layer, so this also catches a core-layer mismatch.
+        if xs1.enclosure != xs2.enclosure:
+            raise ValueError(
+                "Taper requires both cross sections to share the same enclosure "
+                "(slab/exclude sections and main layer); got "
+                f"{xs1.name!r} ({xs1.enclosure.name!r}) and "
+                f"{xs2.name!r} ({xs2.enclosure.name!r}). Only the core width may "
+                "differ between the two cross sections."
+            )
+        width1 = xs1.width
+        width2 = xs2.width
+        layer = xs1.main_layer
+        enclosure = xs1.enclosure
 
         li = c.kcl.layer(layer)
         taper = c.shapes(li).insert(
@@ -219,35 +265,31 @@ def taper_factory(
         c.create_port(
             name="o1",
             trans=kdb.Trans(2, False, 0, 0),
-            width=width1,
-            layer=li,
+            cross_section=xs1,
             port_type=port_type,
         )
         c.create_port(
             name="o2",
             trans=kdb.Trans(0, False, length, 0),
-            width=width2,
-            layer=li,
+            cross_section=xs2,
             port_type=port_type,
         )
 
-        if enclosure is not None:
-            enclosure.apply_minkowski_y(c, layer)
+        enclosure.apply_minkowski_y(c, layer)
+
         _info: dict[str, MetaData] = {
-            "width1_um": width1 * c.kcl.dbu,
-            "width2_um": width2 * c.kcl.dbu,
-            "length_um": length * c.kcl.dbu,
+            "width1_um": c.kcl.to_um(width1),
+            "width2_um": c.kcl.to_um(width2),
+            "length_um": c.kcl.to_um(length),
             "width1_dbu": width1,
             "width2_dbu": width2,
             "length_dbu": length,
         }
         _info.update(
             _additional_info_func(
-                width1=width1,
-                width2=width2,
+                cross_section1=xs1,
+                cross_section2=xs2,
                 length=length,
-                layer=layer,
-                enclosure=enclosure,
             )
         )
         _info.update(_additional_info)
@@ -256,5 +298,37 @@ def taper_factory(
         c.boundary = taper.dpolygon
 
         return c
+
+    @kcl.generic_factory(name=basename)
+    def taper(
+        *,
+        length: dbu,
+        cross_section1: str
+        | AnyCrossSectionInput
+        | CrossSectionSpecDict
+        | DCrossSectionSpecDict
+        | None = None,
+        cross_section2: str
+        | AnyCrossSectionInput
+        | CrossSectionSpecDict
+        | DCrossSectionSpecDict
+        | None = None,
+        width1: dbu | None = None,
+        width2: dbu | None = None,
+        layer: kdb.LayerInfo | None = None,
+        enclosure: LayerEnclosure | None = None,
+    ) -> KC:
+        if cross_section1 is None or cross_section2 is None:
+            if width1 is None or width2 is None or layer is None:
+                raise ValueError(
+                    "Provide cross_section1 and cross_section2, or width1, width2 and"
+                    " layer (legacy call)."
+                )
+            xs1 = cross_section_from_width(kcl, width1, layer, enclosure)
+            xs2 = cross_section_from_width(kcl, width2, layer, enclosure)
+        else:
+            xs1 = kcl.get_icross_section(cross_section1)
+            xs2 = kcl.get_icross_section(cross_section2)
+        return _taper(cross_section1=xs1, cross_section2=xs2, length=length)
 
     return taper

--- a/src/kfactory/factories/utils.py
+++ b/src/kfactory/factories/utils.py
@@ -1,5 +1,6 @@
 """Utility functions for cell factories."""
 
+from collections import defaultdict
 from collections.abc import Callable, Sequence
 from functools import partial
 from typing import TYPE_CHECKING, TypeGuard
@@ -8,19 +9,23 @@ from .. import kdb
 from ..cross_section import CrossSection, CrossSectionSpecDict
 from ..enclosure import (
     LayerEnclosure,
+    _extrude_path_band_points,
     extrude_path_dynamic_points,
     extrude_path_points,
+    path_pts_to_polygon,
 )
 from ..kcell import KCell, VKCell
 from ..typings import MetaData
 
 if TYPE_CHECKING:
+    from ..cross_section import AnyCrossSection
     from ..layout import KCLayout
 
 __all__ = [
     "boundary_from_shapes",
     "cross_section_from_width",
     "extrude_backbone",
+    "extrude_backbone_cross_section",
     "extrude_backbone_dynamic",
     "layer_enclosure_to_sections",
 ]
@@ -134,6 +139,67 @@ def extrude_backbone(
                     )
                     outer_r.reverse()
                     c.shapes(_li).insert(kdb.DPolygon(outer_l + outer_r))
+
+
+def extrude_backbone_cross_section(
+    c: VKCell,
+    backbone: Sequence[kdb.DPoint],
+    cross_section: "AnyCrossSection",
+    start_angle: float,
+    end_angle: float,
+) -> None:
+    """Extrude a (symmetric or asymmetric) cross section along a backbone (um).
+
+    The virtual-cell counterpart of
+    [`extrude_path_cross_section`][kfactory.enclosure.extrude_path_cross_section]:
+    symmetric cross sections reproduce `extrude_backbone` exactly (byte-identical,
+    centered width + enclosure annuli); asymmetric ones are extruded as one signed
+    band ``[section_min, section_max]`` per strip (main strip + each aux section),
+    with strips sharing a layer merged.
+
+    Args:
+        c: target virtual cell
+        backbone: backbone to extrude (in um)
+        cross_section: the cross section to extrude
+        start_angle: force a certain start angle
+        end_angle: force a certain end angle
+    """
+    from ..cross_section import AsymmetricalCrossSection
+
+    if not isinstance(cross_section, AsymmetricalCrossSection):
+        extrude_backbone(
+            c,
+            backbone=list(backbone),
+            width=c.kcl.to_um(cross_section.width),
+            layer=cross_section.main_layer,
+            start_angle=start_angle,
+            end_angle=end_angle,
+            dbu=c.kcl.dbu,
+            enclosure=cross_section.enclosure,
+        )
+        return
+
+    to_um = c.kcl.to_um
+    strips: dict[kdb.LayerInfo, list[tuple[float, float]]] = defaultdict(list)
+    strips[cross_section.layer].append(
+        (to_um(cross_section.section_min), to_um(cross_section.section_max))
+    )
+    for sec in cross_section.sections:
+        strips[sec.layer].append((to_um(sec.section_min), to_um(sec.section_max)))
+
+    for layer, bands in strips.items():
+        region = kdb.Region()
+        for lo, hi in bands:
+            polygon = path_pts_to_polygon(
+                *_extrude_path_band_points(
+                    list(backbone), lo, hi, start_angle, end_angle
+                )
+            )
+            region.insert(c.kcl.to_dbu(polygon))
+        region.merge()
+        li = c.kcl.layer(layer)
+        for poly in region.each():
+            c.shapes(li).insert(poly.to_dtype(c.kcl.dbu))
 
 
 def extrude_backbone_dynamic(

--- a/src/kfactory/factories/virtual/circular.py
+++ b/src/kfactory/factories/virtual/circular.py
@@ -7,12 +7,21 @@ import numpy as np
 
 from ... import kdb
 from ...conf import logger
+from ...cross_section import (
+    AnyCrossSectionInput,
+    CrossSectionSpecDict,
+    DCrossSectionSpecDict,
+)
 from ...enclosure import LayerEnclosure
 from ...kcell import VKCell
 from ...layout import KCLayout
 from ...settings import Info
-from ...typings import MetaData
-from ..utils import _is_additional_info_func, extrude_backbone
+from ...typings import MetaData, deg, um
+from ..utils import (
+    _is_additional_info_func,
+    cross_section_from_width,
+    extrude_backbone_cross_section,
+)
 
 __all__ = ["virtual_bend_circular_factory"]
 
@@ -20,24 +29,35 @@ __all__ = ["virtual_bend_circular_factory"]
 class BendCircularVKCell(Protocol):
     """Factory for virtual circular bend."""
 
+    __name__: str
+
     def __call__(
         self,
-        width: float,
-        radius: float,
-        layer: kdb.LayerInfo,
-        enclosure: LayerEnclosure | None = None,
-        angle: float = 90,
+        *,
+        radius: um,
+        angle: deg = 90,
         angle_step: float = 1,
+        cross_section: str
+        | AnyCrossSectionInput
+        | CrossSectionSpecDict
+        | DCrossSectionSpecDict
+        | None = None,
+        width: um | None = None,
+        layer: kdb.LayerInfo | None = None,
+        enclosure: LayerEnclosure | None = None,
     ) -> VKCell:
         """Create a virtual circular bend.
 
+        Either pass a ``cross_section`` or the legacy ``width``/``layer``/``enclosure``.
+
         Args:
-            width: Width of the core. [um]
             radius: Radius of the backbone. [um]
-            layer: Layer index of the target layer.
-            enclosure: Optional enclosure.
             angle: Angle amount of the bend.
             angle_step: Angle amount per backbone point of the bend.
+            cross_section: Cross section of the bend.
+            width: Width of the core. [um] (legacy; requires ``layer``)
+            layer: Main layer of the bend. (legacy)
+            enclosure: Optional enclosure. (legacy)
         """
         ...
 
@@ -55,11 +75,14 @@ def virtual_bend_circular_factory(
 ) -> BendCircularVKCell:
     """Returns a function generating virtual circular bends.
 
+    The returned function is the generic interface (``cross_section`` or the legacy
+    ``width``/``layer``/``enclosure``).
+
     Args:
         kcl: The KCLayout which will be owned
         additional_info: Add additional key/values to the
             [`VKCell.info`][kfactory.settings.Info]. Can be a static dict
-            mapping info name to info value. Or can a callable which takes the straight
+            mapping info name to info value. Or can a callable which takes the bend
             functions' parameters as kwargs and returns a dict with the mapping.
         basename: Overwrite the prefix of the resulting VKCell's name. By default
             the VKCell will be named 'virtual_bend_circular[...]'.
@@ -71,7 +94,7 @@ def virtual_bend_circular_factory(
             ...,
             dict[str, MetaData],
         ] = additional_info
-        _additional_info: dict[str, MetaData] = {}
+        _additional_info = {}
     else:
 
         def additional_info_func(
@@ -83,28 +106,15 @@ def virtual_bend_circular_factory(
         _additional_info = additional_info or {}  # ty:ignore[invalid-assignment]
 
     @kcl.vcell(
-        basename=basename,
-        output_type=VKCell,
-        **cell_kwargs,
+        basename=basename or "virtual_bend_circular", output_type=VKCell, **cell_kwargs
     )
     def virtual_bend_circular(
-        width: float,
-        radius: float,
-        layer: kdb.LayerInfo,
-        enclosure: LayerEnclosure | None = None,
-        angle: float = 90,
+        cross_section: str | AnyCrossSectionInput,
+        radius: um,
+        angle: deg = 90,
         angle_step: float = 1,
     ) -> VKCell:
-        """Create a virtual circular bend.
-
-        Args:
-            width: Width of the core. [um]
-            radius: Radius of the backbone. [um]
-            layer: Layer index of the target layer.
-            enclosure: Optional enclosure.
-            angle: Angle amount of the bend.
-            angle_step: Angle amount per backbone point of the bend.
-        """
+        """Virtual circular bend defined by a cross section (um)."""
         c = kcl.vkcell()
         if angle < 0:
             logger.critical(
@@ -113,14 +123,8 @@ def virtual_bend_circular_factory(
                 " lengths."
             )
             angle = -angle
-        if width < 0:
-            logger.critical(
-                f"Negative widths are not allowed {width} as ports"
-                " will be inverted. Please use a positive number. Forcing positive"
-                " lengths."
-            )
-            width = -width
-        dbu = c.kcl.dbu
+
+        xs = kcl.get_base_cross_section(cross_section)
         backbone = [
             kdb.DPoint(x, y)
             for x, y in [
@@ -134,23 +138,18 @@ def virtual_bend_circular_factory(
             ]
         ]
 
-        extrude_backbone(
-            c=c,
+        extrude_backbone_cross_section(
+            c,
             backbone=backbone,
-            width=width,
-            layer=layer,
-            enclosure=enclosure,
+            cross_section=xs,
             start_angle=0,
             end_angle=angle,
-            dbu=dbu,
         )
         _info: dict[str, MetaData] = {}
         _info.update(
             _additional_info_func(
-                width=width,
+                cross_section=xs,
                 radius=radius,
-                layer=layer,
-                enclosure=enclosure,
                 angle=angle,
                 angle_step=angle_step,
             )
@@ -160,16 +159,46 @@ def virtual_bend_circular_factory(
 
         c.create_port(
             name="o1",
-            layer=c.kcl.layer(layer),
-            width=round(width / c.kcl.dbu),
+            cross_section=xs,
             dcplx_trans=kdb.DCplxTrans(1, 180, False, backbone[0].to_v()),
         )
         c.create_port(
             name="o2",
             dcplx_trans=kdb.DCplxTrans(1, angle, False, backbone[-1].to_v()),
-            width=width,
-            layer=c.kcl.layer(layer),
+            cross_section=xs,
         )
         return c
 
-    return virtual_bend_circular
+    @kcl.generic_factory(name=basename or "virtual_bend_circular")
+    def virtual_bend_circular_generic(
+        *,
+        radius: um,
+        angle: deg = 90,
+        angle_step: float = 1,
+        cross_section: str
+        | AnyCrossSectionInput
+        | CrossSectionSpecDict
+        | DCrossSectionSpecDict
+        | None = None,
+        width: um | None = None,
+        layer: kdb.LayerInfo | None = None,
+        enclosure: LayerEnclosure | None = None,
+    ) -> VKCell:
+        if cross_section is None:
+            if width is None or layer is None:
+                raise ValueError(
+                    "Provide a cross_section, or width and layer (legacy call)."
+                )
+            if width < 0:
+                logger.critical(
+                    f"Negative widths are not allowed {width}. Forcing positive width."
+                )
+                width = -width
+            xs = cross_section_from_width(kcl, kcl.to_dbu(width), layer, enclosure)
+        else:
+            xs = kcl.get_icross_section(cross_section)
+        return virtual_bend_circular(
+            cross_section=xs, radius=radius, angle=angle, angle_step=angle_step
+        )
+
+    return virtual_bend_circular_generic

--- a/src/kfactory/factories/virtual/euler.py
+++ b/src/kfactory/factories/virtual/euler.py
@@ -5,36 +5,58 @@ from typing import Any, Protocol
 
 from ... import kdb
 from ...conf import logger
+from ...cross_section import (
+    AnyCrossSectionInput,
+    CrossSectionSpecDict,
+    DCrossSectionSpecDict,
+)
 from ...enclosure import LayerEnclosure
 from ...factories.euler import euler_bend_points
 from ...kcell import VKCell
 from ...layout import KCLayout
 from ...settings import Info
-from ...typings import MetaData
-from ..utils import _is_additional_info_func, extrude_backbone
+from ...typings import MetaData, deg, um
+from ..utils import (
+    _is_additional_info_func,
+    cross_section_from_width,
+    extrude_backbone_cross_section,
+)
+
+__all__ = ["virtual_bend_euler_factory"]
 
 
 class BendEulerVKCell(Protocol):
     """Factory for virtual euler bends."""
 
+    __name__: str
+
     def __call__(
         self,
-        width: float,
-        radius: float,
-        layer: kdb.LayerInfo,
-        enclosure: LayerEnclosure | None = None,
-        angle: float = 90,
+        *,
+        radius: um,
+        angle: deg = 90,
         resolution: float = 150,
+        cross_section: str
+        | AnyCrossSectionInput
+        | CrossSectionSpecDict
+        | DCrossSectionSpecDict
+        | None = None,
+        width: um | None = None,
+        layer: kdb.LayerInfo | None = None,
+        enclosure: LayerEnclosure | None = None,
     ) -> VKCell:
         """Create a virtual euler bend.
 
+        Either pass a ``cross_section`` or the legacy ``width``/``layer``/``enclosure``.
+
         Args:
-            width: Width of the core. [um]
             radius: Radius off the backbone. [um]
-            layer: Layer index / LayerEnum of the core.
-            enclosure: Slab/exclude definition. [dbu]
             angle: Angle of the bend.
             resolution: Angle resolution for the backbone.
+            cross_section: Cross section of the bend.
+            width: Width of the core. [um] (legacy; requires ``layer``)
+            layer: Main layer of the bend. (legacy)
+            enclosure: Slab/exclude definition. (legacy)
         """
         ...
 
@@ -52,14 +74,17 @@ def virtual_bend_euler_factory(
 ) -> BendEulerVKCell:
     """Returns a function generating virtual euler bends.
 
+    The returned function is the generic interface (``cross_section`` or the legacy
+    ``width``/``layer``/``enclosure``).
+
     Args:
         kcl: The KCLayout which will be owned
         additional_info: Add additional key/values to the
             [`VKCell.info`][kfactory.settings.Info]. Can be a static dict
-            mapping info name to info value. Or can a callable which takes the straight
+            mapping info name to info value. Or can a callable which takes the bend
             functions' parameters as kwargs and returns a dict with the mapping.
         basename: Overwrite the prefix of the resulting VKCell's name. By default
-            the VKCell will be named 'virtual_bend_euler[...]'.
+            the VKCell will be named 'bend_euler[...]'.
         cell_kwargs: Additional arguments passed as `@kcl.vcell(**cell_kwargs)`.
     """
     _additional_info: dict[str, MetaData] = {}
@@ -78,29 +103,14 @@ def virtual_bend_euler_factory(
         _additional_info_func = additional_info_func
         _additional_info = additional_info or {}  # ty:ignore[invalid-assignment]
 
-    @kcl.vcell(
-        basename=basename,
-        output_type=VKCell,
-        **cell_kwargs,
-    )
+    @kcl.vcell(basename=basename or "bend_euler", output_type=VKCell, **cell_kwargs)
     def bend_euler(
-        width: float,
-        radius: float,
-        layer: kdb.LayerInfo,
-        enclosure: LayerEnclosure | None = None,
-        angle: float = 90,
+        cross_section: str | AnyCrossSectionInput,
+        radius: um,
+        angle: deg = 90,
         resolution: float = 150,
     ) -> VKCell:
-        """Create a virtual euler bend.
-
-        Args:
-            width: Width of the core. [um]
-            radius: Radius off the backbone. [um]
-            layer: Layer index / LayerEnum of the core.
-            enclosure: Slab/exclude definition. [dbu]
-            angle: Angle of the bend.
-            resolution: Angle resolution for the backbone.
-        """
+        """Virtual euler bend defined by a cross section (um)."""
         c = kcl.vkcell()
         if angle < 0:
             logger.critical(
@@ -109,34 +119,24 @@ def virtual_bend_euler_factory(
                 " lengths."
             )
             angle = -angle
-        if width < 0:
-            logger.critical(
-                f"Negative widths are not allowed {width} as ports"
-                " will be inverted. Please use a positive number. Forcing positive"
-                " lengths."
-            )
-            width = -width
-        dbu = c.kcl.dbu
+
+        xs = kcl.get_base_cross_section(cross_section)
         backbone = euler_bend_points(angle, radius=radius, resolution=resolution)
 
-        extrude_backbone(
-            c=c,
+        extrude_backbone_cross_section(
+            c,
             backbone=backbone,
-            width=width,
-            layer=layer,
-            enclosure=enclosure,
+            cross_section=xs,
             start_angle=0,
             end_angle=angle,
-            dbu=dbu,
         )
         _info: dict[str, MetaData] = {}
         _info.update(
             _additional_info_func(
-                width=width,
+                cross_section=xs,
                 radius=radius,
-                layer=layer,
-                enclosure=enclosure,
                 angle=angle,
+                resolution=resolution,
             )
         )
         _info.update(_additional_info)
@@ -144,16 +144,46 @@ def virtual_bend_euler_factory(
 
         c.create_port(
             name="o1",
-            layer=c.kcl.layer(layer),
-            width=width,
+            cross_section=xs,
             dcplx_trans=kdb.DCplxTrans(1, 180, False, backbone[0].to_v()),
         )
         c.create_port(
             name="o2",
             dcplx_trans=kdb.DCplxTrans(1, angle, False, backbone[-1].to_v()),
-            width=width,
-            layer=c.kcl.layer(layer),
+            cross_section=xs,
         )
         return c
 
-    return bend_euler
+    @kcl.generic_factory(name=basename or "virtual_bend_euler")
+    def virtual_bend_euler(
+        *,
+        radius: um,
+        angle: deg = 90,
+        resolution: float = 150,
+        cross_section: str
+        | AnyCrossSectionInput
+        | CrossSectionSpecDict
+        | DCrossSectionSpecDict
+        | None = None,
+        width: um | None = None,
+        layer: kdb.LayerInfo | None = None,
+        enclosure: LayerEnclosure | None = None,
+    ) -> VKCell:
+        if cross_section is None:
+            if width is None or layer is None:
+                raise ValueError(
+                    "Provide a cross_section, or width and layer (legacy call)."
+                )
+            if width < 0:
+                logger.critical(
+                    f"Negative widths are not allowed {width}. Forcing positive width."
+                )
+                width = -width
+            xs = cross_section_from_width(kcl, kcl.to_dbu(width), layer, enclosure)
+        else:
+            xs = kcl.get_icross_section(cross_section)
+        return bend_euler(
+            cross_section=xs, radius=radius, angle=angle, resolution=resolution
+        )
+
+    return virtual_bend_euler

--- a/src/kfactory/factories/virtual/straight.py
+++ b/src/kfactory/factories/virtual/straight.py
@@ -5,22 +5,39 @@ from typing import Any, Protocol
 
 from ... import kdb
 from ...conf import logger
+from ...cross_section import (
+    AnyCrossSectionInput,
+    CrossSectionSpecDict,
+    DCrossSectionSpecDict,
+)
 from ...enclosure import LayerEnclosure
 from ...kcell import VKCell
 from ...layout import KCLayout
 from ...settings import Info
-from ...typings import MetaData
-from ..utils import _is_additional_info_func, extrude_backbone
+from ...typings import MetaData, um
+from ..utils import (
+    _is_additional_info_func,
+    cross_section_from_width,
+    extrude_backbone_cross_section,
+)
 
 __all__ = ["virtual_straight_factory"]
 
 
 class StraightVKCell(Protocol):
+    __name__: str
+
     def __call__(
         self,
-        width: float,
-        length: float,
-        layer: kdb.LayerInfo,
+        *,
+        length: um,
+        cross_section: str
+        | AnyCrossSectionInput
+        | CrossSectionSpecDict
+        | DCrossSectionSpecDict
+        | None = None,
+        width: um | None = None,
+        layer: kdb.LayerInfo | None = None,
         enclosure: LayerEnclosure | None = None,
     ) -> VKCell:
         """Virtual straight waveguide defined in um.
@@ -34,11 +51,15 @@ class StraightVKCell(Protocol):
             ├──────────────────────────────┤
             │         Slab/Exclude         │
             └──────────────────────────────┘
+
+        Either pass a ``cross_section`` or the legacy ``width``/``layer``/``enclosure``.
+
         Args:
-            width: Waveguide width. [um]
             length: Waveguide length. [um]
-            layer: Main layer of the waveguide.
-            enclosure: Definition of slab/excludes. [dbu]
+            cross_section: Cross section of the waveguide.
+            width: Waveguide width. [um] (legacy; requires ``layer``)
+            layer: Main layer of the waveguide. (legacy)
+            enclosure: Definition of slab/excludes. (legacy)
         """
         ...
 
@@ -56,6 +77,10 @@ def virtual_straight_factory(
 ) -> StraightVKCell:
     """Returns a function generating virtual straight waveguides.
 
+    The returned function is the generic interface: it accepts either a
+    ``cross_section`` or the legacy ``width``/``layer``/``enclosure`` (all um),
+    normalized into a symmetric cross section.
+
     Args:
         kcl: The KCLayout which will be owned
         additional_info: Add additional key/values to the
@@ -63,7 +88,7 @@ def virtual_straight_factory(
             mapping info name to info value. Or can a callable which takes the straight
             functions' parameters as kwargs and returns a dict with the mapping.
         basename: Overwrite the prefix of the resulting VKCell's name. By default
-            the VKCell will be named 'virtual_bend_euler[...]'.
+            the VKCell will be named 'virtual_straight[...]'.
         cell_kwargs: Additional arguments passed as `@kcl.vcell(**cell_kwargs)`.
     """
     if _is_additional_info_func(additional_info):
@@ -82,30 +107,14 @@ def virtual_straight_factory(
         _additional_info_func = additional_info_func
         _additional_info = additional_info or {}
 
-    @kcl.vcell
+    @kcl.vcell(
+        basename=basename or "virtual_straight", output_type=VKCell, **cell_kwargs
+    )
     def virtual_straight(
-        width: float,
-        length: float,
-        layer: kdb.LayerInfo,
-        enclosure: LayerEnclosure | None = None,
+        cross_section: str | AnyCrossSectionInput,
+        length: um,
     ) -> VKCell:
-        """Virtual waveguide defined in um.
-
-            ┌──────────────────────────────┐
-            │         Slab/Exclude         │
-            ├──────────────────────────────┤
-            │                              │
-            │             Core             │
-            │                              │
-            ├──────────────────────────────┤
-            │         Slab/Exclude         │
-            └──────────────────────────────┘
-        Args:
-            width: Waveguide width. [um]
-            length: Waveguide length. [um]
-            layer: Main layer of the waveguide.
-            enclosure: Definition of slab/excludes. [dbu]
-        """
+        """Virtual waveguide defined by a cross section (um)."""
         c = kcl.vkcell()
         if length < 0:
             logger.critical(
@@ -114,50 +123,60 @@ def virtual_straight_factory(
                 " lengths."
             )
             length = -length
-        if width < 0:
-            logger.critical(
-                f"Negative widths are not allowed {width} as ports"
-                " will be inverted. Please use a positive number. Forcing positive"
-                " lengths."
-            )
-            width = -width
 
-        extrude_backbone(
+        xs = kcl.get_base_cross_section(cross_section)
+
+        extrude_backbone_cross_section(
             c,
             backbone=[kdb.DPoint(0, 0), kdb.DPoint(length, 0)],
-            width=width,
-            layer=layer,
-            enclosure=enclosure,
+            cross_section=xs,
             start_angle=0,
             end_angle=0,
-            dbu=c.kcl.dbu,
         )
 
         _info: dict[str, MetaData] = {}
-        _info.update(
-            _additional_info_func(
-                width=width,
-                length=length,
-                layer=layer,
-                enclosure=enclosure,
-            )
-        )
-
+        _info.update(_additional_info_func(cross_section=xs, length=length))
         _info.update(_additional_info)  # ty:ignore[no-matching-overload]
         c.info = Info(**_info)
 
         c.create_port(
             name="o1",
             dcplx_trans=kdb.DCplxTrans(1, 180, False, 0, 0),
-            layer=c.kcl.layer(layer),
-            width=width,
+            cross_section=xs,
         )
         c.create_port(
             name="o2",
             dcplx_trans=kdb.DCplxTrans(1, 0, False, length, 0),
-            layer=c.kcl.layer(layer),
-            width=width,
+            cross_section=xs,
         )
         return c
 
-    return virtual_straight
+    @kcl.generic_factory(name=basename or "virtual_straight")
+    def straight(
+        *,
+        length: um,
+        cross_section: str
+        | AnyCrossSectionInput
+        | CrossSectionSpecDict
+        | DCrossSectionSpecDict
+        | None = None,
+        width: um | None = None,
+        layer: kdb.LayerInfo | None = None,
+        enclosure: LayerEnclosure | None = None,
+    ) -> VKCell:
+        if cross_section is None:
+            if width is None or layer is None:
+                raise ValueError(
+                    "Provide a cross_section, or width and layer (legacy call)."
+                )
+            if width < 0:
+                logger.critical(
+                    f"Negative widths are not allowed {width}. Forcing positive width."
+                )
+                width = -width
+            xs = cross_section_from_width(kcl, kcl.to_dbu(width), layer, enclosure)
+        else:
+            xs = kcl.get_icross_section(cross_section)
+        return virtual_straight(cross_section=xs, length=length)
+
+    return straight


### PR DESCRIPTION
## Summary

What changed, by area

  - Cell names changed for taper and the virtual cells: basename/prefix preserved, but the parametrized suffix is now cross-section-derived (taper_CSwgA_CSwgB_L15000 instead of width/layer-based). This matches the scheme straight/bends already use on main. → 6 OASIS goldens
  regenerated (test_l2n, test_cell_in_threads, test_route_length, 3× route_bundle), verified geometry-identical via per-layer XOR before regen.
  - Back-compat preserved: legacy (width, …) calls still work through the generic interfaces (incl. negative-width forgiveness on virtual cells).
  - New guard rails on taper:
    - asymmetric cross section → NotImplementedError (off-center taper edge is ambiguous);
    - cross_section1.enclosure != cross_section2.enclosure → ValueError (taper bakes in one constant enclosure + core layer from cs1; structural equality also catches a core-layer mismatch — only the core width may differ).
  - Bug fix: virtual bend_circular's o1 port previously got a wrong width (dbu value used as µm); now both ports carry the correct cross section.

  Registry effects

  - virtual_factories names unchanged (virtual_straight, bend_euler, virtual_bend_circular).
  - New generic interfaces registered under non-colliding names: taper, virtual_straight, virtual_bend_euler, virtual_bend_circular.

  Verification

  - Full suite: 2059 passed, 4 skipped.
  - uvx ty check clean on all changed files (the one pre-existing cachetools @cached typing diagnostic on @cell is now mirrored on @vcell — same tolerated pattern, no new ty:ignore).
  - Confirmed: object/spec-dict/name forms collapse to one cell + cache entry; symmetric output byte-identical to the legacy width path.

