### PR TITLE
Detect duplicate cell names before writing layouts

### DIFF
--- a/src/kfactory/conf.py
+++ b/src/kfactory/conf.py
@@ -181,14 +181,15 @@ def get_affinity() -> int:
     On (most) linux we can get it through the scheduling affinity. Otherwise,
     fall back to the multiprocessing cpu count.
     """
-    if hasattr(os, "sched_getaffinity"):
-        return len(os.sched_getaffinity(0))
     try:
-        import multiprocessing
+        return len(os.sched_getaffinity(0))
+    except AttributeError:
+        try:
+            import multiprocessing
 
-        return multiprocessing.cpu_count()
-    except ModuleNotFoundError:
-        return 1
+            return multiprocessing.cpu_count()
+        except ModuleNotFoundError:
+            return 1
 
 
 dotenv_path = find_dotenv(usecwd=True)

--- a/src/kfactory/conf.py
+++ b/src/kfactory/conf.py
@@ -181,15 +181,14 @@ def get_affinity() -> int:
     On (most) linux we can get it through the scheduling affinity. Otherwise,
     fall back to the multiprocessing cpu count.
     """
+    if hasattr(os, "sched_getaffinity"):
+        return len(os.sched_getaffinity(0))
     try:
-        return len(os.sched_getaffinity(0))  # ty: ignore[unresolved-attribute]
-    except AttributeError:
-        try:
-            import multiprocessing
+        import multiprocessing
 
-            return multiprocessing.cpu_count()
-        except ModuleNotFoundError:
-            return 1
+        return multiprocessing.cpu_count()
+    except ModuleNotFoundError:
+        return 1
 
 
 dotenv_path = find_dotenv(usecwd=True)

--- a/src/kfactory/conf.py
+++ b/src/kfactory/conf.py
@@ -182,7 +182,7 @@ def get_affinity() -> int:
     fall back to the multiprocessing cpu count.
     """
     try:
-        return len(os.sched_getaffinity(0))
+        return len(os.sched_getaffinity(0))  # ty: ignore[unresolved-attribute]
     except AttributeError:
         try:
             import multiprocessing

--- a/src/kfactory/exceptions.py
+++ b/src/kfactory/exceptions.py
@@ -14,6 +14,7 @@ __all__ = [
     "CellNameError",
     "CrossSectionNamingConflictError",
     "CrossSectionSymmetryMismatchError",
+    "DuplicateCellNameError",
     "FactoriesLockedError",
     "InvalidLayerError",
     "LockedError",
@@ -201,6 +202,14 @@ class CrossSectionSymmetryMismatchError(ValueError):
 
 class CellNameError(ValueError):
     """Raised if a KCell is created and the automatic assigned name is taken."""
+
+
+class DuplicateCellNameError(ValueError):
+    """Raised when writing a layout with multiple cells sharing the same name.
+
+    GDS/OASIS formats require unique cell names. This error provides details
+    about which names are duplicated and which cells are involved.
+    """
 
 
 class InvalidLayerError(ValueError):

--- a/src/kfactory/kcell.py
+++ b/src/kfactory/kcell.py
@@ -145,8 +145,14 @@ __all__ = [
 ]
 
 
-def _check_duplicate_cell_names(layout: kdb.Layout, cell_indices: set[int]) -> None:
-    """Raise `DuplicateCellNameError` if any cells in `cell_indices` share a name."""
+def _deduplicate_cell_names(layout: kdb.Layout, cell_indices: set[int]) -> None:
+    """Auto-rename cells with duplicate names so the layout can be written.
+
+    GDS/OASIS require unique cell names. When duplicates are found among
+    `cell_indices`, the first cell keeps its name and subsequent ones get
+    a ``$1``, ``$2``, … suffix (matching KLayout's own convention).
+    A warning is logged for each renamed cell.
+    """
     from collections import defaultdict
 
     name_to_indices: dict[str, list[int]] = defaultdict(list)
@@ -161,34 +167,27 @@ def _check_duplicate_cell_names(layout: kdb.Layout, cell_indices: set[int]) -> N
     if not duplicates:
         return
 
-    lines = [
-        "Cannot write layout: multiple cells share the same name.",
-        "GDS/OASIS requires every cell name to be unique.",
-        "",
-    ]
-    for name, indices in sorted(duplicates.items()):
-        lines.append(f"  {name!r} is used by {len(indices)} cells:")
-        for ci in indices:
+    for name, indices in duplicates.items():
+        # Keep the first cell, rename the rest
+        for ci in indices[1:]:
             c = layout.cell(ci)
-            if c is None:
+            if c is None or c._destroyed():
                 continue
-            parent_count = len(list(c.each_parent_cell()))
-            lines.append(
-                f"    - cell_index={ci}, {parent_count} parent(s),"
-                f" hierarchy_levels={c.hierarchy_levels()}"
+            unique = layout.unique_cell_name(name)
+            was_locked = c.is_locked()
+            if was_locked:
+                c.locked = False
+            c.name = unique
+            if was_locked:
+                c.locked = True
+            logger.warning(
+                "Renamed duplicate cell {old!r} (cell_index={ci}) to {new!r}"
+                " before writing. Set `kf.config.debug_names = True` to catch"
+                " name conflicts earlier.",
+                old=name,
+                ci=ci,
+                new=unique,
             )
-        lines.append("")
-
-    lines.append(
-        "This usually happens when a cell function creates or returns a cell"
-        " whose name collides with another cell already in the layout."
-    )
-    lines.append(
-        "To catch conflicts earlier, set `kf.config.debug_names = True`"
-        " — this raises an error at the point where the duplicate name is assigned."
-    )
-
-    raise DuplicateCellNameError("\n".join(lines))
 
 
 class BaseKCell(BaseModel, ABC, arbitrary_types_allowed=True):
@@ -1304,7 +1303,7 @@ class ProtoTKCell[T: (int, float)](ProtoKCell[T, TKCell], ABC):
                 ...
 
         relevant_cells = {self.cell_index(), *self.called_cells()}
-        _check_duplicate_cell_names(self.layout(), relevant_cells)
+        _deduplicate_cell_names(self.layout(), relevant_cells)
 
         filename = str(filename)
         if autoformat_from_file_extension:
@@ -1351,7 +1350,7 @@ class ProtoTKCell[T: (int, float)](ProtoKCell[T, TKCell], ABC):
                 ...
 
         relevant_cells = {self.cell_index(), *self.called_cells()}
-        _check_duplicate_cell_names(self.layout(), relevant_cells)
+        _deduplicate_cell_names(self.layout(), relevant_cells)
 
         save_options.format = save_options.format or "OASIS"
         save_options.clear_cells()

--- a/src/kfactory/kcell.py
+++ b/src/kfactory/kcell.py
@@ -145,21 +145,45 @@ __all__ = [
 ]
 
 
-def _cell_detail(ci: int, tkcells: Mapping[int, TKCell] | None) -> str:
+def _cell_detail(
+    ci: int,
+    layout: kdb.Layout,
+    tkcells: Mapping[int, TKCell] | None,
+) -> str:
     """Build a concise description of a cell for error/warning messages."""
     tkcell = tkcells.get(ci) if tkcells else None
-    if tkcell is None:
-        return f"cell_index={ci}"
-
-    factory_name = tkcell.basename or tkcell.function_name
     parts = [f"cell_index={ci}"]
-    if factory_name:
-        parts.append(f"factory={factory_name!r}")
-        factory = tkcell.kcl.factories.get(factory_name) or (
-            tkcell.kcl.virtual_factories.get(factory_name)
-        )
-        if factory is not None:
-            parts.append(str(factory.file))
+
+    if tkcell is not None:
+        factory_name = tkcell.basename or tkcell.function_name
+        if factory_name:
+            parts.append(f"factory={factory_name!r}")
+            factory = tkcell.kcl.factories.get(factory_name) or (
+                tkcell.kcl.virtual_factories.get(factory_name)
+            )
+            if factory is not None:
+                lineno = getattr(
+                    getattr(factory._f_orig, "__code__", None),
+                    "co_firstlineno",
+                    None,
+                )
+                loc = str(factory.file)
+                if lineno is not None:
+                    loc += f":{lineno}"
+                parts.append(loc)
+        else:
+            parts.append("no factory (created manually or via dup)")
+
+    c = layout.cell(ci)
+    if c is not None and not c._destroyed():
+        parent_names = []
+        for parent_ci in c.caller_cells():
+            pc = layout.cell(parent_ci)
+            if pc is not None and not pc._destroyed():
+                parent_names.append(pc.name)
+        if parent_names:
+            parts.append(f"parent(s): {parent_names}")
+
     return ", ".join(parts)
 
 
@@ -198,7 +222,7 @@ def _check_duplicate_cell_names(
         lines = []
         for name, indices in duplicates.items():
             detail_lines = [
-                f"    - {_cell_detail(ci, tkcells)}" for ci in indices
+                f"    - {_cell_detail(ci, layout, tkcells)}" for ci in indices
             ]
             lines.append(f"  {name!r}:\n" + "\n".join(detail_lines))
         raise DuplicateCellNameError(
@@ -221,7 +245,7 @@ def _check_duplicate_cell_names(
             c.name = unique
             if was_locked:
                 c.locked = True
-            detail = _cell_detail(ci, tkcells)
+            detail = _cell_detail(ci, layout, tkcells)
             logger.warning(
                 "Renamed duplicate cell {old!r} ({detail}) -> {new!r}."
                 " Set `kf.config.debug_names = True` to catch name"

--- a/src/kfactory/kcell.py
+++ b/src/kfactory/kcell.py
@@ -145,6 +145,24 @@ __all__ = [
 ]
 
 
+def _cell_detail(ci: int, tkcells: Mapping[int, TKCell] | None) -> str:
+    """Build a concise description of a cell for error/warning messages."""
+    tkcell = tkcells.get(ci) if tkcells else None
+    if tkcell is None:
+        return f"cell_index={ci}"
+
+    factory_name = tkcell.basename or tkcell.function_name
+    parts = [f"cell_index={ci}"]
+    if factory_name:
+        parts.append(f"factory={factory_name!r}")
+        factory = tkcell.kcl.factories.get(factory_name) or (
+            tkcell.kcl.virtual_factories.get(factory_name)
+        )
+        if factory is not None:
+            parts.append(str(factory.file))
+    return ", ".join(parts)
+
+
 def _check_duplicate_cell_names(
     layout: kdb.Layout,
     cell_indices: set[int],
@@ -179,7 +197,10 @@ def _check_duplicate_cell_names(
     if not auto_rename:
         lines = []
         for name, indices in duplicates.items():
-            lines.append(f"  {name!r}: cell_index(es) {indices}")
+            detail_lines = [
+                f"    - {_cell_detail(ci, tkcells)}" for ci in indices
+            ]
+            lines.append(f"  {name!r}:\n" + "\n".join(detail_lines))
         raise DuplicateCellNameError(
             "Duplicate cell names detected — GDS/OASIS require unique cell"
             " names.\n" + "\n".join(lines) + "\n"
@@ -200,18 +221,13 @@ def _check_duplicate_cell_names(
             c.name = unique
             if was_locked:
                 c.locked = True
-            fn = None
-            if tkcells is not None:
-                tkcell = tkcells.get(ci)
-                fn = tkcell.function_name if tkcell else None
+            detail = _cell_detail(ci, tkcells)
             logger.warning(
-                "Renamed duplicate cell {old!r} (cell_index={ci},"
-                " function_name={fn!r}) to {new!r} before writing."
+                "Renamed duplicate cell {old!r} ({detail}) -> {new!r}."
                 " Set `kf.config.debug_names = True` to catch name"
                 " conflicts earlier.",
                 old=name,
-                ci=ci,
-                fn=fn,
+                detail=detail,
                 new=unique,
             )
 

--- a/src/kfactory/kcell.py
+++ b/src/kfactory/kcell.py
@@ -172,7 +172,9 @@ def _cell_detail(
                     loc += f":{lineno}"
                 parts.append(loc)
         else:
-            parts.append("no factory (created manually or via dup)")
+            c = layout.cell(ci)
+            cell_name = c.name if c is not None and not c._destroyed() else None
+            parts.append(f"no factory, name={cell_name!r}")
 
     c = layout.cell(ci)
     if c is not None and not c._destroyed():

--- a/src/kfactory/kcell.py
+++ b/src/kfactory/kcell.py
@@ -150,7 +150,7 @@ def _check_duplicate_cell_names(
     cell_indices: set[int],
     *,
     auto_rename: bool = False,
-    tkcells: Mapping[int, Any] | None = None,
+    tkcells: Mapping[int, TKCell] | None = None,
 ) -> None:
     """Check for duplicate cell names before writing a layout.
 

--- a/src/kfactory/kcell.py
+++ b/src/kfactory/kcell.py
@@ -145,13 +145,21 @@ __all__ = [
 ]
 
 
-def _deduplicate_cell_names(layout: kdb.Layout, cell_indices: set[int]) -> None:
-    """Auto-rename cells with duplicate names so the layout can be written.
+def _check_duplicate_cell_names(
+    layout: kdb.Layout,
+    cell_indices: set[int],
+    *,
+    auto_rename: bool = False,
+) -> None:
+    """Check for duplicate cell names before writing a layout.
 
     GDS/OASIS require unique cell names. When duplicates are found among
-    `cell_indices`, the first cell keeps its name and subsequent ones get
-    a ``$1``, ``$2``, … suffix (matching KLayout's own convention).
-    A warning is logged for each renamed cell.
+    `cell_indices`:
+
+    - If ``auto_rename`` is *False* (the default), raise
+      :class:`~kfactory.exceptions.DuplicateCellNameError`.
+    - If ``auto_rename`` is *True*, rename duplicates with ``$1``, ``$2``, …
+      suffixes (matching KLayout's own convention) and log a warning.
     """
     from collections import defaultdict
 
@@ -167,8 +175,19 @@ def _deduplicate_cell_names(layout: kdb.Layout, cell_indices: set[int]) -> None:
     if not duplicates:
         return
 
+    if not auto_rename:
+        lines = []
+        for name, indices in duplicates.items():
+            lines.append(f"  {name!r}: cell_index(es) {indices}")
+        raise DuplicateCellNameError(
+            "Duplicate cell names detected — GDS/OASIS require unique cell"
+            " names.\n" + "\n".join(lines) + "\n"
+            "Pass `deduplicate_cell_names=True` to auto-rename duplicates,"
+            " or set `kf.config.debug_names = True` to catch conflicts"
+            " earlier at assignment time."
+        )
+
     for name, indices in duplicates.items():
-        # Keep the first cell, rename the rest
         for ci in indices[1:]:
             c = layout.cell(ci)
             if c is None or c._destroyed():
@@ -527,59 +546,125 @@ class TKCell(BaseKCell):
             and not self.kcl.layout.cell(value).is_library_cell()
             and not self.is_library_cell()
         ):
+            stack = inspect.stack()
+            module = inspect.getmodule(stack[3].frame)
             tkcells = [
                 self.kcl.tkcells[cell.cell_index()]
                 for cell in self.kcl.layout.cells(value)
                 if not cell.is_library_cell()
             ]
 
-            conflicting = "\n".join(
-                f"  - {tkcell.name!r} (cell_index={tkcell.kdb_cell.cell_index()},"
-                f" function_name={tkcell.function_name!r},"
-                f" basename={tkcell.basename!r})"
-                for tkcell in tkcells
-            )
-
-            stack = inspect.stack()
-            module = inspect.getmodule(stack[3].frame)
-
             if module is not None and module.__name__ == "kfactory.layout":
-                fi = stack[5]
-                f_obj = fi.frame.f_locals.get("f")
-                if f_obj is not None:
-                    location = (
-                        f"{f_obj.__code__.co_filename}::{f_obj.__name__}"
-                        f" at line {f_obj.__code__.co_firstlineno}"
+                frame_info = stack[5]
+                logger.opt(depth=2).error(
+                    "Name conflict in "
+                    f"{frame_info.frame.f_locals['f'].__code__.co_filename}::"
+                    f"{frame_info.frame.f_locals['f'].__name__} at line "
+                    f"{frame_info.frame.f_locals['f'].__code__.co_firstlineno}\n"
+                    f"Renaming {self.name} (cell_index={self.kdb_cell.cell_index()}) to"
+                    f" {value} would cause it to be named the same as:\n"
+                    + "\n".join(
+                        f" - {tkcell.name} (cell_index={tkcell.kdb_cell.cell_index()}),"
+                        f" function_name={tkcell.function_name},"
+                        f" basename={tkcell.basename}"
+                        for tkcell in tkcells
                     )
-                else:
-                    location = f"{fi.filename}::{fi.function} at line {fi.lineno}"
-                log_depth = 2
+                )
+                if config.debug_names:
+                    raise DuplicateCellNameError(
+                        "Name conflict in "
+                        f"{frame_info.frame.f_locals['f'].__code__.co_filename}::"
+                        f"{frame_info.frame.f_locals['f'].__name__} at line "
+                        f"{frame_info.frame.f_locals['f'].__code__.co_firstlineno}\n"
+                        f"Renaming {self.name} (cell_index={self.kdb_cell.cell_index()}"
+                        f") to {value} would cause it to be named the same as:\n"
+                        + "\n".join(
+                            f" - {tkcell.name} "
+                            f"(cell_index={tkcell.kdb_cell.cell_index()}),"
+                            f" function_name={tkcell.function_name},"
+                            f" basename={tkcell.basename}"
+                            for tkcell in tkcells
+                        )
+                    )
             else:
-                fi = stack[3]
+                frame_info = stack[3]
                 if module is not None:
-                    mod_name = module.__name__
-                    if mod_name == "__main__":
-                        mod_name = fi.filename
+                    module_name = module.__name__
+                    if module_name == "__main__":
+                        module_name = frame_info.filename
+                    function_name = (
+                        "::" + frame_info.function
+                        if frame_info.function != "<module>"
+                        else ""
+                    )
+                    logger.opt(depth=3).error(
+                        "Name conflict in "
+                        f"{module_name}{function_name} at line "
+                        f"{frame_info.lineno}\n"
+                        f"Renaming {self.name} (cell_index="
+                        f"{self.kdb_cell.cell_index()}) to"
+                        f" {value} would cause it to be named the same as:\n"
+                        + "\n".join(
+                            f" - {tkcell.name} "
+                            f"(cell_index={tkcell.kdb_cell.cell_index()}),"
+                            f" function_name={tkcell.function_name},"
+                            f" basename={tkcell.basename}"
+                            for tkcell in tkcells
+                        )
+                    )
+                    if config.debug_names:
+                        raise DuplicateCellNameError(
+                            "Name conflict in "
+                            f"{module_name}{function_name} at line "
+                            f"{frame_info.lineno}\n"
+                            f"Renaming {self.name} (cell_index="
+                            f"{self.kdb_cell.cell_index()}) to"
+                            f" {value} would cause it to be named the same as:\n"
+                            + "\n".join(
+                                f" - {tkcell.name} "
+                                f"(cell_index={tkcell.kdb_cell.cell_index()}),"
+                                f" function_name={tkcell.function_name},"
+                                f" basename={tkcell.basename}"
+                                for tkcell in tkcells
+                            )
+                        )
                 else:
-                    mod_name = fi.filename
-                func_suffix = f"::{fi.function}" if fi.function != "<module>" else ""
-                location = f"{mod_name}{func_suffix} at line {fi.lineno}"
-                log_depth = 3
-
-            msg = (
-                f"Cell name conflict in {location}\n"
-                f"Renaming {self.name!r}"
-                f" (cell_index={self.kdb_cell.cell_index()}) to {value!r}"
-                f" would create a duplicate — the following cell(s) already"
-                f" have that name:\n{conflicting}\n"
-                f"This will make the layout unwritable (GDS/OASIS require"
-                f" unique cell names).\n"
-                f"Set `kf.config.debug_names = True` to turn this warning"
-                f" into an error and catch the conflict at its source."
-            )
-            logger.opt(depth=log_depth).error(msg)
-            if config.debug_names:
-                raise DuplicateCellNameError(msg)
+                    function_name = (
+                        "::" + frame_info.function
+                        if frame_info.function != "<module>"
+                        else ""
+                    )
+                    logger.opt(depth=3).error(
+                        "Name conflict in "
+                        f"{frame_info.filename}"
+                        f"{function_name} at line {frame_info.lineno}\n"
+                        f"Renaming {self.name} (cell_index="
+                        f"{self.kdb_cell.cell_index()}) to"
+                        f" {value} would cause it to be named the same as:\n"
+                        + "\n".join(
+                            f" - {tkcell.name} "
+                            f"(cell_index={tkcell.kdb_cell.cell_index()}),"
+                            f" function_name={tkcell.function_name},"
+                            f" basename={tkcell.basename}"
+                            for tkcell in tkcells
+                        )
+                    )
+                    if config.debug_names:
+                        raise DuplicateCellNameError(
+                            "Name conflict in "
+                            f"{frame_info.filename}"
+                            f"{function_name} at line {frame_info.lineno}\n"
+                            f"Renaming {self.name} (cell_index="
+                            f"{self.kdb_cell.cell_index()}) to"
+                            f" {value} would cause it to be named the same as:\n"
+                            + "\n".join(
+                                f" - {tkcell.name} "
+                                f"(cell_index={tkcell.kdb_cell.cell_index()}),"
+                                f" function_name={tkcell.function_name},"
+                                f" basename={tkcell.basename}"
+                                for tkcell in tkcells
+                            )
+                        )
 
         self.kdb_cell.name = value
 
@@ -1268,10 +1353,17 @@ class ProtoTKCell[T: (int, float)](ProtoKCell[T, TKCell], ABC):
         convert_external_cells: bool = False,
         set_meta_data: bool = True,
         autoformat_from_file_extension: bool = True,
+        deduplicate_cell_names: bool = False,
     ) -> None:
         """Write a KCell to a GDS.
 
         See [KCLayout.write][kfactory.layout.KCLayout.write] for more info.
+
+        Args:
+            deduplicate_cell_names: If True, auto-rename duplicate cells with
+                ``$1``, ``$2``, … suffixes before writing. If False (the
+                default), raise :class:`~kfactory.exceptions.DuplicateCellNameError`
+                when duplicates are detected.
         """
         if save_options is None:
             save_options = save_layout_options()
@@ -1303,7 +1395,9 @@ class ProtoTKCell[T: (int, float)](ProtoKCell[T, TKCell], ABC):
                 ...
 
         relevant_cells = {self.cell_index(), *self.called_cells()}
-        _deduplicate_cell_names(self.layout(), relevant_cells)
+        _check_duplicate_cell_names(
+            self.layout(), relevant_cells, auto_rename=deduplicate_cell_names
+        )
 
         filename = str(filename)
         if autoformat_from_file_extension:
@@ -1315,10 +1409,17 @@ class ProtoTKCell[T: (int, float)](ProtoKCell[T, TKCell], ABC):
         save_options: kdb.SaveLayoutOptions | None = None,
         convert_external_cells: bool = False,
         set_meta_data: bool = True,
+        deduplicate_cell_names: bool = False,
     ) -> bytes:
         """Write a KCell to a binary format as oasis.
 
         See [KCLayout.write][kfactory.layout.KCLayout.write] for more info.
+
+        Args:
+            deduplicate_cell_names: If True, auto-rename duplicate cells with
+                ``$1``, ``$2``, … suffixes before writing. If False (the
+                default), raise :class:`~kfactory.exceptions.DuplicateCellNameError`
+                when duplicates are detected.
         """
         if save_options is None:
             save_options = save_layout_options()
@@ -1350,7 +1451,9 @@ class ProtoTKCell[T: (int, float)](ProtoKCell[T, TKCell], ABC):
                 ...
 
         relevant_cells = {self.cell_index(), *self.called_cells()}
-        _deduplicate_cell_names(self.layout(), relevant_cells)
+        _check_duplicate_cell_names(
+            self.layout(), relevant_cells, auto_rename=deduplicate_cell_names
+        )
 
         save_options.format = save_options.format or "OASIS"
         save_options.clear_cells()

--- a/src/kfactory/kcell.py
+++ b/src/kfactory/kcell.py
@@ -150,6 +150,7 @@ def _check_duplicate_cell_names(
     cell_indices: set[int],
     *,
     auto_rename: bool = False,
+    tkcells: Mapping[int, Any] | None = None,
 ) -> None:
     """Check for duplicate cell names before writing a layout.
 
@@ -199,12 +200,18 @@ def _check_duplicate_cell_names(
             c.name = unique
             if was_locked:
                 c.locked = True
+            fn = None
+            if tkcells is not None:
+                tkcell = tkcells.get(ci)
+                fn = tkcell.function_name if tkcell else None
             logger.warning(
-                "Renamed duplicate cell {old!r} (cell_index={ci}) to {new!r}"
-                " before writing. Set `kf.config.debug_names = True` to catch"
-                " name conflicts earlier.",
+                "Renamed duplicate cell {old!r} (cell_index={ci},"
+                " function_name={fn!r}) to {new!r} before writing."
+                " Set `kf.config.debug_names = True` to catch name"
+                " conflicts earlier.",
                 old=name,
                 ci=ci,
+                fn=fn,
                 new=unique,
             )
 

--- a/src/kfactory/kcell.py
+++ b/src/kfactory/kcell.py
@@ -69,7 +69,7 @@ from .cross_section import (
     TAsymmetricCrossSection,
     TCrossSection,
 )
-from .exceptions import LockedError, MergeError
+from .exceptions import DuplicateCellNameError, LockedError, MergeError
 from .geometry import DBUGeometricObject, GeometricObject, UMGeometricObject
 from .instance import DInstance, Instance, ProtoInstance, ProtoTInstance, VInstance
 from .instances import (
@@ -143,6 +143,52 @@ __all__ = [
     "get_cells",
     "show",
 ]
+
+
+def _check_duplicate_cell_names(layout: kdb.Layout, cell_indices: set[int]) -> None:
+    """Raise `DuplicateCellNameError` if any cells in `cell_indices` share a name."""
+    from collections import defaultdict
+
+    name_to_indices: dict[str, list[int]] = defaultdict(list)
+    for ci in cell_indices:
+        c = layout.cell(ci)
+        if c is not None and not c._destroyed():
+            name_to_indices[c.name].append(ci)
+
+    duplicates = {
+        name: indices for name, indices in name_to_indices.items() if len(indices) > 1
+    }
+    if not duplicates:
+        return
+
+    lines = [
+        "Cannot write layout: multiple cells share the same name.",
+        "GDS/OASIS requires every cell name to be unique.",
+        "",
+    ]
+    for name, indices in sorted(duplicates.items()):
+        lines.append(f"  {name!r} is used by {len(indices)} cells:")
+        for ci in indices:
+            c = layout.cell(ci)
+            if c is None:
+                continue
+            parent_count = len(list(c.each_parent_cell()))
+            lines.append(
+                f"    - cell_index={ci}, {parent_count} parent(s),"
+                f" hierarchy_levels={c.hierarchy_levels()}"
+            )
+        lines.append("")
+
+    lines.append(
+        "This usually happens when a cell function creates or returns a cell"
+        " whose name collides with another cell already in the layout."
+    )
+    lines.append(
+        "To catch conflicts earlier, set `kf.config.debug_names = True`"
+        " — this raises an error at the point where the duplicate name is assigned."
+    )
+
+    raise DuplicateCellNameError("\n".join(lines))
 
 
 class BaseKCell(BaseModel, ABC, arbitrary_types_allowed=True):
@@ -1323,6 +1369,9 @@ class ProtoTKCell[T: (int, float)](ProtoKCell[T, TKCell], ABC):
             case _:
                 ...
 
+        relevant_cells = {self.cell_index(), *self.called_cells()}
+        _check_duplicate_cell_names(self.layout(), relevant_cells)
+
         filename = str(filename)
         if autoformat_from_file_extension:
             save_options.set_format_from_filename(filename)
@@ -1366,6 +1415,9 @@ class ProtoTKCell[T: (int, float)](ProtoKCell[T, TKCell], ABC):
                     self.convert_to_static(recursive=True)
             case _:
                 ...
+
+        relevant_cells = {self.cell_index(), *self.called_cells()}
+        _check_duplicate_cell_names(self.layout(), relevant_cells)
 
         save_options.format = save_options.format or "OASIS"
         save_options.clear_cells()

--- a/src/kfactory/kcell.py
+++ b/src/kfactory/kcell.py
@@ -528,125 +528,59 @@ class TKCell(BaseKCell):
             and not self.kcl.layout.cell(value).is_library_cell()
             and not self.is_library_cell()
         ):
-            stack = inspect.stack()
-            module = inspect.getmodule(stack[3].frame)
             tkcells = [
                 self.kcl.tkcells[cell.cell_index()]
                 for cell in self.kcl.layout.cells(value)
                 if not cell.is_library_cell()
             ]
 
+            conflicting = "\n".join(
+                f"  - {tkcell.name!r} (cell_index={tkcell.kdb_cell.cell_index()},"
+                f" function_name={tkcell.function_name!r},"
+                f" basename={tkcell.basename!r})"
+                for tkcell in tkcells
+            )
+
+            stack = inspect.stack()
+            module = inspect.getmodule(stack[3].frame)
+
             if module is not None and module.__name__ == "kfactory.layout":
-                frame_info = stack[5]
-                logger.opt(depth=2).error(
-                    "Name conflict in "
-                    f"{frame_info.frame.f_locals['f'].__code__.co_filename}::"
-                    f"{frame_info.frame.f_locals['f'].__name__} at line "
-                    f"{frame_info.frame.f_locals['f'].__code__.co_firstlineno}\n"
-                    f"Renaming {self.name} (cell_index={self.kdb_cell.cell_index()}) to"
-                    f" {value} would cause it to be named the same as:\n"
-                    + "\n".join(
-                        f" - {tkcell.name} (cell_index={tkcell.kdb_cell.cell_index()}),"
-                        f" function_name={tkcell.function_name},"
-                        f" basename={tkcell.basename}"
-                        for tkcell in tkcells
+                fi = stack[5]
+                f_obj = fi.frame.f_locals.get("f")
+                if f_obj is not None:
+                    location = (
+                        f"{f_obj.__code__.co_filename}::{f_obj.__name__}"
+                        f" at line {f_obj.__code__.co_firstlineno}"
                     )
-                )
-                if config.debug_names:
-                    raise ValueError(
-                        "Name conflict in "
-                        f"{frame_info.frame.f_locals['f'].__code__.co_filename}::"
-                        f"{frame_info.frame.f_locals['f'].__name__} at line "
-                        f"{frame_info.frame.f_locals['f'].__code__.co_firstlineno}\n"
-                        f"Renaming {self.name} (cell_index={self.kdb_cell.cell_index()}"
-                        f") to {value} would cause it to be named the same as:\n"
-                        + "\n".join(
-                            f" - {tkcell.name} "
-                            f"(cell_index={tkcell.kdb_cell.cell_index()}),"
-                            f" function_name={tkcell.function_name},"
-                            f" basename={tkcell.basename}"
-                            for tkcell in tkcells
-                        )
-                    )
-            else:
-                frame_info = stack[3]
-                if module is not None:
-                    module_name = module.__name__
-                    if module_name == "__main__":
-                        module_name = frame_info.filename
-                    function_name = (
-                        "::" + frame_info.function
-                        if frame_info.function != "<module>"
-                        else ""
-                    )
-                    logger.opt(depth=3).error(
-                        "Name conflict in "
-                        f"{module_name}{function_name} at line "
-                        f"{frame_info.lineno}\n"
-                        f"Renaming {self.name} (cell_index="
-                        f"{self.kdb_cell.cell_index()}) to"
-                        f" {value} would cause it to be named the same as:\n"
-                        + "\n".join(
-                            f" - {tkcell.name} "
-                            f"(cell_index={tkcell.kdb_cell.cell_index()}),"
-                            f" function_name={tkcell.function_name},"
-                            f" basename={tkcell.basename}"
-                            for tkcell in tkcells
-                        )
-                    )
-                    if config.debug_names:
-                        raise ValueError(
-                            "Name conflict in "
-                            f"{module_name}{function_name} at line "
-                            f"{frame_info.lineno}\n"
-                            f"Renaming {self.name} (cell_index="
-                            f"{self.kdb_cell.cell_index()}) to"
-                            f" {value} would cause it to be named the same as:\n"
-                            + "\n".join(
-                                f" - {tkcell.name} "
-                                f"(cell_index={tkcell.kdb_cell.cell_index()}),"
-                                f" function_name={tkcell.function_name},"
-                                f" basename={tkcell.basename}"
-                                for tkcell in tkcells
-                            )
-                        )
                 else:
-                    function_name = (
-                        "::" + frame_info.function
-                        if frame_info.function != "<module>"
-                        else ""
-                    )
-                    logger.opt(depth=3).error(
-                        "Name conflict in "
-                        f"{frame_info.filename}"
-                        f"{function_name} at line {frame_info.lineno}\n"
-                        f"Renaming {self.name} (cell_index="
-                        f"{self.kdb_cell.cell_index()}) to"
-                        f" {value} would cause it to be named the same as:\n"
-                        + "\n".join(
-                            f" - {tkcell.name} "
-                            f"(cell_index={tkcell.kdb_cell.cell_index()}),"
-                            f" function_name={tkcell.function_name},"
-                            f" basename={tkcell.basename}"
-                            for tkcell in tkcells
-                        )
-                    )
-                    if config.debug_names:
-                        raise ValueError(
-                            "Name conflict in "
-                            f"{frame_info.filename}"
-                            f"{function_name} at line {frame_info.lineno}\n"
-                            f"Renaming {self.name} (cell_index="
-                            f"{self.kdb_cell.cell_index()}) to"
-                            f" {value} would cause it to be named the same as:\n"
-                            + "\n".join(
-                                f" - {tkcell.name} "
-                                f"(cell_index={tkcell.kdb_cell.cell_index()}),"
-                                f" function_name={tkcell.function_name},"
-                                f" basename={tkcell.basename}"
-                                for tkcell in tkcells
-                            )
-                        )
+                    location = f"{fi.filename}::{fi.function} at line {fi.lineno}"
+                log_depth = 2
+            else:
+                fi = stack[3]
+                if module is not None:
+                    mod_name = module.__name__
+                    if mod_name == "__main__":
+                        mod_name = fi.filename
+                else:
+                    mod_name = fi.filename
+                func_suffix = f"::{fi.function}" if fi.function != "<module>" else ""
+                location = f"{mod_name}{func_suffix} at line {fi.lineno}"
+                log_depth = 3
+
+            msg = (
+                f"Cell name conflict in {location}\n"
+                f"Renaming {self.name!r}"
+                f" (cell_index={self.kdb_cell.cell_index()}) to {value!r}"
+                f" would create a duplicate — the following cell(s) already"
+                f" have that name:\n{conflicting}\n"
+                f"This will make the layout unwritable (GDS/OASIS require"
+                f" unique cell names).\n"
+                f"Set `kf.config.debug_names = True` to turn this warning"
+                f" into an error and catch the conflict at its source."
+            )
+            logger.opt(depth=log_depth).error(msg)
+            if config.debug_names:
+                raise DuplicateCellNameError(msg)
 
         self.kdb_cell.name = value
 

--- a/src/kfactory/layout.py
+++ b/src/kfactory/layout.py
@@ -2196,6 +2196,7 @@ class KCLayout(
         set_meta_data: bool = True,
         convert_external_cells: bool = False,
         autoformat_from_file_extension: bool = True,
+        deduplicate_cell_names: bool = False,
     ) -> None:
         """Write a GDS file into the existing Layout.
 
@@ -2209,6 +2210,11 @@ class KCLayout(
             autoformat_from_file_extension: Set the format of the output file
                 automatically from the file extension of `filename`. This is necessary
                 for the options. If not set, this will default to `GDSII`.
+            deduplicate_cell_names: If True, auto-rename duplicate cells with
+                ``$1``, ``$2``, … suffixes before writing. If False (the
+                default), raise
+                :class:`~kfactory.exceptions.DuplicateCellNameError` when
+                duplicates are detected.
         """
         if options is None:
             options = save_layout_options()
@@ -2234,21 +2240,26 @@ class KCLayout(
                     if kcell.is_library_cell() and not kcell.destroyed():
                         kcell.convert_to_static(recursive=True)
 
-        self._deduplicate_cell_names()
+        self._check_duplicate_cell_names(auto_rename=deduplicate_cell_names)
 
         if autoformat_from_file_extension:
             options.set_format_from_filename(filename)
 
         return self.layout.write(filename, options)
 
-    def _deduplicate_cell_names(self) -> None:
-        """Auto-rename cells with duplicate names so the layout can be written.
+    def _check_duplicate_cell_names(self, *, auto_rename: bool = False) -> None:
+        """Check for duplicate cell names before writing the layout.
 
-        GDS/OASIS require unique cell names. The first cell keeps its name;
-        subsequent duplicates get ``$1``, ``$2``, … suffixes. A warning is
-        logged for each rename.
+        GDS/OASIS require unique cell names.
+
+        Args:
+            auto_rename: If True, rename duplicates with ``$1``, ``$2``, …
+                suffixes and log a warning. If False (the default), raise
+                :class:`~kfactory.exceptions.DuplicateCellNameError`.
         """
         from collections import defaultdict
+
+        from .exceptions import DuplicateCellNameError
 
         name_to_cells: dict[str, list[kdb.Cell]] = defaultdict(list)
         for c in self.layout.each_cell():
@@ -2260,6 +2271,19 @@ class KCLayout(
         }
         if not duplicates:
             return
+
+        if not auto_rename:
+            lines = []
+            for name, cells in duplicates.items():
+                indices = [c.cell_index() for c in cells if not c._destroyed()]
+                lines.append(f"  {name!r}: cell_index(es) {indices}")
+            raise DuplicateCellNameError(
+                "Duplicate cell names detected — GDS/OASIS require unique cell"
+                " names.\n" + "\n".join(lines) + "\n"
+                "Pass `deduplicate_cell_names=True` to auto-rename duplicates,"
+                " or set `kf.config.debug_names = True` to catch conflicts"
+                " earlier at assignment time."
+            )
 
         for name, cells in duplicates.items():
             for c in cells[1:]:

--- a/src/kfactory/layout.py
+++ b/src/kfactory/layout.py
@@ -80,6 +80,7 @@ from .kcell import (
     TKCell,
     TVCell,
     VKCell,
+    _check_duplicate_cell_names,
     show,
 )
 from .layer import LayerEnum, LayerInfos, LayerStack, layerenum_from_dict
@@ -2240,74 +2241,20 @@ class KCLayout(
                     if kcell.is_library_cell() and not kcell.destroyed():
                         kcell.convert_to_static(recursive=True)
 
-        self._check_duplicate_cell_names(auto_rename=deduplicate_cell_names)
+        all_indices = {
+            c.cell_index() for c in self.layout.each_cell() if not c._destroyed()
+        }
+        _check_duplicate_cell_names(
+            self.layout,
+            all_indices,
+            auto_rename=deduplicate_cell_names,
+            tkcells=self.tkcells,
+        )
 
         if autoformat_from_file_extension:
             options.set_format_from_filename(filename)
 
         return self.layout.write(filename, options)
-
-    def _check_duplicate_cell_names(self, *, auto_rename: bool = False) -> None:
-        """Check for duplicate cell names before writing the layout.
-
-        GDS/OASIS require unique cell names.
-
-        Args:
-            auto_rename: If True, rename duplicates with ``$1``, ``$2``, …
-                suffixes and log a warning. If False (the default), raise
-                :class:`~kfactory.exceptions.DuplicateCellNameError`.
-        """
-        from collections import defaultdict
-
-        from .exceptions import DuplicateCellNameError
-
-        name_to_cells: dict[str, list[kdb.Cell]] = defaultdict(list)
-        for c in self.layout.each_cell():
-            if not c._destroyed():
-                name_to_cells[c.name].append(c)
-
-        duplicates = {
-            name: cells for name, cells in name_to_cells.items() if len(cells) > 1
-        }
-        if not duplicates:
-            return
-
-        if not auto_rename:
-            lines = []
-            for name, cells in duplicates.items():
-                indices = [c.cell_index() for c in cells if not c._destroyed()]
-                lines.append(f"  {name!r}: cell_index(es) {indices}")
-            raise DuplicateCellNameError(
-                "Duplicate cell names detected — GDS/OASIS require unique cell"
-                " names.\n" + "\n".join(lines) + "\n"
-                "Pass `deduplicate_cell_names=True` to auto-rename duplicates,"
-                " or set `kf.config.debug_names = True` to catch conflicts"
-                " earlier at assignment time."
-            )
-
-        for name, cells in duplicates.items():
-            for c in cells[1:]:
-                if c._destroyed():
-                    continue
-                unique = self.layout.unique_cell_name(name)
-                tkcell = self.tkcells.get(c.cell_index())
-                fn = tkcell.function_name if tkcell else None
-                was_locked = c.is_locked()
-                if was_locked:
-                    c.locked = False
-                c.name = unique
-                if was_locked:
-                    c.locked = True
-                logger.warning(
-                    "Renamed duplicate cell {old!r} (cell_index={ci},"
-                    " function_name={fn!r}) to {new!r} before writing."
-                    " Set `kf.config.debug_names = True` to catch name"
-                    " conflicts earlier.",
-                    old=name,
-                    ci=c.cell_index(),
-                    fn=fn,
-                    new=unique,
-                )
 
     def top_kcells(self) -> list[KCell]:
         """Return the top KCells."""

--- a/src/kfactory/layout.py
+++ b/src/kfactory/layout.py
@@ -68,7 +68,7 @@ from .enclosure import (
     LayerEnclosureModel,
     LayerEnclosureSpec,
 )
-from .exceptions import FactoriesLockedError, MergeError
+from .exceptions import DuplicateCellNameError, FactoriesLockedError, MergeError
 from .kcell import (
     AnyTKCell,
     BaseKCell,
@@ -2234,10 +2234,57 @@ class KCLayout(
                     if kcell.is_library_cell() and not kcell.destroyed():
                         kcell.convert_to_static(recursive=True)
 
+        self._check_duplicate_cell_names()
+
         if autoformat_from_file_extension:
             options.set_format_from_filename(filename)
 
         return self.layout.write(filename, options)
+
+    def _check_duplicate_cell_names(self) -> None:
+        """Raise `DuplicateCellNameError` if any cells in the layout share a name."""
+        from collections import defaultdict
+
+        name_to_cells: dict[str, list[kdb.Cell]] = defaultdict(list)
+        for c in self.layout.each_cell():
+            if not c._destroyed():
+                name_to_cells[c.name].append(c)
+
+        duplicates = {
+            name: cells for name, cells in name_to_cells.items() if len(cells) > 1
+        }
+        if not duplicates:
+            return
+
+        lines = [
+            "Cannot write layout: multiple cells share the same name.",
+            "GDS/OASIS requires every cell name to be unique.",
+            "",
+        ]
+        for name, cells in sorted(duplicates.items()):
+            lines.append(f"  {name!r} is used by {len(cells)} cells:")
+            for c in cells:
+                tkcell = self.tkcells.get(c.cell_index())
+                fn = tkcell.function_name if tkcell else None
+                bn = tkcell.basename if tkcell else None
+                parent_count = len(list(c.each_parent_cell()))
+                lines.append(
+                    f"    - cell_index={c.cell_index()}, function_name={fn!r},"
+                    f" basename={bn!r}, {parent_count} parent(s)"
+                )
+            lines.append("")
+
+        lines.append(
+            "This usually happens when a cell function creates or returns a cell"
+            " whose name collides with another cell already in the layout."
+        )
+        lines.append(
+            "To catch conflicts earlier, set `kf.config.debug_names = True`"
+            " — this raises an error at the point where the duplicate name"
+            " is assigned."
+        )
+
+        raise DuplicateCellNameError("\n".join(lines))
 
     def top_kcells(self) -> list[KCell]:
         """Return the top KCells."""

--- a/src/kfactory/layout.py
+++ b/src/kfactory/layout.py
@@ -2256,6 +2256,47 @@ class KCLayout(
 
         return self.layout.write(filename, options)
 
+    def write_bytes(
+        self,
+        options: kdb.SaveLayoutOptions | None = None,
+        convert_external_cells: bool = False,
+        set_meta_data: bool = True,
+        deduplicate_cell_names: bool = False,
+    ) -> bytes:
+        if options is None:
+            options = save_layout_options()
+        for kc in list(self.kcells.values()):
+            kc.insert_vinsts()
+        match (set_meta_data, convert_external_cells):
+            case (True, True):
+                self.set_meta_data()
+                for kcell in self.kcells.values():
+                    if not kcell.destroyed():
+                        kcell.set_meta_data()
+                        if kcell.is_library_cell():
+                            kcell.convert_to_static(recursive=True)
+            case (True, False):
+                self.set_meta_data()
+                for kcell in self.kcells.values():
+                    if not kcell.destroyed():
+                        kcell.set_meta_data()
+            case (False, True):
+                for kcell in self.kcells.values():
+                    if kcell.is_library_cell() and not kcell.destroyed():
+                        kcell.convert_to_static(recursive=True)
+
+        all_indices = {
+            c.cell_index() for c in self.layout.each_cell() if not c._destroyed()
+        }
+        _check_duplicate_cell_names(
+            self.layout,
+            all_indices,
+            auto_rename=deduplicate_cell_names,
+            tkcells=self.tkcells,
+        )
+
+        return self.layout.write_bytes(options)
+
     def top_kcells(self) -> list[KCell]:
         """Return the top KCells."""
         return [self[tc.cell_index()] for tc in self.top_cells()]

--- a/src/kfactory/layout.py
+++ b/src/kfactory/layout.py
@@ -68,7 +68,7 @@ from .enclosure import (
     LayerEnclosureModel,
     LayerEnclosureSpec,
 )
-from .exceptions import DuplicateCellNameError, FactoriesLockedError, MergeError
+from .exceptions import FactoriesLockedError, MergeError
 from .kcell import (
     AnyTKCell,
     BaseKCell,
@@ -2234,15 +2234,20 @@ class KCLayout(
                     if kcell.is_library_cell() and not kcell.destroyed():
                         kcell.convert_to_static(recursive=True)
 
-        self._check_duplicate_cell_names()
+        self._deduplicate_cell_names()
 
         if autoformat_from_file_extension:
             options.set_format_from_filename(filename)
 
         return self.layout.write(filename, options)
 
-    def _check_duplicate_cell_names(self) -> None:
-        """Raise `DuplicateCellNameError` if any cells in the layout share a name."""
+    def _deduplicate_cell_names(self) -> None:
+        """Auto-rename cells with duplicate names so the layout can be written.
+
+        GDS/OASIS require unique cell names. The first cell keeps its name;
+        subsequent duplicates get ``$1``, ``$2``, … suffixes. A warning is
+        logged for each rename.
+        """
         from collections import defaultdict
 
         name_to_cells: dict[str, list[kdb.Cell]] = defaultdict(list)
@@ -2256,35 +2261,29 @@ class KCLayout(
         if not duplicates:
             return
 
-        lines = [
-            "Cannot write layout: multiple cells share the same name.",
-            "GDS/OASIS requires every cell name to be unique.",
-            "",
-        ]
-        for name, cells in sorted(duplicates.items()):
-            lines.append(f"  {name!r} is used by {len(cells)} cells:")
-            for c in cells:
+        for name, cells in duplicates.items():
+            for c in cells[1:]:
+                if c._destroyed():
+                    continue
+                unique = self.layout.unique_cell_name(name)
                 tkcell = self.tkcells.get(c.cell_index())
                 fn = tkcell.function_name if tkcell else None
-                bn = tkcell.basename if tkcell else None
-                parent_count = len(list(c.each_parent_cell()))
-                lines.append(
-                    f"    - cell_index={c.cell_index()}, function_name={fn!r},"
-                    f" basename={bn!r}, {parent_count} parent(s)"
+                was_locked = c.is_locked()
+                if was_locked:
+                    c.locked = False
+                c.name = unique
+                if was_locked:
+                    c.locked = True
+                logger.warning(
+                    "Renamed duplicate cell {old!r} (cell_index={ci},"
+                    " function_name={fn!r}) to {new!r} before writing."
+                    " Set `kf.config.debug_names = True` to catch name"
+                    " conflicts earlier.",
+                    old=name,
+                    ci=c.cell_index(),
+                    fn=fn,
+                    new=unique,
                 )
-            lines.append("")
-
-        lines.append(
-            "This usually happens when a cell function creates or returns a cell"
-            " whose name collides with another cell already in the layout."
-        )
-        lines.append(
-            "To catch conflicts earlier, set `kf.config.debug_names = True`"
-            " — this raises an error at the point where the duplicate name"
-            " is assigned."
-        )
-
-        raise DuplicateCellNameError("\n".join(lines))
 
     def top_kcells(self) -> list[KCell]:
         """Return the top KCells."""

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -1,0 +1,74 @@
+"""Tests for KCell/KCLayout write and write_bytes.
+
+Covers the happy path (a file / bytes are produced) and the duplicate cell name
+detection used by ``write``/``write_bytes``: raise a
+:class:`~kfactory.exceptions.DuplicateCellNameError` by default, or auto-rename
+with ``$1`` suffixes when ``deduplicate_cell_names=True``.
+"""
+
+from pathlib import Path
+
+import pytest
+
+import kfactory as kf
+from kfactory.exceptions import DuplicateCellNameError
+from tests.conftest import Layers
+
+
+def test_write_and_write_bytes(
+    kcl: kf.KCLayout, layers: Layers, tmp_path: Path
+) -> None:
+    top = kcl.kcell("top")
+    child_a = kcl.kcell("child_a")
+    child_a.shapes(kcl.find_layer(layers.WG)).insert(kf.kdb.Box(0, 0, 1000, 1000))
+    child_b = kcl.kcell("child_b")
+    child_b.shapes(kcl.find_layer(layers.WG)).insert(kf.kdb.Box(0, 0, 500, 500))
+    top << child_a
+    top << child_b
+
+    def make_duplicate() -> None:
+        # Force a raw duplicate name, bypassing the KCell name setter which
+        # would otherwise log/raise depending on ``config.debug_names``.
+        child_b.kdb_cell.name = "child_a"
+
+    def dedup_names() -> list[str]:
+        return sorted(c.name for c in kcl.layout.each_cell())
+
+    path = tmp_path / "out.gds"
+
+    # Happy path: no duplicates -> file / bytes are produced.
+    kcl.write(path)
+    assert path.exists()
+    assert len(kcl.write_bytes()) > 0
+    top.write(path)
+    assert path.exists()
+    assert len(top.write_bytes()) > 0
+
+    # KCLayout.write
+    make_duplicate()
+    with pytest.raises(DuplicateCellNameError):
+        kcl.write(path)
+    kcl.write(path, deduplicate_cell_names=True)
+    assert path.exists()
+    assert dedup_names() == ["child_a", "child_a$1", "top"]
+
+    # KCLayout.write_bytes
+    make_duplicate()
+    with pytest.raises(DuplicateCellNameError):
+        kcl.write_bytes()
+    assert len(kcl.write_bytes(deduplicate_cell_names=True)) > 0
+    assert dedup_names() == ["child_a", "child_a$1", "top"]
+
+    # KCell.write
+    make_duplicate()
+    with pytest.raises(DuplicateCellNameError):
+        top.write(path)
+    top.write(path, deduplicate_cell_names=True)
+    assert dedup_names() == ["child_a", "child_a$1", "top"]
+
+    # KCell.write_bytes
+    make_duplicate()
+    with pytest.raises(DuplicateCellNameError):
+        top.write_bytes()
+    assert len(top.write_bytes(deduplicate_cell_names=True)) > 0
+    assert dedup_names() == ["child_a", "child_a$1", "top"]


### PR DESCRIPTION
## Summary
- Add `DuplicateCellNameError` and a pre-write check (`_check_duplicate_cell_names`) that validates all cells in the write set have unique names before writing GDS/OASIS files
- The error message details which names are duplicated, how many cells share each name, and suggests enabling `kf.config.debug_names` for earlier detection
- Fix pre-existing `ty` type-checker false positive for `os.sched_getaffinity` on macOS

## Test plan
- [ ] Verify writing a layout with unique cell names still works normally
- [ ] Verify writing a layout with duplicate cell names raises `DuplicateCellNameError` with a clear message
- [ ] Run existing test suite to check for regressions