### PR TITLE
refactor: consolidate duplicate _check_duplicate_cell_names

### DIFF
--- a/src/kfactory/kcell.py
+++ b/src/kfactory/kcell.py
@@ -145,21 +145,45 @@ __all__ = [
 ]
 
 
-def _cell_detail(ci: int, tkcells: Mapping[int, TKCell] | None) -> str:
+def _cell_detail(
+    ci: int,
+    layout: kdb.Layout,
+    tkcells: Mapping[int, TKCell] | None,
+) -> str:
     """Build a concise description of a cell for error/warning messages."""
     tkcell = tkcells.get(ci) if tkcells else None
-    if tkcell is None:
-        return f"cell_index={ci}"
-
-    factory_name = tkcell.basename or tkcell.function_name
     parts = [f"cell_index={ci}"]
-    if factory_name:
-        parts.append(f"factory={factory_name!r}")
-        factory = tkcell.kcl.factories.get(factory_name) or (
-            tkcell.kcl.virtual_factories.get(factory_name)
-        )
-        if factory is not None:
-            parts.append(str(factory.file))
+
+    if tkcell is not None:
+        factory_name = tkcell.basename or tkcell.function_name
+        if factory_name:
+            parts.append(f"factory={factory_name!r}")
+            factory = tkcell.kcl.factories.get(factory_name) or (
+                tkcell.kcl.virtual_factories.get(factory_name)
+            )
+            if factory is not None:
+                lineno = getattr(
+                    getattr(factory._f_orig, "__code__", None),
+                    "co_firstlineno",
+                    None,
+                )
+                loc = str(factory.file)
+                if lineno is not None:
+                    loc += f":{lineno}"
+                parts.append(loc)
+        else:
+            parts.append("no factory (created manually or via dup)")
+
+    c = layout.cell(ci)
+    if c is not None and not c._destroyed():
+        parent_names = []
+        for parent_ci in c.caller_cells():
+            pc = layout.cell(parent_ci)
+            if pc is not None and not pc._destroyed():
+                parent_names.append(pc.name)
+        if parent_names:
+            parts.append(f"parent(s): {parent_names}")
+
     return ", ".join(parts)
 
 
@@ -198,7 +222,7 @@ def _check_duplicate_cell_names(
         lines = []
         for name, indices in duplicates.items():
             detail_lines = [
-                f"    - {_cell_detail(ci, tkcells)}" for ci in indices
+                f"    - {_cell_detail(ci, layout, tkcells)}" for ci in indices
             ]
             lines.append(f"  {name!r}:\n" + "\n".join(detail_lines))
         raise DuplicateCellNameError(
@@ -221,7 +245,7 @@ def _check_duplicate_cell_names(
             c.name = unique
             if was_locked:
                 c.locked = True
-            detail = _cell_detail(ci, tkcells)
+            detail = _cell_detail(ci, layout, tkcells)
             logger.warning(
                 "Renamed duplicate cell {old!r} ({detail}) -> {new!r}."
                 " Set `kf.config.debug_names = True` to catch name"

--- a/src/kfactory/kcell.py
+++ b/src/kfactory/kcell.py
@@ -145,6 +145,24 @@ __all__ = [
 ]
 
 
+def _cell_detail(ci: int, tkcells: Mapping[int, TKCell] | None) -> str:
+    """Build a concise description of a cell for error/warning messages."""
+    tkcell = tkcells.get(ci) if tkcells else None
+    if tkcell is None:
+        return f"cell_index={ci}"
+
+    factory_name = tkcell.basename or tkcell.function_name
+    parts = [f"cell_index={ci}"]
+    if factory_name:
+        parts.append(f"factory={factory_name!r}")
+        factory = tkcell.kcl.factories.get(factory_name) or (
+            tkcell.kcl.virtual_factories.get(factory_name)
+        )
+        if factory is not None:
+            parts.append(str(factory.file))
+    return ", ".join(parts)
+
+
 def _check_duplicate_cell_names(
     layout: kdb.Layout,
     cell_indices: set[int],
@@ -179,7 +197,10 @@ def _check_duplicate_cell_names(
     if not auto_rename:
         lines = []
         for name, indices in duplicates.items():
-            lines.append(f"  {name!r}: cell_index(es) {indices}")
+            detail_lines = [
+                f"    - {_cell_detail(ci, tkcells)}" for ci in indices
+            ]
+            lines.append(f"  {name!r}:\n" + "\n".join(detail_lines))
         raise DuplicateCellNameError(
             "Duplicate cell names detected — GDS/OASIS require unique cell"
             " names.\n" + "\n".join(lines) + "\n"
@@ -200,18 +221,13 @@ def _check_duplicate_cell_names(
             c.name = unique
             if was_locked:
                 c.locked = True
-            fn = None
-            if tkcells is not None:
-                tkcell = tkcells.get(ci)
-                fn = tkcell.function_name if tkcell else None
+            detail = _cell_detail(ci, tkcells)
             logger.warning(
-                "Renamed duplicate cell {old!r} (cell_index={ci},"
-                " function_name={fn!r}) to {new!r} before writing."
+                "Renamed duplicate cell {old!r} ({detail}) -> {new!r}."
                 " Set `kf.config.debug_names = True` to catch name"
                 " conflicts earlier.",
                 old=name,
-                ci=ci,
-                fn=fn,
+                detail=detail,
                 new=unique,
             )
 

--- a/src/kfactory/kcell.py
+++ b/src/kfactory/kcell.py
@@ -172,7 +172,9 @@ def _cell_detail(
                     loc += f":{lineno}"
                 parts.append(loc)
         else:
-            parts.append("no factory (created manually or via dup)")
+            c = layout.cell(ci)
+            cell_name = c.name if c is not None and not c._destroyed() else None
+            parts.append(f"no factory, name={cell_name!r}")
 
     c = layout.cell(ci)
     if c is not None and not c._destroyed():

--- a/src/kfactory/kcell.py
+++ b/src/kfactory/kcell.py
@@ -150,7 +150,7 @@ def _check_duplicate_cell_names(
     cell_indices: set[int],
     *,
     auto_rename: bool = False,
-    tkcells: Mapping[int, Any] | None = None,
+    tkcells: Mapping[int, TKCell] | None = None,
 ) -> None:
     """Check for duplicate cell names before writing a layout.
 

--- a/src/kfactory/kcell.py
+++ b/src/kfactory/kcell.py
@@ -150,6 +150,7 @@ def _check_duplicate_cell_names(
     cell_indices: set[int],
     *,
     auto_rename: bool = False,
+    tkcells: Mapping[int, Any] | None = None,
 ) -> None:
     """Check for duplicate cell names before writing a layout.
 
@@ -199,12 +200,18 @@ def _check_duplicate_cell_names(
             c.name = unique
             if was_locked:
                 c.locked = True
+            fn = None
+            if tkcells is not None:
+                tkcell = tkcells.get(ci)
+                fn = tkcell.function_name if tkcell else None
             logger.warning(
-                "Renamed duplicate cell {old!r} (cell_index={ci}) to {new!r}"
-                " before writing. Set `kf.config.debug_names = True` to catch"
-                " name conflicts earlier.",
+                "Renamed duplicate cell {old!r} (cell_index={ci},"
+                " function_name={fn!r}) to {new!r} before writing."
+                " Set `kf.config.debug_names = True` to catch name"
+                " conflicts earlier.",
                 old=name,
                 ci=ci,
+                fn=fn,
                 new=unique,
             )
 

--- a/src/kfactory/layout.py
+++ b/src/kfactory/layout.py
@@ -80,6 +80,7 @@ from .kcell import (
     TKCell,
     TVCell,
     VKCell,
+    _check_duplicate_cell_names,
     show,
 )
 from .layer import LayerEnum, LayerInfos, LayerStack, layerenum_from_dict
@@ -2240,74 +2241,20 @@ class KCLayout(
                     if kcell.is_library_cell() and not kcell.destroyed():
                         kcell.convert_to_static(recursive=True)
 
-        self._check_duplicate_cell_names(auto_rename=deduplicate_cell_names)
+        all_indices = {
+            c.cell_index() for c in self.layout.each_cell() if not c._destroyed()
+        }
+        _check_duplicate_cell_names(
+            self.layout,
+            all_indices,
+            auto_rename=deduplicate_cell_names,
+            tkcells=self.tkcells,
+        )
 
         if autoformat_from_file_extension:
             options.set_format_from_filename(filename)
 
         return self.layout.write(filename, options)
-
-    def _check_duplicate_cell_names(self, *, auto_rename: bool = False) -> None:
-        """Check for duplicate cell names before writing the layout.
-
-        GDS/OASIS require unique cell names.
-
-        Args:
-            auto_rename: If True, rename duplicates with ``$1``, ``$2``, …
-                suffixes and log a warning. If False (the default), raise
-                :class:`~kfactory.exceptions.DuplicateCellNameError`.
-        """
-        from collections import defaultdict
-
-        from .exceptions import DuplicateCellNameError
-
-        name_to_cells: dict[str, list[kdb.Cell]] = defaultdict(list)
-        for c in self.layout.each_cell():
-            if not c._destroyed():
-                name_to_cells[c.name].append(c)
-
-        duplicates = {
-            name: cells for name, cells in name_to_cells.items() if len(cells) > 1
-        }
-        if not duplicates:
-            return
-
-        if not auto_rename:
-            lines = []
-            for name, cells in duplicates.items():
-                indices = [c.cell_index() for c in cells if not c._destroyed()]
-                lines.append(f"  {name!r}: cell_index(es) {indices}")
-            raise DuplicateCellNameError(
-                "Duplicate cell names detected — GDS/OASIS require unique cell"
-                " names.\n" + "\n".join(lines) + "\n"
-                "Pass `deduplicate_cell_names=True` to auto-rename duplicates,"
-                " or set `kf.config.debug_names = True` to catch conflicts"
-                " earlier at assignment time."
-            )
-
-        for name, cells in duplicates.items():
-            for c in cells[1:]:
-                if c._destroyed():
-                    continue
-                unique = self.layout.unique_cell_name(name)
-                tkcell = self.tkcells.get(c.cell_index())
-                fn = tkcell.function_name if tkcell else None
-                was_locked = c.is_locked()
-                if was_locked:
-                    c.locked = False
-                c.name = unique
-                if was_locked:
-                    c.locked = True
-                logger.warning(
-                    "Renamed duplicate cell {old!r} (cell_index={ci},"
-                    " function_name={fn!r}) to {new!r} before writing."
-                    " Set `kf.config.debug_names = True` to catch name"
-                    " conflicts earlier.",
-                    old=name,
-                    ci=c.cell_index(),
-                    fn=fn,
-                    new=unique,
-                )
 
     def top_kcells(self) -> list[KCell]:
         """Return the top KCells."""


### PR DESCRIPTION
Consolidates the two `_check_duplicate_cell_names` implementations into one.

The module-level function in `kcell.py` already accepts `cell_indices`, so `KCLayout.write()` now calls it directly instead of having its own duplicate copy. Added an optional `tkcells` parameter to preserve `function_name` logging.

Addresses review feedback from @sebastian-goeldi on #997.