### PR TITLE
ignore ty warning on affinity

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,6 +167,7 @@ skip = "pyproject.toml, uv.lock"
 [tool.ty]
 src.exclude = [ "docs", "src/kfactory/widgets/interactive.py", "tests/gdsfactory-yaml-pics" ]
 src.include = [ "docs", "src", "tests" ]
+environment.python-platform = "all"
 
 [tool.pytest]
 ini_options.testpaths = [ "src", "tests" ]

--- a/src/kfactory/conf.py
+++ b/src/kfactory/conf.py
@@ -181,15 +181,15 @@ def get_affinity() -> int:
     On (most) linux we can get it through the scheduling affinity. Otherwise,
     fall back to the multiprocessing cpu count.
     """
+    sched_getaffinity = getattr(os, "sched_getaffinity", None)
+    if sched_getaffinity is not None:
+        return len(sched_getaffinity(0))
     try:
-        return len(os.sched_getaffinity(0))
-    except AttributeError:
-        try:
-            import multiprocessing
+        import multiprocessing
 
-            return multiprocessing.cpu_count()
-        except ModuleNotFoundError:
-            return 1
+        return multiprocessing.cpu_count()
+    except ModuleNotFoundError:
+        return 1
 
 
 dotenv_path = find_dotenv(usecwd=True)

--- a/src/kfactory/conf.py
+++ b/src/kfactory/conf.py
@@ -182,7 +182,9 @@ def get_affinity() -> int:
     fall back to the multiprocessing cpu count.
     """
     try:
-        return len(os.sched_getaffinity(0))  # ty:ignore[unresolved-attribute]
+        return len(
+            os.sched_getaffinity(0)  # ty:ignore[unresolved-attribute, unused-ignore-comment]
+        )
     except AttributeError:
         try:
             import multiprocessing

--- a/src/kfactory/conf.py
+++ b/src/kfactory/conf.py
@@ -181,15 +181,15 @@ def get_affinity() -> int:
     On (most) linux we can get it through the scheduling affinity. Otherwise,
     fall back to the multiprocessing cpu count.
     """
-    sched_getaffinity = getattr(os, "sched_getaffinity", None)
-    if sched_getaffinity is not None:
-        return len(sched_getaffinity(0))
     try:
-        import multiprocessing
+        return len(os.sched_getaffinity(0))  # ty:ignore[unresolved-attribute]
+    except AttributeError:
+        try:
+            import multiprocessing
 
-        return multiprocessing.cpu_count()
-    except ModuleNotFoundError:
-        return 1
+            return multiprocessing.cpu_count()
+        except ModuleNotFoundError:
+            return 1
 
 
 dotenv_path = find_dotenv(usecwd=True)


### PR DESCRIPTION
## Summary
- avoid calling os.sched_getaffinity on platforms that do not provide it
- fall back to multiprocessing.cpu_count() for ty worker count detection

## Verification
- uv run ty check src/kfactory
- uv run pytest -q