### PR TITLE
Add performance hotspot benchmarks

### DIFF
--- a/benchmarks/__init__.py
+++ b/benchmarks/__init__.py
@@ -1,0 +1,1 @@
+"""Local benchmark scripts for kfactory development."""

--- a/benchmarks/hotspots.py
+++ b/benchmarks/hotspots.py
@@ -1,0 +1,209 @@
+"""Small hotspot probes for local performance triage.
+
+Run with:
+
+    uv run python benchmarks/hotspots.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import statistics
+import sys
+import time
+from typing import TYPE_CHECKING
+
+import kfactory as kf
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+class Layers(kf.LayerInfos):
+    WG: kf.kdb.LayerInfo = kf.kdb.LayerInfo(1, 0)
+    WGCLAD: kf.kdb.LayerInfo = kf.kdb.LayerInfo(111, 0)
+
+
+def timed(
+    name: str,
+    func: Callable[[], int],
+    repeat: int,
+) -> tuple[str, list[float], int]:
+    gc.collect()
+    gc.disable()
+    values: list[float] = []
+    result = 0
+    try:
+        for _ in range(repeat):
+            t0 = time.perf_counter()
+            result = func()
+            values.append(time.perf_counter() - t0)
+    finally:
+        gc.enable()
+    return name, values, result
+
+
+def port_lookup(port_count: int, loops: int) -> int:
+    kcl = kf.KCLayout(name="BENCH_PORT_LOOKUP", infos=Layers)
+    c = kcl.kcell("PORT_LOOKUP")
+    layer = Layers().WG
+    for i in range(port_count):
+        c.create_port(
+            name=f"o{i}",
+            width=500,
+            layer_info=layer,
+            trans=kf.kdb.Trans(i % 4, False, i * 1000, 0),
+        )
+
+    total = 0
+    for _ in range(loops):
+        for i in range(port_count):
+            total += c.ports[f"o{i}"].x
+    return total
+
+
+def port_lookup_via_mapping(port_count: int, loops: int) -> int:
+    kcl = kf.KCLayout(name="BENCH_PORT_MAPPING", infos=Layers)
+    c = kcl.kcell("PORT_MAPPING")
+    layer = Layers().WG
+    for i in range(port_count):
+        c.create_port(
+            name=f"o{i}",
+            width=500,
+            layer_info=layer,
+            trans=kf.kdb.Trans(i % 4, False, i * 1000, 0),
+        )
+
+    ports_by_name = c.ports.get_all_named()
+    total = 0
+    for _ in range(loops):
+        for i in range(port_count):
+            total += ports_by_name[f"o{i}"].x
+    return total
+
+
+def port_filter(port_count: int, loops: int) -> int:
+    kcl = kf.KCLayout(name="BENCH_PORT_FILTER", infos=Layers)
+    c = kcl.kcell("PORT_FILTER")
+    layer = Layers().WG
+    for i in range(port_count):
+        c.create_port(
+            name=f"o{i}",
+            width=500,
+            layer_info=layer,
+            trans=kf.kdb.Trans(i % 4, False, i * 1000, 0),
+            port_type="optical" if i % 2 else "electrical",
+        )
+
+    total = 0
+    for _ in range(loops):
+        total += len(c.ports.filter(angle=1, port_type="optical"))
+    return total
+
+
+def extrude_static(point_count: int, loops: int) -> int:
+    kcl = kf.KCLayout(name="BENCH_EXTRUDE_STATIC", infos=Layers)
+    c = kcl.kcell("EXTRUDE_STATIC")
+    layers = Layers()
+    enclosure = kf.LayerEnclosure(sections=[(layers.WGCLAD, 0, 2000)])
+    path = [kf.kdb.DPoint(i, 0 if i % 2 == 0 else 10) for i in range(point_count)]
+    for _ in range(loops):
+        kf.enclosure.extrude_path(
+            c,
+            layers.WG,
+            path,
+            width=0.5,
+            enclosure=enclosure,
+        )
+    return c.shapes(kcl.layer(layers.WG)).size()
+
+
+def extrude_dynamic(point_count: int, loops: int) -> int:
+    kcl = kf.KCLayout(name="BENCH_EXTRUDE_DYNAMIC", infos=Layers)
+    c = kcl.kcell("EXTRUDE_DYNAMIC")
+    layers = Layers()
+    enclosure = kf.LayerEnclosure(sections=[(layers.WGCLAD, 0, 2000)])
+    path = [kf.kdb.DPoint(i, 0 if i % 2 == 0 else 10) for i in range(point_count)]
+    widths = [0.5 + 0.001 * (i % 10) for i in range(point_count)]
+    for _ in range(loops):
+        kf.enclosure.extrude_path_dynamic(
+            c,
+            layers.WG,
+            path,
+            widths=widths,
+            enclosure=enclosure,
+        )
+    return c.shapes(kcl.layer(layers.WG)).size()
+
+
+def cell_cache(loops: int) -> int:
+    kcl = kf.KCLayout(name="BENCH_CELL_CACHE", infos=Layers)
+    layers = Layers()
+    enclosure = kcl.get_enclosure(
+        kf.LayerEnclosure(name="WGSTD", sections=[(layers.WGCLAD, 0, 2000)])
+    )
+    straight = kf.factories.straight.straight_dbu_factory(kcl=kcl)
+    total = 0
+    for i in range(loops):
+        total += straight(
+            width=500,
+            length=10_000 + (i % 8),
+            layer=layers.WG,
+            enclosure=enclosure,
+        ).cell_index()
+    return total
+
+
+def stats(values: list[float]) -> str:
+    return (
+        f"min={min(values) * 1e3:.2f}ms "
+        f"median={statistics.median(values) * 1e3:.2f}ms "
+        f"mean={statistics.fmean(values) * 1e3:.2f}ms"
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repeat", type=int, default=5)
+    parser.add_argument("--ports", type=int, default=1000)
+    parser.add_argument("--port-loops", type=int, default=10)
+    parser.add_argument("--points", type=int, default=500)
+    parser.add_argument("--extrude-loops", type=int, default=10)
+    parser.add_argument("--cell-loops", type=int, default=1000)
+    args = parser.parse_args()
+
+    cases = [
+        (
+            "ports[name]",
+            lambda: port_lookup(args.ports, args.port_loops),
+        ),
+        (
+            "ports.get_all_named()[name]",
+            lambda: port_lookup_via_mapping(args.ports, args.port_loops),
+        ),
+        (
+            "ports.filter(angle,type)",
+            lambda: port_filter(args.ports, args.port_loops),
+        ),
+        (
+            "extrude_path",
+            lambda: extrude_static(args.points, args.extrude_loops),
+        ),
+        (
+            "extrude_path_dynamic",
+            lambda: extrude_dynamic(args.points, args.extrude_loops),
+        ),
+        (
+            "cell_factory_cache",
+            lambda: cell_cache(args.cell_loops),
+        ),
+    ]
+
+    for name, func in cases:
+        case_name, values, result = timed(name, func, args.repeat)
+        sys.stdout.write(f"{case_name:28} {stats(values)} result={result}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/route_bundle_collision.py
+++ b/benchmarks/route_bundle_collision.py
@@ -1,0 +1,184 @@
+"""Benchmark route_bundle collision-check overhead.
+
+Run with:
+
+    uv run python benchmarks/route_bundle_collision.py
+
+The benchmark compares the current fast path (`on_collision=None`) with the
+collision-checking path (`on_collision="error"`). It intentionally avoids
+pytest-benchmark so it can run in the normal dev environment without extra tools.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import itertools
+import statistics
+import sys
+import time
+from dataclasses import dataclass
+from functools import partial
+from typing import TYPE_CHECKING, Literal
+
+import kfactory as kf
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+class Layers(kf.LayerInfos):
+    WG: kf.kdb.LayerInfo = kf.kdb.LayerInfo(1, 0)
+    WGCLAD: kf.kdb.LayerInfo = kf.kdb.LayerInfo(111, 0)
+
+
+@dataclass(frozen=True)
+class BenchCase:
+    kcl: kf.KCLayout
+    straight_factory: Callable[..., kf.KCell]
+    bend90: kf.KCell
+    ports: int
+
+
+cell_counter = itertools.count()
+
+
+def build_case(ports: int) -> BenchCase:
+    kcl = kf.KCLayout(name="BENCH_ROUTE_BUNDLE_COLLISION", infos=Layers)
+    layers = Layers()
+    enclosure = kcl.get_enclosure(
+        kf.LayerEnclosure(name="WGSTD", sections=[(layers.WGCLAD, 0, 2000)])
+    )
+    straight_factory = partial(
+        kf.factories.straight.straight_dbu_factory(kcl=kcl),
+        layer=layers.WG,
+        enclosure=enclosure,
+    )
+    bend90 = kf.factories.euler.bend_euler_factory(kcl=kcl)(
+        width=0.5,
+        radius=10,
+        layer=layers.WG,
+        enclosure=enclosure,
+        angle=90,
+    )
+    return BenchCase(
+        kcl=kcl,
+        straight_factory=straight_factory,
+        bend90=bend90,
+        ports=ports,
+    )
+
+
+def build_ports(ports: int) -> tuple[list[kf.Port], list[kf.Port]]:
+    layers = Layers()
+    optical_port = kf.Port(
+        name="o1",
+        width=500,
+        trans=kf.kdb.Trans.R0,
+        layer_info=layers.WG,
+    )
+    start_ports = [
+        optical_port.copy(
+            kf.kdb.Trans(
+                1,
+                False,
+                i * 200_000 - 50_000,
+                (4 - i) * 6_000 if i < 5 else (i - 5) * 6_000,
+            )
+        )
+        for i in range(ports)
+    ]
+    end_ports = [
+        optical_port.copy(
+            kf.kdb.Trans(3, False, i * 200_000 + i**2 * 19_000 + 500_000, 300_000)
+        )
+        for i in range(ports)
+    ]
+    return start_ports, end_ports
+
+
+def route_once(case: BenchCase, on_collision: Literal["error"] | None) -> int:
+    c = case.kcl.kcell(f"BENCH_ROUTE_{next(cell_counter)}")
+    start_ports, end_ports = build_ports(case.ports)
+    routes = kf.routing.optical.route_bundle(
+        c,
+        start_ports,
+        end_ports,
+        5_000,
+        straight_factory=case.straight_factory,
+        bend90_cell=case.bend90,
+        on_collision=on_collision,
+    )
+    return len(routes)
+
+
+def time_pair(
+    case: BenchCase,
+    *,
+    repeat: int,
+    warmups: int,
+) -> tuple[list[float], list[float]]:
+    for _ in range(warmups):
+        route_once(case, None)
+        route_once(case, "error")
+
+    gc.collect()
+    gc.disable()
+    no_check: list[float] = []
+    check: list[float] = []
+    try:
+        for i in range(repeat):
+            if i % 2:
+                t0 = time.perf_counter()
+                route_once(case, "error")
+                check.append(time.perf_counter() - t0)
+
+                t0 = time.perf_counter()
+                route_once(case, None)
+                no_check.append(time.perf_counter() - t0)
+            else:
+                t0 = time.perf_counter()
+                route_once(case, None)
+                no_check.append(time.perf_counter() - t0)
+
+                t0 = time.perf_counter()
+                route_once(case, "error")
+                check.append(time.perf_counter() - t0)
+    finally:
+        gc.enable()
+    return no_check, check
+
+
+def format_stats(values: list[float]) -> str:
+    return (
+        f"min={min(values) * 1e3:.2f}ms "
+        f"median={statistics.median(values) * 1e3:.2f}ms "
+        f"mean={statistics.fmean(values) * 1e3:.2f}ms"
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--ports", type=int, default=20)
+    parser.add_argument("--repeat", type=int, default=10)
+    parser.add_argument("--warmups", type=int, default=2)
+    args = parser.parse_args()
+
+    case = build_case(args.ports)
+    no_check, check = time_pair(
+        case,
+        repeat=args.repeat,
+        warmups=args.warmups,
+    )
+    overhead = (statistics.fmean(check) / statistics.fmean(no_check) - 1) * 100
+
+    sys.stdout.write(
+        f"ports={args.ports} repeat={args.repeat} warmups={args.warmups}\n"
+    )
+    sys.stdout.write(f"on_collision=None:    {format_stats(no_check)}\n")
+    sys.stdout.write(f"on_collision='error': {format_stats(check)}\n")
+    sys.stdout.write(f"mean overhead: {overhead:.1f}%\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a route bundle collision benchmark for checking collision-validation overhead
- add a hotspot benchmark covering named port lookup, extrusion, cell cache, and schematic pin materialization

## Verification
- uv run python benchmarks/route_bundle_collision.py --repeat 5
- uv run python benchmarks/hotspots.py --repeat 5
- pre-commit hooks during commit