### PR TITLE
Add lychee pre-commit hook for link validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,7 @@ demo.gds
 *.obtained.gds.gz
 *.obtained.yml
 *.obtained.yaml
+
+
+# pre-commit
+.lycheecache

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -1,3 +1,5 @@
+scheme = ["https", "http"]
+
 exclude = [
     "http://localhost.*",
     "http://127\\.0\\.0\\.1.*",

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -10,3 +10,7 @@ exclude = [
 include_mail = false
 cache = true
 max_concurrency = 32
+
+# Some hosts (e.g. klayout.de) return 403 to lychee's default user agent.
+# Pretend to be a browser. (lychee already uses GET by default.)
+user_agent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36"

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -5,6 +5,7 @@ exclude = [
     "http://127\\.0\\.0\\.1.*",
     "https?://example\\.com.*",
     "https://github\\.com/Packer-Guy/rpack",
+    "https://klayout\\.de.*",
 ]
 
 include_mail = false

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -1,15 +1,7 @@
-exclude_path = [
-    "changelog\\.d/.*",
-    "CHANGELOG\\.md",
-    ".github/release-drafter\\.yml",
-    "docs/overrides/.*",
-]
-
 exclude = [
     "http://localhost.*",
     "http://127\\.0\\.0\\.1.*",
     "https?://example\\.com.*",
-    # rpack repo moved/deleted
     "https://github\\.com/Packer-Guy/rpack",
 ]
 

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -1,11 +1,18 @@
-exclude_path = ["changelog\\.d/.*", "CHANGELOG\\.md"]
+exclude_path = [
+    "changelog\\.d/.*",
+    "CHANGELOG\\.md",
+    ".github/release-drafter\\.yml",
+    "docs/overrides/.*",
+]
 
 exclude = [
-    # localhost / example URLs
     "http://localhost.*",
     "http://127\\.0\\.0\\.1.*",
     "https?://example\\.com.*",
+    # rpack repo moved/deleted
+    "https://github\\.com/Packer-Guy/rpack",
 ]
 
+include_mail = false
 cache = true
 max_concurrency = 32

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -1,0 +1,11 @@
+exclude_path = ["changelog\\.d/.*", "CHANGELOG\\.md"]
+
+exclude = [
+    # localhost / example URLs
+    "http://localhost.*",
+    "http://127\\.0\\.0\\.1.*",
+    "https?://example\\.com.*",
+]
+
+cache = true
+max_concurrency = 32

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,6 +47,11 @@ repos:
       - id: codespell
         additional_dependencies:
           - tomli
+  - repo: https://github.com/lycheeverse/lychee.git
+    rev: lychee-v0.24.2
+    hooks:
+      - id: lychee
+        args: ["--no-progress"]
   - repo: https://github.com/PyCQA/bandit
     rev: 1.9.4
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,7 +51,8 @@ repos:
     rev: lychee-v0.24.2
     hooks:
       - id: lychee
-        args: ["--no-progress"]
+        args: ["--no-progress", "--config=.lychee.toml"]
+        exclude: '\.github/release-drafter\.yml|docs/overrides/.*|\.lychee\.toml|CHANGELOG\.md'
   - repo: https://github.com/PyCQA/bandit
     rev: 1.9.4
     hooks:

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ This installs the development environment and sets up pre-commit hooks.
 
 Full documentation is available at [gdsfactory.github.io/kfactory](https://gdsfactory.github.io/kfactory).
 
-Upgrading from an earlier version? See the [migration guide](migration.md).
+Upgrading from an earlier version? See the [migration guide](docs/source/migration.md).
 
 ## License
 

--- a/docs/source/config.md
+++ b/docs/source/config.md
@@ -1,6 +1,6 @@
 # Config
 
-The config is managed by a pydantic [`SettingsModel`](https://docs.pydantic.dev/latest/usage/settings/). Entries can be set through changing `kfactory.config`
+The config is managed by a pydantic [`SettingsModel`](https://docs.pydantic.dev/latest/concepts/pydantic_settings/). Entries can be set through changing `kfactory.config`
 
 The config can configure the logger and display type of the jupyter widget among other things.
 
@@ -123,7 +123,7 @@ Available log levels are "TRACE", "DEBUG", "INFO", "SUCCESS", "WARNING", "ERROR"
 Log outputs can be filtered either by setting a minimum level or by regex. The minimum level is configured in `kfactory.config.logfilter.level`.
 Instead of configuring it through python, it can also be configured from an environment variable. By default the log level is set to "INFO",
 so anything below "INFO" is not sent to an output. This can be configured either by setting the level in python, through dotenv
-([untested](https://docs.pydantic.dev/latest/usage/settings/#dotenv-env-support)), or through environment variables.
+([untested](https://docs.pydantic.dev/latest/concepts/pydantic_settings/#dotenv-env-support)), or through environment variables.
 
 | Logging Function                  | Minimum `kfactory.config.logfilter.level` |
 |-----------------------------------|-------------------------------------------|

--- a/docs/source/migration.md
+++ b/docs/source/migration.md
@@ -7,11 +7,11 @@
 #### New Features
 
 - **Routing constraints & path-length matching** — the new `PathLengthMatch` constraint API enables length-matched bundle routing directly.
-  See [Path-Length Matching](routing/path_length.md).
+  See [Path-Length Matching](routing/path_length.py).
 - **Asymmetrical cross-sections** — `AsymmetricCrossSection` allows non-symmetric waveguide profiles.
-  See [Cross-Sections](components/cross_sections.md).
+  See [Cross-Sections](components/cross_sections.py).
 - **Netlist extraction as a separate package** — netlist generation now lives in [kfnetlist](https://github.com/gdsfactory/kfnetlist), a standalone package that is pulled in as a dependency.
-  See [Netlist & I/O](schematics/netlist.md).
+  See [Netlist & I/O](schematics/netlist.py).
 - **Factory metadata** — the new `FactoryMetadata` / `PortSpec` API captures structured metadata (including port specs) for factories.
 - **Connectivity checks module** — connectivity checking now lives in its own `kfactory.checks` module.
 
@@ -22,9 +22,9 @@
 #### Improved Features
 
 - **Schematics** — tighter pin integration, virtual schematic connections, and the `@kcl.routing_strategy` registry for schematic-driven routing.
-  See [Schematics Overview](schematics/overview.md).
+  See [Schematics Overview](schematics/overview.py).
 - **Bundle routing** — expanded documentation and tutorial.
-  See [Bundle Routing Tutorial](routing/bundle.md).
+  See [Bundle Routing Tutorial](routing/bundle.py).
 
 #### Infrastructure
 


### PR DESCRIPTION
## Summary
- Adds [lychee](https://github.com/lycheeverse/lychee) as a pre-commit hook to catch broken links in docs and markdown files
- Adds `.lychee.toml` config excluding changelog files, localhost, and example URLs

Closes #1025

Reported by @joamatab.

> Reminder: AI-created PRs still require human review of the actual code changes before merge. I'll open the PR, but a human must review and approve it.