### PR TITLE
Preserve dictionary insertion order in cell decorators

### DIFF
--- a/src/kfactory/serialization.py
+++ b/src/kfactory/serialization.py
@@ -44,7 +44,13 @@ class DecoratorDict(UserDict[Hashable, Any]):
 
     def __hash__(self) -> int:
         """Hash the dictionary."""
-        return hash(tuple(sorted(self.data.items())))
+        return hash(tuple(self.data.items()))
+
+    def __eq__(self, other: object) -> bool:
+        """Compare both dictionary items and their insertion order."""
+        return isinstance(other, DecoratorDict) and tuple(self.items()) == tuple(
+            other.items()
+        )
 
     def __reduce__(self) -> tuple[type[DecoratorDict], tuple[dict[Hashable, Any]]]:
         return (DecoratorDict, (self.data,))
@@ -151,7 +157,7 @@ def to_hashable(
     """Convert a `dict` to a `DecoratorDict`."""
     if isinstance(d, dict):
         ud = DecoratorDict()
-        for item, value in sorted(d.items()):
+        for item, value in d.items():
             if isinstance(value, dict | list):
                 value_: Any = to_hashable(value)
             else:

--- a/tests/test_cell.py
+++ b/tests/test_cell.py
@@ -91,6 +91,23 @@ def test_nested_dict_list(
     oas_regression(c)
 
 
+def test_cell_preserves_dictionary_order(kcl: kf.KCLayout) -> None:
+    received: list[list[str]] = []
+
+    @kcl.cell
+    def ordered_dict_cell(arg: dict[str, int]) -> kf.KCell:
+        received.append(list(arg))
+        return kcl.kcell()
+
+    first = ordered_dict_cell({"one": 1, "two": 2})
+    second = ordered_dict_cell({"two": 2, "one": 1})
+
+    assert received == [["one", "two"], ["two", "one"]]
+    assert list(first.settings["arg"]) == ["one", "two"]
+    assert list(second.settings["arg"]) == ["two", "one"]
+    assert first is not second
+
+
 def test_no_snap(
     layers: Layers,
     oas_regression: Callable[[kf.ProtoTKCell[Any]], None],


### PR DESCRIPTION
## Summary
- preserve dictionary insertion order while converting cell arguments to hashable wrappers
- make ordered dictionary contents part of cache equality and hashing
- ensure equal key/value pairs in different orders reach cell functions in their supplied order and produce distinct cached cells

Fixes gdsfactory/gdsfactory#3310

## Validation
- `uv run pytest -q tests/test_cell.py::test_cell_preserves_dictionary_order`
- `uv run pre-commit run --all-files`