### PR TITLE
Improving KCLayout.delete

### DIFF
--- a/src/kfactory/decorators.py
+++ b/src/kfactory/decorators.py
@@ -16,6 +16,7 @@ from typing import (
     TYPE_CHECKING,
     Annotated,
     Any,
+    Final,
     Protocol,
     TypeAliasType,
     TypedDict,
@@ -377,13 +378,13 @@ def _post_process[K: ProtoKCell[Any, Any]](
 
 @final
 class WrappedKCellFunc[**KCellParams, KC: ProtoTKCell[Any]]:
-    _f: Callable[KCellParams, KC]
+    _f: Final[Callable[KCellParams, KC]]
     _f_orig: Callable[KCellParams, ProtoTKCell[Any]]
     _f_schematic: Callable[KCellParams, TSchematic[Any]] | None = None
     cache: Cache[Hashable, Any] | dict[Hashable, Any]
     name: str
     kcl: KCLayout
-    output_type: type[KC]
+    output_type: Final[type[KC]]
     lvs_equivalent_ports: list[list[str]] | None = None
     ports_definition: PortsDefinition | None = None
     tags: set[str]
@@ -746,12 +747,12 @@ class WrappedKCellFunc[**KCellParams, KC: ProtoTKCell[Any]]:
 
 @final
 class WrappedVKCellFunc[**VKCellParams, VK: VKCell]:
-    _f: Callable[VKCellParams, VK]
+    _f: Final[Callable[VKCellParams, VK]]
     _f_orig: Callable[VKCellParams, VKCell]
     cache: Cache[Hashable, VK] | dict[Hashable, Any]
     name: str
     kcl: KCLayout
-    output_type: type[VK]
+    output_type: Final[type[VK]]
     lvs_equivalent_ports: list[list[str]] | None = None
     ports_definition: PortsDefinition | None = None
     tags: set[str]

--- a/src/kfactory/instance_group.py
+++ b/src/kfactory/instance_group.py
@@ -12,7 +12,7 @@ from .exceptions import (
     PortWidthMismatchError,
 )
 from .geometry import DBUGeometricObject, GeometricObject, UMGeometricObject
-from .instance import DInstance, Instance, ProtoTInstance, VInstance
+from .instance import DInstance, Instance, ProtoInstance, ProtoTInstance, VInstance
 from .port import BasePort, DPort, Port, ProtoPort
 from .ports import DCreatePort, DPorts, ICreatePort, Ports, ProtoPorts
 
@@ -30,7 +30,7 @@ __all__ = [
 ]
 
 
-class ProtoInstanceGroup[T: (int, float), TI: ProtoTInstance[Any] | VInstance](
+class ProtoInstanceGroup[T: (int, float), TI: ProtoInstance[Any]](
     GeometricObject[T], ABC
 ):
     insts: list[TI]
@@ -82,7 +82,7 @@ class ProtoInstanceGroup[T: (int, float), TI: ProtoTInstance[Any] | VInstance](
     ) -> None:
         """Transform the instance group."""
         for inst in self.insts:
-            inst.transform(trans)  # ty: ignore[invalid-argument-type]
+            inst.transform(trans)
         if isinstance(trans, kdb.DTrans):
             trans = trans.to_itype(self.kcl.dbu)
         elif isinstance(trans, kdb.ICplxTrans):
@@ -93,14 +93,14 @@ class ProtoInstanceGroup[T: (int, float), TI: ProtoTInstance[Any] | VInstance](
     def ibbox(self, layer: int | None = None) -> kdb.Box:
         """Get the total bounding box or the bounding box of a layer in dbu."""
         bb = kdb.Box()
-        for _bb in (inst.ibbox(layer) for inst in self.insts):  # ty: ignore[invalid-argument-type]
+        for _bb in (inst.ibbox(layer) for inst in self.insts):
             bb += _bb
         return bb
 
     def dbbox(self, layer: int | None = None) -> kdb.DBox:
         """Get the total bounding box or the bounding box of a layer in um."""
         bb = kdb.DBox()
-        for _bb in (inst.dbbox(layer) for inst in self.insts):  # ty: ignore[invalid-argument-type]
+        for _bb in (inst.dbbox(layer) for inst in self.insts):
             bb += _bb
         return bb
 

--- a/src/kfactory/layout.py
+++ b/src/kfactory/layout.py
@@ -198,7 +198,7 @@ class Factories[F: WrappedKCellFunc[Any, Any] | WrappedVKCellFunc[Any, Any]](
 
     def get_by_qualified_name(self, qualified_name: str) -> F | None:
         for factory in self._all:
-            if factory.qualified_name == qualified_name:
+            if factory.qualified_name == qualified_name:  # ty:ignore[invalid-attribute-access]
                 return factory
         return None
 

--- a/src/kfactory/layout.py
+++ b/src/kfactory/layout.py
@@ -2816,8 +2816,11 @@ class KCLayout(
         return f"{self.__class__.__name__}({self.name}, n={len(self.kcells)})"
 
     def delete(self) -> None:
-        del kcls[self.name]
-        self.library.delete()
+        if kcls.get(self.name) is self:
+            del kcls[self.name]
+        if not self.library._destroyed():
+            self.library.delete()
+        self.tkcells = {}
 
     def routing_strategy(
         self,

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -254,6 +254,24 @@ def test_kclayout_rebuild(kcl: kf.KCLayout, layers: Layers) -> None:
     assert len(list(kcl.layout.each_cell())) == 1
 
 
+def test_kclayout_delete_stale_destroyed_layout(kcl: kf.KCLayout) -> None:
+    kcl.kcell(name="cached_cell")
+    kcl.library.delete()
+    replacement = kf.KCLayout(name=kcl.name)
+
+    kcl.delete()
+
+    assert kf.kcls[kcl.name] is replacement
+    assert kcl.tkcells == {}
+
+    kcl.delete()
+    assert kf.kcls[kcl.name] is replacement
+
+    replacement.delete()
+    assert kcl.name not in kf.kcls
+    assert replacement.library._destroyed()
+
+
 def test_kclayout_assign(kcl: kf.KCLayout, layers: Layers) -> None:
     kcl2 = kf.KCLayout(name="kcl2")
     kcl2.infos = layers


### PR DESCRIPTION
## Summary

Just like it says, some improvements to `KCLayout.delete`, including reset of `tkcells` mapping.

As mentioned in https://github.com/gdsfactory/kfactory/issues/1043#issuecomment-5248724569 I still think there are potential missing locks here. I'm doing the bare minimum with some checks.

## Test Plan

Unit test.
