### PR TITLE
Build the types for serialization checks once at import time

### DIFF
--- a/src/kfactory/serialization.py
+++ b/src/kfactory/serialization.py
@@ -5,7 +5,7 @@ import inspect
 from collections import UserDict, UserList
 from collections.abc import Callable, Hashable
 from hashlib import sha3_512
-from types import FunctionType
+from types import FunctionType, UnionType
 from typing import TYPE_CHECKING, Any, TypeGuard, overload
 
 import numpy as np
@@ -311,113 +311,64 @@ def get_cell_name(
     return name
 
 
+_ISHAPES: UnionType = (
+    kdb.Box
+    | kdb.Edge
+    | kdb.Path
+    | kdb.Polygon
+    | kdb.Region
+    | kdb.SimplePolygon
+    | kdb.Text
+)
+_DSHAPES: UnionType = (
+    kdb.DBox | kdb.DEdge | kdb.DPath | kdb.DPolygon | kdb.DSimplePolygon | kdb.DText
+)
+_SERIALIZABLE_SHAPES: UnionType = (
+    kdb.CplxTrans
+    | kdb.DCplxTrans
+    | kdb.DEdgePair
+    | kdb.DPoint
+    | kdb.DTrans
+    | kdb.DVector
+    | kdb.EdgePair
+    | kdb.EdgePairs
+    | kdb.Edges
+    | kdb.ICplxTrans
+    | kdb.LayerInfo
+    | kdb.Matrix2d
+    | kdb.Matrix3d
+    | kdb.Point
+    | kdb.Texts
+    | kdb.Trans
+    | kdb.VCplxTrans
+    | kdb.Vector
+    | lay.LayerProperties
+    | _ISHAPES
+    | _DSHAPES
+)
+_SERIALIZABLE_VALUES_OR_SHAPES: UnionType = (
+    bool | int | float | str | _SERIALIZABLE_SHAPES
+)
+
+
 def serializible_value_or_shape_guard(
     value: Any,
 ) -> TypeGuard[int | float | bool | str | SerializableShape]:
-    return isinstance(
-        value,
-        int
-        | float
-        | bool
-        | str
-        | kdb.Box
-        | kdb.DBox
-        | kdb.Edge
-        | kdb.DEdge
-        | kdb.EdgePair
-        | kdb.DEdgePair
-        | kdb.EdgePairs
-        | kdb.Edges
-        | lay.LayerProperties
-        | kdb.Matrix2d
-        | kdb.Matrix3d
-        | kdb.Path
-        | kdb.DPath
-        | kdb.Point
-        | kdb.DPoint
-        | kdb.Polygon
-        | kdb.DPolygon
-        | kdb.SimplePolygon
-        | kdb.DSimplePolygon
-        | kdb.Region
-        | kdb.Text
-        | kdb.DText
-        | kdb.Texts
-        | kdb.Trans
-        | kdb.DTrans
-        | kdb.CplxTrans
-        | kdb.ICplxTrans
-        | kdb.DCplxTrans
-        | kdb.VCplxTrans
-        | kdb.Vector
-        | kdb.DVector
-        | kdb.LayerInfo,
-    )
+    return isinstance(value, _SERIALIZABLE_VALUES_OR_SHAPES)
 
 
 def serializible_shape_guard(
     value: Any,
 ) -> TypeGuard[SerializableShape]:
-    return isinstance(
-        value,
-        kdb.Box
-        | kdb.DBox
-        | kdb.Edge
-        | kdb.DEdge
-        | kdb.EdgePair
-        | kdb.DEdgePair
-        | kdb.EdgePairs
-        | kdb.Edges
-        | lay.LayerProperties
-        | kdb.Matrix2d
-        | kdb.Matrix3d
-        | kdb.Path
-        | kdb.DPath
-        | kdb.Point
-        | kdb.DPoint
-        | kdb.Polygon
-        | kdb.DPolygon
-        | kdb.SimplePolygon
-        | kdb.DSimplePolygon
-        | kdb.Region
-        | kdb.Text
-        | kdb.DText
-        | kdb.Texts
-        | kdb.Trans
-        | kdb.DTrans
-        | kdb.CplxTrans
-        | kdb.ICplxTrans
-        | kdb.DCplxTrans
-        | kdb.VCplxTrans
-        | kdb.Vector
-        | kdb.DVector
-        | kdb.LayerInfo,
-    )
+    return isinstance(value, _SERIALIZABLE_SHAPES)
 
 
 def ishape_guard(value: Any) -> TypeGuard[IShapeLike]:
-    return isinstance(
-        value,
-        kdb.Polygon
-        | kdb.Edge
-        | kdb.Path
-        | kdb.Box
-        | kdb.Text
-        | kdb.SimplePolygon
-        | kdb.Region,
-    )
+    return isinstance(value, _ISHAPES)
 
 
 def dshape_guard(value: Any) -> TypeGuard[DShapeLike]:
-    return isinstance(
-        value,
-        kdb.DPolygon
-        | kdb.DEdge
-        | kdb.DPath
-        | kdb.DBox
-        | kdb.DText
-        | kdb.DSimplePolygon,
-    )
+    return isinstance(value, _DSHAPES)
 
 
 def get_function_name(f: Callable[..., Any]) -> str:


### PR DESCRIPTION
## Summary

When using nested types with a lot of elements, profiling showed a lot of time was just spent on the type union per `isinstance` call. It gets costly.

I'd appreciate it if a patch release is made for this one :)

## Test Plan

<!-- How was it tested? -->
