### PR TITLE
fix: guard empty lists in route_bundle to prevent IndexError

### DIFF
--- a/src/kfactory/routing/electrical.py
+++ b/src/kfactory/routing/electrical.py
@@ -330,13 +330,13 @@ def route_bundle(
     if isinstance(starts, int | float):
         starts = c.kcl.to_dbu(starts)
     elif isinstance(starts, list):
-        if isinstance(starts[0], int | float):
+        if starts and isinstance(starts[0], int | float):
             starts = [c.kcl.to_dbu(cast("int|float", start)) for start in starts]
         starts = cast("int | list[int] | list[Step] | list[list[Step]]", starts)
     if isinstance(ends, int | float):
         ends = c.kcl.to_dbu(ends)
     elif isinstance(ends, list):
-        if isinstance(ends[0], int | float):
+        if ends and isinstance(ends[0], int | float):
             ends = [c.kcl.to_dbu(cast("int|float", end)) for end in ends]
         ends = cast("int | list[int] | list[Step] | list[list[Step]]", ends)
     if waypoints is not None:


### PR DESCRIPTION
Closes #1048

When `starts` or `ends` is an empty list, the code attempts to access `starts[0]` or `ends[0]` causing an IndexError. This adds a guard to check if the list is non-empty before checking the type of the first element.

Fixes #1048