### PR TITLE
fix: keep bbox_sections in um conversions and enclosure specs

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -5,7 +5,9 @@ exclude = [
     "http://127\\.0\\.0\\.1.*",
     "https?://example\\.com.*",
     "https://github\\.com/Packer-Guy/rpack",
-    "https://klayout\\.de.*",
+    # klayout.de is frequently slow enough to time out in CI (and 403s some
+    # user agents), so don't check it at all. Covers the www. subdomain too.
+    "https?://(www\\.)?klayout\\.de.*",
 ]
 
 include_mail = false

--- a/src/kfactory/enclosure.py
+++ b/src/kfactory/enclosure.py
@@ -574,13 +574,20 @@ class LayerSection(BaseModel):
 
 
 class DLayerEnclosure(BaseModel, arbitrary_types_allowed=True):
+    """um based version of [LayerEnclosure][kfactory.enclosure.LayerEnclosure]."""
+
     sections: list[tuple[kdb.LayerInfo, float] | tuple[kdb.LayerInfo, float, float]]
     name: str | None = None
     main_layer: kdb.LayerInfo
+    bbox_sections: list[tuple[kdb.LayerInfo, float]] = Field(default_factory=list)
 
     def to_itype(self, kcl: KCLayout) -> LayerEnclosure:
         return LayerEnclosure(
-            dsections=self.sections, name=self.name, main_layer=self.main_layer, kcl=kcl
+            dsections=self.sections,
+            name=self.name,
+            main_layer=self.main_layer,
+            dbbox_sections=self.bbox_sections,
+            kcl=kcl,
         )
 
 
@@ -626,6 +633,7 @@ class LayerEnclosure(BaseModel, arbitrary_types_allowed=True, frozen=True):
         ]
         | None = None,
         bbox_sections: Sequence[tuple[kdb.LayerInfo, int]] = [],
+        dbbox_sections: Sequence[tuple[kdb.LayerInfo, float]] | None = None,
         kcl: KCLayout | None = None,
     ) -> None:
         """Constructor of new enclosure.
@@ -637,9 +645,13 @@ class LayerEnclosure(BaseModel, arbitrary_types_allowed=True, frozen=True):
                 cell name this name will be used for enclosure arguments.
             main_layer: Main layer used if the functions don't get an explicit layer.
             dsections: Same as sections but min/max defined in um
+            bbox_sections: tuples of (layer, offset) to grow the bounding box of the
+                reference by `offset` on `layer`.
+            dbbox_sections: Same as `bbox_sections` but the offset defined in um.
             kcl: `KCLayout` Used for conversion dbu -> um or when copying.
-                Must be specified if `desections` is not `None`. Also necessary
-                if copying to another layout and not all layers used are LayerInfos.
+                Must be specified if `dsections` or `dbbox_sections` is not `None`.
+                Also necessary if copying to another layout and not all layers used
+                are LayerInfos.
         """
         layer_sections: dict[kdb.LayerInfo, LayerSection] = {}
 
@@ -658,6 +670,15 @@ class LayerEnclosure(BaseModel, arbitrary_types_allowed=True, frozen=True):
                             kcl.to_dbu(section[2]),
                         )
                     )
+
+        if dbbox_sections is not None:
+            assert kcl is not None, (
+                "If bbox sections in um are defined, kcl must be set"
+            )
+            bbox_sections = [
+                *bbox_sections,
+                *((layer, kcl.to_dbu(offset)) for layer, offset in dbbox_sections),
+            ]
 
         for sec in sorted(
             sections,
@@ -723,6 +744,10 @@ class LayerEnclosure(BaseModel, arbitrary_types_allowed=True, frozen=True):
                 for section in layer_section.sections
             ],
             main_layer=self.main_layer,
+            bbox_sections=[
+                (layer, kcl.to_um(offset))
+                for layer, offset in self.bbox_sections.items()
+            ],
         )
 
     @property
@@ -1199,6 +1224,8 @@ class LayerEnclosureSpec(TypedDict):
     dsections: NotRequired[
         list[tuple[kdb.LayerInfo, float] | tuple[kdb.LayerInfo, float, float]]
     ]
+    bbox_sections: NotRequired[list[tuple[kdb.LayerInfo, int]]]
+    dbbox_sections: NotRequired[list[tuple[kdb.LayerInfo, float]]]
 
 
 class LayerEnclosureCollection(BaseModel):
@@ -1253,11 +1280,21 @@ class KCellLayerEnclosures(BaseModel):
     ) -> LayerEnclosure:
         if isinstance(enclosure, str):
             return self[enclosure]
-        if isinstance(enclosure, dict) and enclosure.get("dsections") is None:
+        if isinstance(enclosure, dict):
+            if (
+                enclosure.get("dsections") is not None
+                or enclosure.get("dbbox_sections") is not None
+            ):
+                raise ValueError(
+                    "um based enclosure specs (`dsections`/`dbbox_sections`) cannot be"
+                    " converted without a `KCLayout`. Use `KCLayout.get_enclosure` or"
+                    " pass a `LayerEnclosure` instead."
+                )
             enclosure = LayerEnclosure(
                 sections=enclosure.get("sections", []),
                 name=enclosure.get("name"),
                 main_layer=enclosure["main_layer"],
+                bbox_sections=enclosure.get("bbox_sections", []),
             )
 
         if enclosure not in self.enclosures:
@@ -1787,6 +1824,8 @@ class LayerEnclosureModel(RootModel[dict[str, LayerEnclosure]]):
                     dsections=enclosure.get("dsections", []),
                     name=enclosure.get("name"),
                     main_layer=enclosure["main_layer"],
+                    bbox_sections=enclosure.get("bbox_sections", []),
+                    dbbox_sections=enclosure.get("dbbox_sections"),
                     kcl=kcl,
                 )
             else:
@@ -1794,6 +1833,8 @@ class LayerEnclosureModel(RootModel[dict[str, LayerEnclosure]]):
                     sections=enclosure.get("sections", []),
                     name=enclosure.get("name"),
                     main_layer=enclosure["main_layer"],
+                    bbox_sections=enclosure.get("bbox_sections", []),
+                    dbbox_sections=enclosure.get("dbbox_sections"),
                     kcl=kcl,
                 )
         enclosure = cast("LayerEnclosure", enclosure)

--- a/src/kfactory/layout.py
+++ b/src/kfactory/layout.py
@@ -697,6 +697,8 @@ class KCLayout(
             tuple[kdb.LayerInfo, float] | tuple[kdb.LayerInfo, float, float]
         ]
         | None = None,
+        bbox_sections: Sequence[tuple[kdb.LayerInfo, int]] = [],
+        dbbox_sections: Sequence[tuple[kdb.LayerInfo, float]] | None = None,
     ) -> LayerEnclosure:
         """Create a new LayerEnclosure in the KCLayout."""
         if name is None and main_layer is not None and main_layer.name != "":
@@ -706,6 +708,8 @@ class KCLayout(
             dsections=dsections,
             name=name,
             main_layer=main_layer,
+            bbox_sections=bbox_sections,
+            dbbox_sections=dbbox_sections,
             kcl=self,
         )
 

--- a/tests/test_enclosure.py
+++ b/tests/test_enclosure.py
@@ -156,6 +156,124 @@ def test_bbox_sections_gds_roundtrip(
     assert restored_xs == xs
 
 
+def test_bbox_sections_dtype_roundtrip(kcl: kf.KCLayout, layers: Layers) -> None:
+    """``bbox_sections`` survive the dbu -> um -> dbu conversion.
+
+    Regression: `DLayerEnclosure` had no `bbox_sections` field, so `to_dtype`
+    silently dropped them.
+    """
+    enc = kf.LayerEnclosure(
+        sections=[(layers.WGCLAD, 3000)],
+        main_layer=layers.WG,
+        bbox_sections=[(layers.FILL1, 2000), (layers.FILL2, -500)],
+        name="enc_dtype_bbox",
+    )
+
+    denc = enc.to_dtype(kcl)
+    assert denc.bbox_sections == [(layers.FILL1, 2.0), (layers.FILL2, -0.5)]
+    assert denc.to_itype(kcl) == enc
+
+
+def test_bbox_sections_dbbox_sections_equivalent(
+    kcl: kf.KCLayout, layers: Layers
+) -> None:
+    """``dbbox_sections`` is the um based equivalent of ``bbox_sections``."""
+    enc = kf.LayerEnclosure(
+        sections=[(layers.WGCLAD, 3000)],
+        main_layer=layers.WG,
+        bbox_sections=[(layers.FILL1, 2000)],
+        kcl=kcl,
+    )
+    enc_um = kf.LayerEnclosure(
+        sections=[(layers.WGCLAD, 3000)],
+        main_layer=layers.WG,
+        dbbox_sections=[(layers.FILL1, 2.0)],
+        kcl=kcl,
+    )
+
+    assert enc == enc_um
+
+
+def test_dbbox_sections_nodbu(layers: Layers) -> None:
+    """When defining um bbox sections, kcl must be defined."""
+    with pytest.raises(AssertionError):
+        kf.LayerEnclosure(main_layer=layers.WG, dbbox_sections=[(layers.FILL1, 2.0)])
+
+
+def test_bbox_sections_spec_roundtrip(kcl: kf.KCLayout, layers: Layers) -> None:
+    """A dumped enclosure fed back through ``get_enclosure`` keeps its bbox sections.
+
+    Regression: `LayerEnclosureSpec` had no `bbox_sections` key and the dict
+    branches of `get_enclosure` dropped it.
+    """
+    enc = kf.LayerEnclosure(
+        sections=[(layers.WGCLAD, 3000)],
+        main_layer=layers.WG,
+        bbox_sections=[(layers.FILL1, 2000)],
+        name="enc_spec_bbox",
+    )
+
+    restored = kcl.get_enclosure(enc.model_dump())
+    assert restored.bbox_sections == {layers.FILL1: 2000}
+    assert restored == enc
+
+
+def test_bbox_sections_spec_um(kcl: kf.KCLayout, layers: Layers) -> None:
+    """A um based spec can define bbox sections via ``dbbox_sections``."""
+    spec: kf.enclosure.LayerEnclosureSpec = {
+        "main_layer": layers.WG,
+        "dsections": [(layers.WGCLAD, 3.0)],
+        "dbbox_sections": [(layers.FILL1, 2.0)],
+        "name": "enc_spec_um_bbox",
+    }
+
+    enc = kcl.get_enclosure(spec)
+    assert enc.bbox_sections == {layers.FILL1: 2000}
+
+
+def test_kcell_layer_enclosures_spec_bbox_sections(layers: Layers) -> None:
+    """``KCellLayerEnclosures`` specs keep bbox sections, and reject um specs."""
+    collection = kf.enclosure.KCellLayerEnclosures(enclosures=[])
+
+    enc = collection.get_enclosure(
+        {
+            "main_layer": layers.WG,
+            "sections": [(layers.WGCLAD, 3000)],
+            "bbox_sections": [(layers.FILL1, 2000)],
+        }
+    )
+    assert enc.bbox_sections == {layers.FILL1: 2000}
+    assert collection.enclosures == [enc]
+
+    with pytest.raises(ValueError, match="cannot be converted without"):
+        collection.get_enclosure(
+            {
+                "main_layer": layers.WG,
+                "dbbox_sections": [(layers.FILL1, 2.0)],
+            }
+        )
+
+
+def test_create_layer_enclosure_bbox_sections(kcl: kf.KCLayout, layers: Layers) -> None:
+    """``KCLayout.create_layer_enclosure`` can express bbox sections."""
+    enc = kcl.create_layer_enclosure(
+        sections=[(layers.WGCLAD, 3000)],
+        main_layer=layers.WG,
+        name="enc_created_bbox",
+        bbox_sections=[(layers.FILL1, 2000)],
+    )
+    assert enc.bbox_sections == {layers.FILL1: 2000}
+    assert kcl.layer_enclosures["enc_created_bbox"] is enc
+
+    enc_um = kcl.create_layer_enclosure(
+        dsections=[(layers.WGCLAD, 3.0)],
+        main_layer=layers.WG,
+        name="enc_created_bbox_um",
+        dbbox_sections=[(layers.FILL1, 2.0)],
+    )
+    assert enc_um.bbox_sections == {layers.FILL1: 2000}
+
+
 def test_bbox_sections_eq_and_hash_agree(layers: Layers) -> None:
     """Enclosures differing only in ``bbox_sections`` are unequal and hash apart."""
     without_bbox = kf.LayerEnclosure(


### PR DESCRIPTION
`DLayerEnclosure` had no `bbox_sections` field, so `LayerEnclosure.to_dtype` dropped them and `enc.to_dtype(kcl).to_itype(kcl) != enc`. Add the field (um based) plus a `dbbox_sections` constructor argument on `LayerEnclosure`, the um counterpart of `bbox_sections` mirroring `dsections`/`sections`.

`LayerEnclosureSpec` had no `bbox_sections` key and all three dict -> `LayerEnclosure` branches dropped it, so a `model_dump()` dict fed back through `get_enclosure()` lost the bbox sections even though the file round trip works. Add both `bbox_sections` (dbu) and `dbbox_sections` (um) to the spec and forward them in every branch. `KCellLayerEnclosures.get_enclosure` has no `KCLayout` to convert with, so it now raises instead of silently dropping um based keys.

`KCLayout.create_layer_enclosure` gains `bbox_sections`/`dbbox_sections` so bbox sections can be expressed there too.