### PR TITLE
Add per-reference info channel on instances

### DIFF
--- a/docs/source/concepts/instances.py
+++ b/docs/source/concepts/instances.py
@@ -224,6 +224,46 @@ b30b.flatten()  # merges geometry into parent to close sub-nm gaps
 angled
 
 # %% [markdown]
+# ## Per-instance info
+#
+# A cell's `info` is shared by *every* placement of that cell. When you need
+# metadata that differs **per placement** — e.g. which measurement each copy of a
+# reusable device is used for — attach it to the instance instead via `inst.info`.
+#
+# `inst.info` mirrors `cell.info`: attribute- or item-style access, and the same
+# metadata types (Python scalars/containers and `kdb` shapes). It is stored on the
+# instance's GDS user properties, so different placements of the *same cached cell*
+# carry different info without breaking cell caching, and it survives a GDS/OASIS
+# roundtrip.
+
+# %%
+device = kf.KCell(name="reusable_device")
+device.shapes(kf.kcl.find_layer(L.WG)).insert(kf.kdb.DBox(0, 0, 20, 10))
+device.info["component"] = "mzi"  # shared by every placement
+
+circuit = kf.KCell(name="per_instance_info")
+ref_a = circuit << device
+ref_b = circuit << device
+ref_b.dmovey(30)
+
+# per-placement metadata: same cached cell, different info on each instance
+ref_a.info["measure"] = "spectrum"
+ref_a.info.wavelength_nm = 1550  # attribute-style assignment also persists
+ref_b.info["measure"] = "power"
+
+# a single cell definition is reused, yet each instance keeps its own info
+assert ref_a.cell_index == ref_b.cell_index
+assert dict(ref_a.info) == {"measure": "spectrum", "wavelength_nm": 1550}
+assert dict(ref_b.info) == {"measure": "power"}
+print("cell.info :", dict(device.info))
+print("ref_a.info:", dict(ref_a.info))
+print("ref_b.info:", dict(ref_b.info))
+
+# %% [markdown]
+# > **Note:** `inst.info` lives on the instance's properties, so — like the
+# > instance name — it is discarded when the instance is flattened into its parent.
+
+# %% [markdown]
 # ## Summary
 #
 # | Task | API |
@@ -235,6 +275,7 @@ angled
 # | Regular array | `parent.create_inst(child, na=N, nb=M, a=vec_a, b=vec_b)` |
 # | Access array port | `arr_inst["port_name", col, row]` |
 # | Expose child ports | `parent.add_ports(inst.ports, prefix="…")` |
+# | Per-placement metadata | `inst.info["key"] = value` |
 # | Flatten into parent | `inst.flatten()` |
 
 # %% [markdown]

--- a/src/kfactory/conf.py
+++ b/src/kfactory/conf.py
@@ -64,6 +64,8 @@ class PROPID(IntEnum):
     """Instance name."""
     PURPOSE = 1
     """Instance purpose (e.g. 'routing')."""
+    INFO = 2
+    """Per-instance info dict, stored as a single JSON blob (see ``Instance.info``)."""
 
 
 class PORTDIRECTION(IntEnum):

--- a/src/kfactory/instance.py
+++ b/src/kfactory/instance.py
@@ -25,6 +25,7 @@ from .exceptions import (
 )
 from .geometry import DBUGeometricObject, GeometricObject, UMGeometricObject
 from .port import DPort, Port, ProtoPort
+from .serialization import deserialize_setting, serialize_setting
 from .settings import Info
 
 if TYPE_CHECKING:
@@ -60,16 +61,49 @@ __all__ = [
 ]
 
 
+def _dump_instance_info(data: dict[str, Any]) -> str:
+    """Serialize an info dict to the JSON blob stored on an instance property.
+
+    Reuses the cell-level ``serialize_setting`` scheme so that ``kdb`` shapes
+    (``Box``, ``Trans``, ``LayerInfo``, ``Polygon``, ...) survive the JSON
+    encoding that instance properties require.
+
+    A handful of ``kdb`` collection/matrix types (``Region``, ``Edges``,
+    ``Texts``, ``EdgePairs``, ``Matrix2d``, ``Matrix3d``, ``LayerProperties``)
+    can be *serialized* but not reconstructed by ``deserialize_setting`` (they
+    have no ``from_s``). Those round-trip on a cell (native layout meta info) but
+    not through instance properties, so they are rejected here with a clear error
+    at assignment time instead of crashing later when the info is read back.
+    """
+    blob = json.dumps(serialize_setting(data))
+    try:
+        deserialize_setting(json.loads(blob))
+    except Exception as e:
+        raise ValueError(
+            "Instance info value cannot be stored per-instance: it serializes "
+            "but is not reconstructable through instance properties. kdb "
+            "collection/matrix types (Region, Edges, Texts, EdgePairs, "
+            "Matrix2d, Matrix3d, LayerProperties) are only supported on cell "
+            f"info, not on instance info. Offending data: {data!r}"
+        ) from e
+    return blob
+
+
+def _load_instance_info(blob: str) -> dict[str, Any]:
+    """Deserialize an instance-property JSON blob back into an info dict."""
+    return deserialize_setting(json.loads(blob))
+
+
 class InstanceInfo(Info):
     """Per-instance ``info`` bound to a KLayout instance's user properties.
 
     Behaves like the cell-level :class:`~kfactory.settings.Info`: values are
     restricted to JSON-compatible metadata (``int``, ``float``, ``str``,
-    ``tuple``, ``list``, ``dict`` or ``None``) and can be accessed either as
-    attributes or items. Unlike the cell version, every mutation is immediately
-    serialized to a single JSON blob stored on the underlying ``kdb.Instance``
-    under :attr:`~kfactory.conf.PROPID.INFO`, so the change persists on the
-    instance (and survives a GDS/OASIS roundtrip).
+    ``tuple``, ``list``, ``dict``, ``None`` or serializable ``kdb`` shapes) and
+    can be accessed either as attributes or items. Unlike the cell version,
+    every mutation is immediately serialized to a single JSON blob stored on the
+    underlying ``kdb.Instance`` under :attr:`~kfactory.conf.PROPID.INFO`, so the
+    change persists on the instance (and survives a GDS/OASIS roundtrip).
 
     Instances are wrapped lazily, so this object is created on each ``inst.info``
     access. It writes straight through to the instance, meaning
@@ -79,6 +113,14 @@ class InstanceInfo(Info):
     Note:
         Tuples are stored as JSON arrays and therefore read back as ``list``,
         matching how cell info behaves when it is serialized to GDS metadata.
+
+    Note:
+        A few ``kdb`` collection/matrix types (``Region``, ``Edges``, ``Texts``,
+        ``EdgePairs``, ``Matrix2d``, ``Matrix3d``, ``LayerProperties``) are only
+        supported on *cell* info (native layout meta info), not on instance
+        info; assigning one raises ``ValueError``. All other serializable ``kdb``
+        shapes (boxes, points, vectors, transformations, polygons, edges, paths,
+        texts, ``LayerInfo``, ...) round-trip fine.
     """
 
     _instance: kdb.Instance | None = PrivateAttr(default=None)
@@ -93,7 +135,9 @@ class InstanceInfo(Info):
     def _persist(self) -> None:
         """Serialize the current info to the bound instance property."""
         if self._instance is not None:
-            self._instance.set_property(self._prop_id, json.dumps(self.model_dump()))
+            self._instance.set_property(
+                self._prop_id, _dump_instance_info(self.model_dump())
+            )
 
     def __setattr__(self, name: str, value: Any) -> None:
         """Validate/store the value, then write back to the instance."""
@@ -243,7 +287,7 @@ class ProtoTInstance[T: (int, float)](ProtoInstance[T]):
             info is lost on flatten (the same as instance names).
         """
         prop = self._instance.property(PROPID.INFO)
-        data: dict[str, Any] = json.loads(prop) if prop is not None else {}
+        data: dict[str, Any] = _load_instance_info(prop) if prop is not None else {}
         return InstanceInfo(**data)._bind(self._instance, PROPID.INFO)
 
     @info.setter
@@ -253,7 +297,9 @@ class ProtoTInstance[T: (int, float)](ProtoInstance[T]):
         # The runtime ``Info(**data)`` call below still validates the metadata
         # types (raising on unsupported values, like the cell-level info).
         data = value.model_dump() if isinstance(value, Info) else dict(value)
-        self._instance.set_property(PROPID.INFO, json.dumps(Info(**data).model_dump()))
+        self._instance.set_property(
+            PROPID.INFO, _dump_instance_info(Info(**data).model_dump())
+        )
 
     @property
     def cell_index(self) -> int:

--- a/src/kfactory/instance.py
+++ b/src/kfactory/instance.py
@@ -62,20 +62,34 @@ __all__ = [
 _GDS_MAX_PROPERTY_BYTES = 65530
 """Maximum byte length of a single GDS property value.
 
-GDS stores each property value in a record whose length field is two bytes, so a
-``PROPVALUE`` payload cannot exceed 65530 bytes. Instance info is written as one
-JSON blob under a single property, so an oversized blob makes the whole layout
-unwritable to GDS (KLayout raises ``String max. length overflow``). OASIS has no
-such limit; cell info is unaffected because it uses native layout meta info.
+A GDS ``PROPVALUE`` record is ``4-byte header + value`` and its length field is a
+16-bit integer, so read as unsigned the value cannot exceed 65530 bytes. Instance
+info is written as one JSON blob under a single property, so a larger blob makes
+the whole layout unwritable to GDS (KLayout raises ``String max. length
+overflow``). OASIS has no such limit; cell info is unaffected because it uses
+native layout meta info.
+"""
+
+_GDS_SPEC_PROPERTY_BYTES = 32764
+"""GDS-spec-safe byte length of a single property value.
+
+The strict GDS spec treats the 16-bit record-length field as *signed* (max
+0x8000), so a ``PROPVALUE`` record longer than 32768 bytes -- i.e. a value over
+32764 bytes -- has the high bit set and reads as negative to strict parsers.
+KLayout writes and reads such records by treating the field as unsigned (and
+warns), but other GDS tools may misinterpret or reject them. This is an
+interoperability limit, not a data-integrity one.
 """
 
 
 def _set_info_property(instance: kdb.Instance, prop_id: int, blob: str) -> None:
-    """Write an info blob to an instance property, logging if not GDS-writable.
+    """Write an info blob to an instance property, logging any GDS size problem.
 
-    The size limit only applies to GDS, so the value is stored regardless and
+    The size limits only apply to GDS, so the value is stored regardless and
     OASIS output keeps working; the log flags the problem at assignment time
-    instead of letting the GDS write fail later with an unattributable error.
+    instead of letting it surface later (a hard write failure over the 64 KB
+    record limit, or silent interoperability breakage over the 32 KB
+    strict-spec limit).
 
     Args:
         instance: The KLayout instance to write the property on.
@@ -90,6 +104,14 @@ def _set_info_property(instance: kdb.Instance, prop_id: int, blob: str) -> None:
             f"{_GDS_MAX_PROPERTY_BYTES} bytes; writing this layout to GDS will "
             "fail with a 'String max. length overflow' error (OASIS is "
             "unaffected)."
+        )
+    elif size > _GDS_SPEC_PROPERTY_BYTES:
+        logger.warning(
+            f"Instance info for a placement of cell {instance.cell.name!r} is "
+            f"{size} bytes; the GDS property record exceeds the strict GDS "
+            f"spec's signed 16-bit length limit ({_GDS_SPEC_PROPERTY_BYTES} "
+            "bytes of value). KLayout reads it back correctly, but other GDS "
+            "tools may misinterpret or reject the record (OASIS is unaffected)."
         )
     instance.set_property(prop_id, blob)
 

--- a/src/kfactory/instance.py
+++ b/src/kfactory/instance.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import functools
+import json
 from abc import abstractmethod
 from hashlib import sha3_512
 from typing import (
@@ -12,6 +13,7 @@ from typing import (
 )
 
 import klayout.db as kdb
+from pydantic import PrivateAttr
 
 from .conf import PROPID, config, logger
 from .exceptions import (
@@ -23,8 +25,11 @@ from .exceptions import (
 )
 from .geometry import DBUGeometricObject, GeometricObject, UMGeometricObject
 from .port import DPort, Port, ProtoPort
+from .settings import Info
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from ruamel.yaml.representer import BaseRepresenter, MappingNode
 
     from .instance_pins import (
@@ -43,8 +48,63 @@ if TYPE_CHECKING:
     from .kcell import AnyKCell, AnyTKCell, DKCell, KCell, ProtoTKCell
     from .layer import LayerEnum
     from .layout import KCLayout
+    from .typings import MetaData
 
-__all__ = ["DInstance", "Instance", "ProtoInstance", "ProtoTInstance", "VInstance"]
+__all__ = [
+    "DInstance",
+    "Instance",
+    "InstanceInfo",
+    "ProtoInstance",
+    "ProtoTInstance",
+    "VInstance",
+]
+
+
+class InstanceInfo(Info):
+    """Per-instance ``info`` bound to a KLayout instance's user properties.
+
+    Behaves like the cell-level :class:`~kfactory.settings.Info`: values are
+    restricted to JSON-compatible metadata (``int``, ``float``, ``str``,
+    ``tuple``, ``list``, ``dict`` or ``None``) and can be accessed either as
+    attributes or items. Unlike the cell version, every mutation is immediately
+    serialized to a single JSON blob stored on the underlying ``kdb.Instance``
+    under :attr:`~kfactory.conf.PROPID.INFO`, so the change persists on the
+    instance (and survives a GDS/OASIS roundtrip).
+
+    Instances are wrapped lazily, so this object is created on each ``inst.info``
+    access. It writes straight through to the instance, meaning
+    ``inst.info["key"] = value`` persists exactly like ``cell.info["key"] =
+    value`` does for cells.
+
+    Note:
+        Tuples are stored as JSON arrays and therefore read back as ``list``,
+        matching how cell info behaves when it is serialized to GDS metadata.
+    """
+
+    _instance: kdb.Instance | None = PrivateAttr(default=None)
+    _prop_id: int = PrivateAttr(default=PROPID.INFO)
+
+    def _bind(self, instance: kdb.Instance, prop_id: int) -> Self:
+        """Bind this info object to an instance property for write-back."""
+        self._instance = instance
+        self._prop_id = prop_id
+        return self
+
+    def _persist(self) -> None:
+        """Serialize the current info to the bound instance property."""
+        if self._instance is not None:
+            self._instance.set_property(self._prop_id, json.dumps(self.model_dump()))
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        """Validate/store the value, then write back to the instance."""
+        super().__setattr__(name, value)
+        if not name.startswith("_"):
+            self._persist()
+
+    def update(self, data: dict[str, MetaData]) -> None:
+        """Update several values at once and write back to the instance."""
+        super().update(data)
+        self._persist()
 
 
 class ProtoInstance[T: (int, float)](GeometricObject[T]):
@@ -157,6 +217,43 @@ class ProtoTInstance[T: (int, float)](ProtoInstance[T]):
     @purpose.setter
     def purpose(self, value: str | None) -> None:
         self._instance.set_property(PROPID.PURPOSE, value)
+
+    @property
+    def info(self) -> InstanceInfo:
+        """Per-instance info, mirroring the cell-level ``info`` API.
+
+        Returns an :class:`InstanceInfo` bound to this instance. Reads and
+        mutations go through the instance's GDS user properties (a single JSON
+        blob under :attr:`~kfactory.conf.PROPID.INFO`), so different placements
+        of the *same* cached cell can carry different info without wrapper cells
+        and without breaking cell caching::
+
+            ref = cell << other
+            ref.info["measure"] = "spectrum"  # persists on this instance only
+            ref.info.wavelength = 1550
+            ref.info.update({"port": "o1"})
+
+        Assigning replaces the whole info dict; the value may be a mapping or
+        another :class:`~kfactory.settings.Info`::
+
+            ref.info = {"measure": "power"}
+
+        Note:
+            Flattening the instance discards its properties, so per-instance
+            info is lost on flatten (the same as instance names).
+        """
+        prop = self._instance.property(PROPID.INFO)
+        data: dict[str, Any] = json.loads(prop) if prop is not None else {}
+        return InstanceInfo(**data)._bind(self._instance, PROPID.INFO)
+
+    @info.setter
+    def info(self, value: Info | Mapping[str, Any]) -> None:
+        # NOTE: annotated with ``Any`` rather than the recursive ``MetaData``
+        # alias here on purpose - the latter overflows ``ty`` in this position.
+        # The runtime ``Info(**data)`` call below still validates the metadata
+        # types (raising on unsupported values, like the cell-level info).
+        data = value.model_dump() if isinstance(value, Info) else dict(value)
+        self._instance.set_property(PROPID.INFO, json.dumps(Info(**data).model_dump()))
 
     @property
     def cell_index(self) -> int:

--- a/src/kfactory/instance.py
+++ b/src/kfactory/instance.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import functools
-import json
 from abc import abstractmethod
 from hashlib import sha3_512
 from typing import (
@@ -25,7 +24,7 @@ from .exceptions import (
 )
 from .geometry import DBUGeometricObject, GeometricObject, UMGeometricObject
 from .port import DPort, Port, ProtoPort
-from .serialization import deserialize_setting, serialize_setting
+from .serialization import deserialize_info_blob, serialize_info_blob
 from .settings import Info
 
 if TYPE_CHECKING:
@@ -61,39 +60,6 @@ __all__ = [
 ]
 
 
-def _dump_instance_info(data: dict[str, Any]) -> str:
-    """Serialize an info dict to the JSON blob stored on an instance property.
-
-    Reuses the cell-level ``serialize_setting`` scheme so that ``kdb`` shapes
-    (``Box``, ``Trans``, ``LayerInfo``, ``Polygon``, ...) survive the JSON
-    encoding that instance properties require.
-
-    A handful of ``kdb`` collection/matrix types (``Region``, ``Edges``,
-    ``Texts``, ``EdgePairs``, ``Matrix2d``, ``Matrix3d``, ``LayerProperties``)
-    can be *serialized* but not reconstructed by ``deserialize_setting`` (they
-    have no ``from_s``). Those round-trip on a cell (native layout meta info) but
-    not through instance properties, so they are rejected here with a clear error
-    at assignment time instead of crashing later when the info is read back.
-    """
-    blob = json.dumps(serialize_setting(data))
-    try:
-        deserialize_setting(json.loads(blob))
-    except Exception as e:
-        raise ValueError(
-            "Instance info value cannot be stored per-instance: it serializes "
-            "but is not reconstructable through instance properties. kdb "
-            "collection/matrix types (Region, Edges, Texts, EdgePairs, "
-            "Matrix2d, Matrix3d, LayerProperties) are only supported on cell "
-            f"info, not on instance info. Offending data: {data!r}"
-        ) from e
-    return blob
-
-
-def _load_instance_info(blob: str) -> dict[str, Any]:
-    """Deserialize an instance-property JSON blob back into an info dict."""
-    return deserialize_setting(json.loads(blob))
-
-
 class InstanceInfo(Info):
     """Per-instance ``info`` bound to a KLayout instance's user properties.
 
@@ -105,6 +71,13 @@ class InstanceInfo(Info):
     underlying ``kdb.Instance`` under :attr:`~kfactory.conf.PROPID.INFO`, so the
     change persists on the instance (and survives a GDS/OASIS roundtrip).
 
+    Cells store their info as native layout meta info; instances have no such
+    channel, so the same value set is round-tripped through the shared
+    :func:`~kfactory.serialization.serialize_setting` codec into one string
+    property. The codec is symmetric for every supported shape, so instance info
+    accepts exactly the same types as cell info (including collection/matrix
+    shapes like ``Region``, ``Edges``, ``Matrix2d``, ...).
+
     Instances are wrapped lazily, so this object is created on each ``inst.info``
     access. It writes straight through to the instance, meaning
     ``inst.info["key"] = value`` persists exactly like ``cell.info["key"] =
@@ -113,14 +86,6 @@ class InstanceInfo(Info):
     Note:
         Tuples are stored as JSON arrays and therefore read back as ``list``,
         matching how cell info behaves when it is serialized to GDS metadata.
-
-    Note:
-        A few ``kdb`` collection/matrix types (``Region``, ``Edges``, ``Texts``,
-        ``EdgePairs``, ``Matrix2d``, ``Matrix3d``, ``LayerProperties``) are only
-        supported on *cell* info (native layout meta info), not on instance
-        info; assigning one raises ``ValueError``. All other serializable ``kdb``
-        shapes (boxes, points, vectors, transformations, polygons, edges, paths,
-        texts, ``LayerInfo``, ...) round-trip fine.
     """
 
     _instance: kdb.Instance | None = PrivateAttr(default=None)
@@ -136,7 +101,7 @@ class InstanceInfo(Info):
         """Serialize the current info to the bound instance property."""
         if self._instance is not None:
             self._instance.set_property(
-                self._prop_id, _dump_instance_info(self.model_dump())
+                self._prop_id, serialize_info_blob(self.model_dump())
             )
 
     def __setattr__(self, name: str, value: Any) -> None:
@@ -287,7 +252,7 @@ class ProtoTInstance[T: (int, float)](ProtoInstance[T]):
             info is lost on flatten (the same as instance names).
         """
         prop = self._instance.property(PROPID.INFO)
-        data: dict[str, Any] = _load_instance_info(prop) if prop is not None else {}
+        data: dict[str, Any] = deserialize_info_blob(prop) if prop is not None else {}
         return InstanceInfo(**data)._bind(self._instance, PROPID.INFO)
 
     @info.setter
@@ -298,7 +263,7 @@ class ProtoTInstance[T: (int, float)](ProtoInstance[T]):
         # types (raising on unsupported values, like the cell-level info).
         data = value.model_dump() if isinstance(value, Info) else dict(value)
         self._instance.set_property(
-            PROPID.INFO, _dump_instance_info(Info(**data).model_dump())
+            PROPID.INFO, serialize_info_blob(Info(**data).model_dump())
         )
 
     @property

--- a/src/kfactory/instance.py
+++ b/src/kfactory/instance.py
@@ -59,6 +59,40 @@ __all__ = [
     "VInstance",
 ]
 
+_GDS_MAX_PROPERTY_BYTES = 65530
+"""Maximum byte length of a single GDS property value.
+
+GDS stores each property value in a record whose length field is two bytes, so a
+``PROPVALUE`` payload cannot exceed 65530 bytes. Instance info is written as one
+JSON blob under a single property, so an oversized blob makes the whole layout
+unwritable to GDS (KLayout raises ``String max. length overflow``). OASIS has no
+such limit; cell info is unaffected because it uses native layout meta info.
+"""
+
+
+def _set_info_property(instance: kdb.Instance, prop_id: int, blob: str) -> None:
+    """Write an info blob to an instance property, logging if not GDS-writable.
+
+    The size limit only applies to GDS, so the value is stored regardless and
+    OASIS output keeps working; the log flags the problem at assignment time
+    instead of letting the GDS write fail later with an unattributable error.
+
+    Args:
+        instance: The KLayout instance to write the property on.
+        prop_id: The property id to store the blob under.
+        blob: The serialized info blob.
+    """
+    size = len(blob.encode("utf-8"))
+    if size > _GDS_MAX_PROPERTY_BYTES:
+        logger.error(
+            f"Instance info for a placement of cell {instance.cell.name!r} is "
+            f"{size} bytes, exceeding the GDS per-property limit of "
+            f"{_GDS_MAX_PROPERTY_BYTES} bytes; writing this layout to GDS will "
+            "fail with a 'String max. length overflow' error (OASIS is "
+            "unaffected)."
+        )
+    instance.set_property(prop_id, blob)
+
 
 class InstanceInfo(Info):
     """Per-instance ``info`` bound to a KLayout instance's user properties.
@@ -100,8 +134,8 @@ class InstanceInfo(Info):
     def _persist(self) -> None:
         """Serialize the current info to the bound instance property."""
         if self._instance is not None:
-            self._instance.set_property(
-                self._prop_id, serialize_info_blob(self.model_dump())
+            _set_info_property(
+                self._instance, self._prop_id, serialize_info_blob(self.model_dump())
             )
 
     def __setattr__(self, name: str, value: Any) -> None:
@@ -262,8 +296,8 @@ class ProtoTInstance[T: (int, float)](ProtoInstance[T]):
         # The runtime ``Info(**data)`` call below still validates the metadata
         # types (raising on unsupported values, like the cell-level info).
         data = value.model_dump() if isinstance(value, Info) else dict(value)
-        self._instance.set_property(
-            PROPID.INFO, serialize_info_blob(Info(**data).model_dump())
+        _set_info_property(
+            self._instance, PROPID.INFO, serialize_info_blob(Info(**data).model_dump())
         )
 
     @property

--- a/src/kfactory/serialization.py
+++ b/src/kfactory/serialization.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import functools
 import inspect
+import json
 from collections import UserDict, UserList
 from collections.abc import Callable, Hashable
 from hashlib import sha3_512
@@ -11,7 +12,7 @@ from typing import TYPE_CHECKING, Any, TypeGuard, overload
 import numpy as np
 import toolz
 
-from . import kdb, lay
+from . import kdb
 from .conf import config
 from .exceptions import CellNameError
 
@@ -257,8 +258,58 @@ def check_metadata_type(value: Any) -> MetaData:
     raise ValueError(msg)
 
 
+# ``kdb`` collection wrappers have ``to_s`` but no ``from_s``. They are encoded
+# element-wise instead: each element (which *does* have ``from_s``) is dumped via
+# its own ``to_s`` into a JSON list, so the payload is robust to the delimiter
+# characters (``;``, ``)``, ``'``) that ``to_s`` reuses inside and between
+# elements. Maps the wrapper class name to (wrapper_class, element_class).
+_COLLECTION_SHAPES: dict[str, tuple[type[Any], type[Any]]] = {
+    "Region": (kdb.Region, kdb.Polygon),
+    "Edges": (kdb.Edges, kdb.Edge),
+    "Texts": (kdb.Texts, kdb.Text),
+    "EdgePairs": (kdb.EdgePairs, kdb.EdgePair),
+}
+# ``kdb`` matrices also lack ``from_s``; they are encoded as a JSON list of their
+# scalar components and rebuilt through their component constructor.
+_MATRIX_SHAPES: frozenset[str] = frozenset({"Matrix2d", "Matrix3d"})
+
+
+def _serialize_shape(shape: SerializableShape) -> str:
+    """Encode a ``kdb`` shape as a ``!#ClassName <payload>`` string."""
+    cls_name = type(shape).__name__
+    if cls_name in _COLLECTION_SHAPES:
+        return f"!#{cls_name} " + json.dumps([e.to_s() for e in shape.each()])
+    if cls_name == "Matrix2d":
+        return "!#Matrix2d " + json.dumps(
+            [shape.m11(), shape.m12(), shape.m21(), shape.m22()]
+        )
+    if cls_name == "Matrix3d":
+        return "!#Matrix3d " + json.dumps(
+            [shape.m(i, j) for i in range(3) for j in range(3)]
+        )
+    return f"!#{cls_name} {shape!s}"
+
+
+def _deserialize_shape(cls_name: str, payload: str) -> SerializableShape:
+    """Rebuild a ``kdb`` shape from a ``!#ClassName <payload>`` string."""
+    if cls_name in _COLLECTION_SHAPES:
+        wrapper_cls, element_cls = _COLLECTION_SHAPES[cls_name]
+        return wrapper_cls([element_cls.from_s(s) for s in json.loads(payload)])
+    if cls_name in _MATRIX_SHAPES:
+        return getattr(kdb, cls_name)(*json.loads(payload))
+    if cls_name == "LayerInfo":
+        return kdb.LayerInfo.from_string(payload)
+    return getattr(kdb, cls_name).from_s(payload)
+
+
 def serialize_setting(setting: MetaData) -> JSONSerializable:
-    """Serialize a setting."""
+    """Serialize a setting to a JSON-compatible form.
+
+    ``kdb`` shapes are encoded as a ``!#ClassName <payload>`` string so they
+    survive JSON/YAML/GDS-property stores that cannot hold native ``kdb``
+    objects. The inverse is :func:`deserialize_setting`; the two are symmetric
+    for every shape in :data:`~kfactory.typings.SerializableShape`.
+    """
     if setting is None:
         return None
     if isinstance(setting, dict):
@@ -270,12 +321,12 @@ def serialize_setting(setting: MetaData) -> JSONSerializable:
     if isinstance(setting, tuple):
         return tuple(serialize_setting(s) for s in setting)
     if serializible_shape_guard(setting):
-        return f"!#{setting.__class__.__name__} {setting!s}"
+        return _serialize_shape(setting)
     return setting  # ty:ignore[invalid-return-type]
 
 
 def deserialize_setting(setting: JSONSerializable) -> MetaData:
-    """Deserialize a setting."""
+    """Deserialize a setting produced by :func:`serialize_setting`."""
     if isinstance(setting, dict):
         return {
             name: deserialize_setting(_setting) for name, _setting in setting.items()
@@ -285,13 +336,27 @@ def deserialize_setting(setting: JSONSerializable) -> MetaData:
     if isinstance(setting, tuple):
         return tuple(deserialize_setting(s) for s in setting)
     if isinstance(setting, str) and setting.startswith("!#"):
-        cls_name, value = setting.removeprefix("!#").split(" ", 1)
-        match cls_name:
-            case "LayerInfo":
-                return getattr(kdb, cls_name).from_string(value)
-            case _:
-                return getattr(kdb, cls_name).from_s(value)
+        cls_name, payload = setting.removeprefix("!#").split(" ", 1)
+        return _deserialize_shape(cls_name, payload)
     return setting
+
+
+def serialize_info_blob(info: dict[str, MetaData]) -> str:
+    """Serialize an info dict to a single JSON blob for string-only stores.
+
+    Used where metadata must round-trip through a single string value (e.g. a
+    ``kdb.Instance`` user property, which GDS coerces to a string), as opposed
+    to the native per-cell meta info used for cells.
+    """
+    return json.dumps(serialize_setting(info))
+
+
+def deserialize_info_blob(blob: str) -> dict[str, MetaData]:
+    """Deserialize a JSON info blob produced by :func:`serialize_info_blob`."""
+    data = deserialize_setting(json.loads(blob))
+    if not isinstance(data, dict):
+        raise TypeError(f"Info blob did not decode to a dict: {blob!r}")
+    return data
 
 
 def get_cell_name(
@@ -342,7 +407,6 @@ _SERIALIZABLE_SHAPES: UnionType = (
     | kdb.Trans
     | kdb.VCplxTrans
     | kdb.Vector
-    | lay.LayerProperties
     | _ISHAPES
     | _DSHAPES
 )

--- a/src/kfactory/typings.py
+++ b/src/kfactory/typings.py
@@ -12,7 +12,6 @@ from typing import (
 )
 
 import klayout.db as kdb
-from klayout import lay
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable
@@ -90,7 +89,6 @@ type SerializableShape = (
     | kdb.DEdgePair
     | kdb.EdgePairs
     | kdb.Edges
-    | lay.LayerProperties
     | kdb.Matrix2d
     | kdb.Matrix3d
     | kdb.Path

--- a/tests/test_instance.py
+++ b/tests/test_instance.py
@@ -820,3 +820,58 @@ def test_instance_info_rejects_non_metadata(
     ref = c << straight_factory(width=0.5, length=1, layer=layers.WG)
     with pytest.raises(ValueError):
         ref.info["bad"] = object()
+
+
+def test_instance_info_kdb_shape_roundtrip() -> None:
+    """kdb shapes must survive assignment and a GDS roundtrip (like cell info)."""
+    kcl_write = kf.KCLayout("TEST_INSTANCE_INFO_SHAPE_WRITE")
+    child = kcl_write.kcell("child")
+    child.shapes(kcl_write.layer(1, 0)).insert(kf.kdb.Box(10_000, 1000))
+    top = kcl_write.kcell("top")
+    ref = top << child
+
+    shapes: dict[str, object] = {
+        "box": kf.kdb.Box(0, 0, 500, 500),
+        "dbox": kf.kdb.DBox(0, 0, 1.5, 2.5),
+        "point": kf.kdb.Point(10, 20),
+        "vector": kf.kdb.Vector(3, 4),
+        "trans": kf.kdb.Trans(1, False, 100, 200),
+        "dcplx_trans": kf.kdb.DCplxTrans(1.0, 30.0, False, 1.0, 2.0),
+        "layer_info": kf.kdb.LayerInfo(1, 0),
+        "polygon": kf.kdb.Polygon(kf.kdb.Box(0, 0, 100, 100)),
+    }
+    for key, value in shapes.items():
+        ref.info[key] = value
+
+    # readable in-memory straight after assignment
+    for key, value in shapes.items():
+        assert str(ref.info[key]) == str(value)
+
+    kcl_read = kf.KCLayout("TEST_INSTANCE_INFO_SHAPE_READ")
+    with NamedTemporaryFile(suffix=".gds") as tf:
+        top.write(tf.name)
+        kcl_read.read(tf.name)
+
+    read_info = next(iter(kcl_read["top"].insts)).info
+    for key, value in shapes.items():
+        assert type(read_info[key]) is type(value)
+        assert str(read_info[key]) == str(value)
+
+
+def test_instance_info_rejects_non_roundtrippable_shapes() -> None:
+    """kdb collection/matrix shapes only work on cell info, not per-instance.
+
+    They serialize but cannot be reconstructed through instance properties, so
+    assignment must fail fast with a clear error instead of crashing on read.
+    """
+    kcl = kf.KCLayout("TEST_INSTANCE_INFO_BAD_SHAPE")
+    child = kcl.kcell("child")
+    top = kcl.kcell("top")
+    ref = top << child
+    for value in (
+        kf.kdb.Region(kf.kdb.Box(0, 0, 50, 50)),
+        kf.kdb.Edges([kf.kdb.Edge(0, 0, 10, 10)]),
+        kf.kdb.Matrix2d(1, 0, 0, 1),
+    ):
+        with pytest.raises(ValueError):
+            ref.info["bad"] = value

--- a/tests/test_instance.py
+++ b/tests/test_instance.py
@@ -858,20 +858,43 @@ def test_instance_info_kdb_shape_roundtrip() -> None:
         assert str(read_info[key]) == str(value)
 
 
-def test_instance_info_rejects_non_roundtrippable_shapes() -> None:
-    """kdb collection/matrix shapes only work on cell info, not per-instance.
+def test_instance_info_collection_shape_roundtrip() -> None:
+    """kdb collection/matrix shapes round-trip on instances, same as cell info.
 
-    They serialize but cannot be reconstructed through instance properties, so
-    assignment must fail fast with a clear error instead of crashing on read.
+    These types lack ``from_s`` and used to be rejected per-instance; the codec
+    now encodes them element-wise so they survive a GDS roundtrip.
     """
-    kcl = kf.KCLayout("TEST_INSTANCE_INFO_BAD_SHAPE")
-    child = kcl.kcell("child")
-    top = kcl.kcell("top")
+    kcl_write = kf.KCLayout("TEST_INSTANCE_INFO_COLL_WRITE")
+    child = kcl_write.kcell("child")
+    child.shapes(kcl_write.layer(1, 0)).insert(kf.kdb.Box(10_000, 1000))
+    top = kcl_write.kcell("top")
     ref = top << child
-    for value in (
-        kf.kdb.Region(kf.kdb.Box(0, 0, 50, 50)),
-        kf.kdb.Edges([kf.kdb.Edge(0, 0, 10, 10)]),
-        kf.kdb.Matrix2d(1, 0, 0, 1),
-    ):
-        with pytest.raises(ValueError):
-            ref.info["bad"] = value
+
+    shapes: dict[str, object] = {
+        "region": kf.kdb.Region(
+            [
+                kf.kdb.Polygon(kf.kdb.Box(0, 0, 50, 50)),
+                kf.kdb.Polygon(kf.kdb.Box(100, 0, 150, 60)),
+            ]
+        ),
+        "edges": kf.kdb.Edges([kf.kdb.Edge(0, 0, 10, 10), kf.kdb.Edge(1, 1, 2, 2)]),
+        # text content deliberately contains the delimiters to_s reuses
+        "texts": kf.kdb.Texts([kf.kdb.Text("a;b)c", kf.kdb.Trans())]),
+        "edge_pairs": kf.kdb.EdgePairs(
+            [kf.kdb.EdgePair(kf.kdb.Edge(0, 0, 1, 1), kf.kdb.Edge(2, 2, 3, 3))]
+        ),
+        "matrix2d": kf.kdb.Matrix2d(1.5, 2.0, 3.0, 4.0),
+        "matrix3d": kf.kdb.Matrix3d(1, 0, 5, 0, 1, 7, 0, 0, 1),
+    }
+    for key, value in shapes.items():
+        ref.info[key] = value
+
+    kcl_read = kf.KCLayout("TEST_INSTANCE_INFO_COLL_READ")
+    with NamedTemporaryFile(suffix=".gds") as tf:
+        top.write(tf.name)
+        kcl_read.read(tf.name)
+
+    read_info = next(iter(kcl_read["top"].insts)).info
+    for key, value in shapes.items():
+        assert type(read_info[key]) is type(value)
+        assert read_info[key].to_s() == value.to_s()

--- a/tests/test_instance.py
+++ b/tests/test_instance.py
@@ -923,18 +923,54 @@ def test_instance_info_oversize_blob_logs_error(
     assert len(dict(ref.info)["huge"]) == 70_000
 
 
+def test_instance_info_interop_zone_logs_warning() -> None:
+    """A blob over the strict-GDS-spec size warns but still round-trips.
+
+    Between the 32 KB strict-spec limit and the 64 KB hard limit the record is
+    written and read back correctly by KLayout (interoperability risk only), so
+    it must warn -- not error -- and the value must survive a GDS roundtrip.
+    """
+    kcl_write = kf.KCLayout("TEST_INSTANCE_INFO_INTEROP_WRITE")
+    child = kcl_write.kcell("child")
+    child.shapes(kcl_write.layer(1, 0)).insert(kf.kdb.Box(10_000, 1000))
+    top = kcl_write.kcell("top")
+    ref = top << child
+
+    records: list[tuple[str, str]] = []
+    sink_id = kf.logger.add(
+        lambda m: records.append((m.record["level"].name, m.record["message"])),
+        level="WARNING",
+    )
+    try:
+        ref.info["big"] = "x" * 40_000  # > 32764 (spec) but <= 65530 (hard)
+    finally:
+        kf.logger.remove(sink_id)
+
+    levels = {level for level, _ in records}
+    assert "WARNING" in levels
+    assert "ERROR" not in levels
+    assert any("strict GDS spec" in msg for _, msg in records)
+
+    # still round-trips through GDS (KLayout reads oversized-per-spec records)
+    kcl_read = kf.KCLayout("TEST_INSTANCE_INFO_INTEROP_READ")
+    with NamedTemporaryFile(suffix=".gds") as tf:
+        top.write(tf.name)
+        kcl_read.read(tf.name)
+    assert len(next(iter(kcl_read["top"].insts)).info["big"]) == 40_000
+
+
 def test_instance_info_normal_size_logs_nothing(
     kcl: kf.KCLayout, straight_factory: Callable[..., kf.KCell]
 ) -> None:
-    """A normal-size info blob does not log an error."""
+    """A normal-size info blob does not log a warning or error."""
     c = kcl.kcell()
     ref = c << straight_factory(width=0.5, length=1, layer=kf.kdb.LayerInfo(1, 0))
 
-    errors: list[str] = []
-    sink_id = kf.logger.add(lambda m: errors.append(str(m)), level="ERROR")
+    records: list[str] = []
+    sink_id = kf.logger.add(lambda m: records.append(str(m)), level="WARNING")
     try:
         ref.info["small"] = "x" * 100
     finally:
         kf.logger.remove(sink_id)
 
-    assert not errors
+    assert not records

--- a/tests/test_instance.py
+++ b/tests/test_instance.py
@@ -1,4 +1,5 @@
 from collections.abc import Callable
+from tempfile import NamedTemporaryFile
 from typing import Any
 
 import klayout.db as kdb
@@ -6,6 +7,7 @@ import pytest
 
 import kfactory as kf
 from kfactory import exceptions
+from kfactory.conf import PROPID
 from tests.conftest import Layers
 
 
@@ -723,3 +725,98 @@ def test_to_dtype(kcl: kf.KCLayout) -> None:
     ref = dref.to_itype()
     assert ref.bbox() == kf.kdb.Box(-5000, -5000, 5000, 5000)
     assert isinstance(ref, kf.Instance)
+
+
+def test_instance_info_default_empty(
+    layers: Layers, kcl: kf.KCLayout, straight_factory: Callable[..., kf.KCell]
+) -> None:
+    c = kcl.kcell()
+    ref = c << straight_factory(width=0.5, length=1, layer=layers.WG)
+    assert dict(ref.info) == {}
+    assert isinstance(ref.info, kf.settings.Info)
+
+
+def test_instance_info_mutation_persists(
+    layers: Layers, kcl: kf.KCLayout, straight_factory: Callable[..., kf.KCell]
+) -> None:
+    c = kcl.kcell()
+    ref = c << straight_factory(width=0.5, length=1, layer=layers.WG)
+
+    # every cell-info-style mutation writes straight through to the instance
+    ref.info["measure"] = "spectrum"
+    ref.info.wavelength = 1550
+    ref.info.update({"port": "o1"})
+
+    assert dict(ref.info) == {
+        "measure": "spectrum",
+        "wavelength": 1550,
+        "port": "o1",
+    }
+    # persisted on the underlying kdb property, not just the wrapper
+    assert ref.instance.property(PROPID.INFO) is not None
+
+
+def test_instance_info_assignment_replaces(
+    layers: Layers, kcl: kf.KCLayout, straight_factory: Callable[..., kf.KCell]
+) -> None:
+    c = kcl.kcell()
+    ref = c << straight_factory(width=0.5, length=1, layer=layers.WG)
+    ref.info["stale"] = 1
+    ref.info = {"measure": "power"}
+    assert dict(ref.info) == {"measure": "power"}
+    # accepts another Info too
+    ref.info = kf.settings.Info(measure="loss")
+    assert dict(ref.info) == {"measure": "loss"}
+
+
+def test_instance_info_per_placement_keeps_caching(
+    layers: Layers, kcl: kf.KCLayout, straight_factory: Callable[..., kf.KCell]
+) -> None:
+    child = straight_factory(width=0.5, length=1, layer=layers.WG)
+    c = kcl.kcell()
+    a = c << child
+    b = c << child
+    b.dmovey(10)
+
+    a.info["measure"] = "spectrum"
+    b.info["measure"] = "power"
+
+    # the same cached cell is reused for both placements ...
+    assert a.cell_index == b.cell_index
+    # ... yet each instance carries its own info
+    assert dict(a.info) == {"measure": "spectrum"}
+    assert dict(b.info) == {"measure": "power"}
+
+
+def test_instance_info_gds_roundtrip() -> None:
+    kcl_write = kf.KCLayout("TEST_INSTANCE_INFO_WRITE")
+    child = kcl_write.kcell("child")
+    child.shapes(kcl_write.layer(1, 0)).insert(kf.kdb.Box(10_000, 1000))
+    top = kcl_write.kcell("top")
+    a = top << child
+    b = top << child
+    b.dmovey(10)
+    a.info["measure"] = "spectrum"
+    a.info.wavelength = 1550
+    b.info["measure"] = "power"
+
+    kcl_read = kf.KCLayout("TEST_INSTANCE_INFO_READ")
+    with NamedTemporaryFile(suffix=".gds") as tf:
+        top.write(tf.name)
+        kcl_read.read(tf.name)
+
+    top_read = kcl_read["top"]
+    infos = sorted((dict(inst.info) for inst in top_read.insts), key=repr)
+    assert infos == [
+        {"measure": "power"},
+        {"measure": "spectrum", "wavelength": 1550},
+    ]
+
+
+def test_instance_info_rejects_non_metadata(
+    layers: Layers, kcl: kf.KCLayout, straight_factory: Callable[..., kf.KCell]
+) -> None:
+    c = kcl.kcell()
+    ref = c << straight_factory(width=0.5, length=1, layer=layers.WG)
+    with pytest.raises(ValueError):
+        ref.info["bad"] = object()

--- a/tests/test_instance.py
+++ b/tests/test_instance.py
@@ -898,3 +898,43 @@ def test_instance_info_collection_shape_roundtrip() -> None:
     for key, value in shapes.items():
         assert type(read_info[key]) is type(value)
         assert read_info[key].to_s() == value.to_s()
+
+
+def test_instance_info_oversize_blob_logs_error(
+    kcl: kf.KCLayout, straight_factory: Callable[..., kf.KCell]
+) -> None:
+    """An info blob over the GDS per-property limit logs an error, without raising.
+
+    The value is still stored (OASIS has no such limit); the log flags the
+    GDS-unwritable blob at assignment time.
+    """
+    c = kcl.kcell()
+    ref = c << straight_factory(width=0.5, length=1, layer=kf.kdb.LayerInfo(1, 0))
+
+    errors: list[str] = []
+    sink_id = kf.logger.add(lambda m: errors.append(str(m)), level="ERROR")
+    try:
+        ref.info["huge"] = "x" * 70_000
+    finally:
+        kf.logger.remove(sink_id)
+
+    assert any("GDS per-property limit" in m for m in errors)
+    # not raised: the value is still stored per-instance
+    assert len(dict(ref.info)["huge"]) == 70_000
+
+
+def test_instance_info_normal_size_logs_nothing(
+    kcl: kf.KCLayout, straight_factory: Callable[..., kf.KCell]
+) -> None:
+    """A normal-size info blob does not log an error."""
+    c = kcl.kcell()
+    ref = c << straight_factory(width=0.5, length=1, layer=kf.kdb.LayerInfo(1, 0))
+
+    errors: list[str] = []
+    sink_id = kf.logger.add(lambda m: errors.append(str(m)), level="ERROR")
+    try:
+        ref.info["small"] = "x" * 100
+    finally:
+        kf.logger.remove(sink_id)
+
+    assert not errors

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,0 +1,126 @@
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+
+import klayout.db as kdb
+import pytest
+from klayout import lay
+
+import kfactory as kf
+from kfactory.serialization import (
+    deserialize_info_blob,
+    deserialize_setting,
+    serialize_info_blob,
+    serialize_setting,
+)
+
+
+def _all_shapes() -> dict[str, object]:
+    """Every kdb shape kfactory claims to serialize, one sample each."""
+    return {
+        "Box": kdb.Box(0, 0, 10, 10),
+        "DBox": kdb.DBox(0, 0, 1.5, 2.5),
+        "Point": kdb.Point(1, 2),
+        "DPoint": kdb.DPoint(1.5, 2.5),
+        "Vector": kdb.Vector(3, 4),
+        "DVector": kdb.DVector(3.5, 4.5),
+        "Trans": kdb.Trans(1, False, 10, 20),
+        "DTrans": kdb.DTrans(1, False, 1.0, 2.0),
+        "CplxTrans": kdb.CplxTrans(2.0),
+        "ICplxTrans": kdb.ICplxTrans(2.0),
+        "DCplxTrans": kdb.DCplxTrans(1.0, 30.0, False, 1.0, 2.0),
+        "VCplxTrans": kdb.VCplxTrans(2.0),
+        "Edge": kdb.Edge(0, 0, 10, 10),
+        "DEdge": kdb.DEdge(0, 0, 1.0, 1.0),
+        "Path": kdb.Path([kdb.Point(0, 0), kdb.Point(10, 0)], 5),
+        "DPath": kdb.DPath([kdb.DPoint(0, 0), kdb.DPoint(1, 0)], 0.5),
+        "Polygon": kdb.Polygon(kdb.Box(0, 0, 100, 100)),
+        "DPolygon": kdb.DPolygon(kdb.DBox(0, 0, 1, 1)),
+        "SimplePolygon": kdb.SimplePolygon(kdb.Box(0, 0, 50, 50)),
+        "DSimplePolygon": kdb.DSimplePolygon(kdb.DBox(0, 0, 1, 1)),
+        "Text": kdb.Text("hi", kdb.Trans()),
+        "DText": kdb.DText("hi", kdb.DTrans()),
+        "EdgePair": kdb.EdgePair(kdb.Edge(0, 0, 1, 1), kdb.Edge(2, 2, 3, 3)),
+        "DEdgePair": kdb.DEdgePair(kdb.DEdge(0, 0, 1, 1), kdb.DEdge(2, 2, 3, 3)),
+        "LayerInfo": kdb.LayerInfo(1, 0),
+        # collection / matrix wrappers: no from_s, encoded element-wise
+        "Region": kdb.Region(
+            [kdb.Polygon(kdb.Box(0, 0, 50, 50)), kdb.Polygon(kdb.Box(100, 0, 150, 60))]
+        ),
+        "Edges": kdb.Edges([kdb.Edge(0, 0, 10, 10), kdb.Edge(1, 1, 2, 2)]),
+        "Texts": kdb.Texts([kdb.Text("a", kdb.Trans()), kdb.Text("b", kdb.Trans())]),
+        "EdgePairs": kdb.EdgePairs(
+            [kdb.EdgePair(kdb.Edge(0, 0, 1, 1), kdb.Edge(2, 2, 3, 3))]
+        ),
+        "Matrix2d": kdb.Matrix2d(1.5, 2.0, 3.0, 4.0),
+        "Matrix3d": kdb.Matrix3d(1, 0, 5, 0, 1, 7, 0, 0, 1),
+    }
+
+
+@pytest.mark.parametrize(("name", "shape"), list(_all_shapes().items()))
+def test_serialize_setting_symmetric(name: str, shape: object) -> None:
+    """serialize_setting and deserialize_setting round-trip every shape."""
+    restored = deserialize_setting(serialize_setting(shape))
+    assert type(restored) is type(shape)
+    assert restored.to_s() == shape.to_s()  # ty:ignore[unresolved-attribute]
+
+
+def test_serialize_setting_scalars_and_containers() -> None:
+    """Plain metadata passes through; tuples become lists (JSON has no tuple)."""
+    assert serialize_setting(42) == 42
+    assert serialize_setting("x") == "x"
+    assert serialize_setting(True) is True
+    assert serialize_setting(None) is None
+    nested = {"a": [1, {"b": kdb.Box(0, 0, 5, 5)}]}
+    restored = deserialize_setting(serialize_setting(nested))
+    assert restored["a"][1]["b"].to_s() == kdb.Box(0, 0, 5, 5).to_s()
+
+
+def test_info_blob_roundtrip_all_shapes() -> None:
+    """The single-blob codec (used by instance info) round-trips every shape."""
+    shapes = _all_shapes()
+    restored = deserialize_info_blob(serialize_info_blob(shapes))
+    for name, shape in shapes.items():
+        assert type(restored[name]) is type(shape)
+        assert restored[name].to_s() == shape.to_s()
+
+
+def test_collection_payload_survives_delimiter_characters() -> None:
+    """Element strings reuse ';' ')' '\\''; JSON payload must not be confused."""
+    texts = kdb.Texts(
+        [kdb.Text("has;semi)paren'quote", kdb.Trans()), kdb.Text("b", kdb.Trans())]
+    )
+    restored = deserialize_setting(serialize_setting(texts))
+    assert restored.to_s() == texts.to_s()
+
+
+def test_cell_info_region_yaml_roundtrip() -> None:
+    """Regression: a Region in cell info must survive a YAML roundtrip.
+
+    Before the codec was made symmetric this raised ``AttributeError: type
+    object 'Region' has no attribute 'from_s'`` on read.
+    """
+    kcl = kf.KCLayout("TEST_CELL_INFO_YAML")
+    c = kcl.kcell("c")
+    c.shapes(kcl.layer(1, 0)).insert(kdb.Box(0, 0, 1000, 1000))
+    c.info["reg"] = kdb.Region(kdb.Box(0, 0, 500, 500))
+    c.info["n"] = 42
+
+    with NamedTemporaryFile(suffix=".yml", delete=False) as _tf:
+        tf = Path(_tf.name)
+    kf.placer.cells_to_yaml(tf, cells=c)
+    kcl_read = kf.KCLayout("TEST_CELL_INFO_YAML_READ")
+    kf.placer.cells_from_yaml(tf, kcl=kcl_read)
+    tf.unlink()
+
+    info = kcl_read["c"].info
+    assert info["n"] == 42
+    assert type(info["reg"]) is kdb.Region
+    assert info["reg"].to_s() == kdb.Region(kdb.Box(0, 0, 500, 500)).to_s()
+
+
+def test_layer_properties_no_longer_serializable() -> None:
+    """LayerProperties cannot round-trip anywhere and is rejected up front."""
+    kcl = kf.KCLayout("TEST_LP_REJECT")
+    c = kcl.kcell("c")
+    with pytest.raises((ValueError, TypeError)):
+        c.info["lp"] = lay.LayerProperties()


### PR DESCRIPTION
## Summary

Added an InstanceInfo object to references mimicking the behavior if Info object on cells. This allows a more precise distinction between instances by assigning metadata beyond a specific instance name.

## Test Plan

Usage and GDS roundtrip can be verified with the following script:

```python
"""Cell info vs per-reference (instance) info.

It shows:

1. How to attach ``info`` to a *cell* (shared by every placement).
2. How to attach ``info`` to an *instance* / reference (unique per placement),
   the new per-reference info channel.
3. That both kinds of info survive a GDS write -> read roundtrip, and that
   placing the same cached cell twice keeps a single cell in the layout while
   each instance keeps its own info.
"""

from __future__ import annotations

import tempfile
from pathlib import Path

import kfactory as kf


def build_layout() -> kf.KCLayout:
    """Create a layout with one reusable cell placed twice, each with own info."""
    kcl = kf.KCLayout("INFO_EXAMPLE")
    layer = kcl.layer(1, 0)

    # --- a single, reusable "device" cell -----------------------------------
    # Cell-level info is shared by *every* placement of this cell.
    device = kcl.kcell("mzi_device")
    device.shapes(layer).insert(kf.kdb.DBox(0, 0, 20, 10))
    device.info["component"] = "mzi"
    device.info["length_um"] = 20.0

    # --- a top cell that places the same device twice -----------------------
    top = kcl.kcell("top")

    ref_a = top << device
    ref_b = top << device
    ref_b.dmovey(30)  # move the second placement out of the way

    # Per-reference info: the *same* cached cell, but each placement is
    # measured differently. This is exactly like doing cell.info[...] = ...,
    # only it lives on the instance instead of the cell.
    ref_a.info["measure"] = "spectrum"
    ref_a.info["input_port"] = "o1"
    ref_a.info.wavelength_nm = 1550  # attribute-style assignment also persists

    ref_b.info["measure"] = "power"
    ref_b.info["input_port"] = "o2"

    return kcl


def show(kcl: kf.KCLayout, banner: str) -> None:
    """Pretty-print the cell info and every instance's info under ``top``."""
    print(f"\n{'=' * 70}\n{banner}\n{'=' * 70}")

    top = kcl["top"]
    device = kcl["mzi_device"]

    print(f"cells in layout : {[c.name for c in kcl.each_cell()]}")
    print(f"instances in top: {len(top.insts)} (same cached cell reused)")
    print(f"\ncell 'mzi_device'.info = {dict(device.info)}")

    for inst in top.insts:
        # inst.cell_name is the shared cell; inst.info is unique per placement
        print(f"  instance -> cell={inst.cell_name!r}  info={dict(inst.info)}")


def main() -> None:
    kcl = build_layout()
    show(kcl, "BEFORE WRITE (in memory)")

    with tempfile.TemporaryDirectory() as tmp:
        gds_path = Path(tmp) / "info_example.gds"
        kcl["top"].write(gds_path)
        print(f"\nwrote GDS -> {gds_path}")

        # Read the GDS back into a completely fresh layout.
        kcl_read = kf.KCLayout("INFO_EXAMPLE_READ")
        kcl_read.read(gds_path)
        show(kcl_read, "AFTER GDS ROUNDTRIP (read back from disk)")


if __name__ == "__main__":
    main()
```