### PR TITLE
fix: bare-core extents and radius in um cross section conversions

### DIFF
--- a/src/kfactory/cross_section.py
+++ b/src/kfactory/cross_section.py
@@ -566,10 +566,8 @@ class AsymmetricalCrossSection(BaseModel, frozen=True, arbitrary_types_allowed=T
                 for s in self.sections
             ),
             name=self.name,
-            radius=kcl.to_um(self.radius) if self.radius is not None else None,
-            radius_min=kcl.to_um(self.radius_min)
-            if self.radius_min is not None
-            else None,
+            radius=kcl.to_um(self.radius),
+            radius_min=kcl.to_um(self.radius_min),
             bbox_sections={k: kcl.to_um(v) for k, v in self.bbox_sections.items()},
         )
 
@@ -714,10 +712,8 @@ class DAsymmetricalCrossSection(BaseModel, arbitrary_types_allowed=True):
             section_max=kcl.to_dbu(self.section_max),
             sections=tuple(s.to_itype(kcl) for s in self.sections),
             name=self.name or "",
-            radius=kcl.to_dbu(self.radius) if self.radius is not None else None,
-            radius_min=kcl.to_dbu(self.radius_min)
-            if self.radius_min is not None
-            else None,
+            radius=kcl.to_dbu(self.radius),
+            radius_min=kcl.to_dbu(self.radius_min),
             bbox_sections={k: kcl.to_dbu(v) for k, v in self.bbox_sections.items()},
         )
 
@@ -986,13 +982,11 @@ class DAsymmetricCrossSection(TAsymmetricCrossSection[float]):
 
     @property
     def radius(self) -> float | None:
-        r = self._base.radius
-        return self.kcl.to_um(r) if r is not None else None
+        return self.kcl.to_um(self._base.radius)
 
     @property
     def radius_min(self) -> float | None:
-        r = self._base.radius_min
-        return self.kcl.to_um(r) if r is not None else None
+        return self.kcl.to_um(self._base.radius_min)
 
     @property
     def bbox_sections(self) -> dict[kdb.LayerInfo, float]:
@@ -1306,9 +1300,7 @@ class DCrossSection(TCrossSection[float]):
         return {
             layer: [
                 (
-                    self.kcl.to_um(section.d_min)
-                    if section.d_min is not None
-                    else None,
+                    self.kcl.to_um(section.d_min),
                     self.kcl.to_um(section.d_max),
                 )
                 for section in sections.sections

--- a/src/kfactory/cross_section.py
+++ b/src/kfactory/cross_section.py
@@ -166,14 +166,27 @@ class SymmetricalCrossSection(BaseModel, frozen=True, arbitrary_types_allowed=Tr
             width=kcl.to_um(self.width),
             enclosure=self.enclosure.to_dtype(kcl),
             name=self.name,
+            radius=kcl.to_um(self.radius),
+            radius_min=kcl.to_um(self.radius_min),
         )
 
     def get_xmax(self) -> int:
-        return self.width // 2 + max(
-            s.d_max
-            for sections in self.enclosure.layer_sections.values()
-            for s in sections.sections
+        """Outer edge of the profile in dbu.
+
+        The core always reaches `width // 2`, so the enclosure can only push the
+        extent outwards: a cross section with no bands at all is just its core,
+        and a band that shrinks inwards (negative `d_max`) does not pull the
+        extent inside the core it sits on.
+        """
+        outermost = max(
+            (
+                s.d_max
+                for sections in self.enclosure.layer_sections.values()
+                for s in sections.sections
+            ),
+            default=0,
         )
+        return self.width // 2 + max(outermost, 0)
 
     def get_xmin(self) -> int:
         # Symmetric by construction: the full extent is mirrored about the center line.
@@ -208,6 +221,8 @@ class DSymmetricalCrossSection(BaseModel):
     width: float
     enclosure: DLayerEnclosure
     name: str | None = None
+    radius: float | None = None
+    radius_min: float | None = None
 
     @model_validator(mode="after")
     def _validate_width(self) -> Self:
@@ -225,6 +240,8 @@ class DSymmetricalCrossSection(BaseModel):
             width=kcl.to_dbu(self.width),
             enclosure=kcl.get_enclosure(self.enclosure.to_itype(kcl)),
             name=self.name,
+            radius=kcl.to_dbu(self.radius),
+            radius_min=kcl.to_dbu(self.radius_min),
         )
 
 
@@ -1276,8 +1293,8 @@ class DCrossSection(TCrossSection[float]):
                         ],
                     ),
                     name=name,
-                    radius=kcl.to_dbu(radius) if radius else None,
-                    radius_min=kcl.to_dbu(radius_min) if radius_min else None,
+                    radius=kcl.to_dbu(radius),
+                    radius_min=kcl.to_dbu(radius_min),
                 )
             )
         self.kcl = kcl

--- a/tests/test_cross_section.py
+++ b/tests/test_cross_section.py
@@ -1155,3 +1155,153 @@ def test_get_sections_wrappers(kcl: kf.KCLayout) -> None:
             (str(s.layer), kcl.to_um(s.section_min), kcl.to_um(s.section_max))
             for s in base.get_sections()
         ]
+
+
+def test_symmetric_extent_without_cladding(kcl: kf.KCLayout) -> None:
+    """A cross section with no enclosure bands is just its core.
+
+    Regression: `get_xmax` took `max()` over the enclosure's bands, so a bare
+    core raised `ValueError: max() iterable argument is empty` — the shape every
+    single-section profile and every port-derived core has.
+    """
+    wg = kf.kdb.LayerInfo(1, 0, "WG")
+    base = kcl.get_symmetrical_cross_section(
+        kf.SymmetricalCrossSection(
+            width=500,
+            enclosure=kcl.get_enclosure(kf.LayerEnclosure(sections=[], main_layer=wg)),
+            name="bare_extent",
+        )
+    )
+    assert base.get_xmax() == 250
+    assert base.get_xmin() == -250
+    assert kf.CrossSection(kcl=kcl, base=base).get_xmin_xmax() == (-250, 250)
+    assert kf.DCrossSection(kcl=kcl, base=base).get_xmin_xmax() == (
+        kcl.to_um(-250),
+        kcl.to_um(250),
+    )
+    # Consistent with the strips the profile actually realises.
+    assert base.get_sections()[0].section_max == base.get_xmax()
+
+
+def test_symmetric_extent_with_only_shrunk_bands(kcl: kf.KCLayout) -> None:
+    """A band shrinking inwards cannot pull the extent inside the core.
+
+    Regression: `get_xmax` returned `width // 2 + max(d_max)` unclamped, so an
+    enclosure holding only a negative band reported 150 for a profile whose core
+    reaches 250.
+    """
+    wg = kf.kdb.LayerInfo(1, 0, "WG")
+    fill = kf.kdb.LayerInfo(2, 0, "FILL")
+    base = kcl.get_symmetrical_cross_section(
+        kf.SymmetricalCrossSection(
+            width=500,
+            enclosure=kcl.get_enclosure(
+                kf.LayerEnclosure(
+                    sections=[(fill, -100)], main_layer=wg, name="shrunk_only"
+                )
+            ),
+            name="shrunk_extent",
+        )
+    )
+    assert base.get_xmax() == 250
+    assert base.get_xmin() == -250
+    # The outermost strip of the realised profile agrees.
+    assert max(s.section_max for s in base.get_sections()) == 250
+    # A band reaching past the core still wins.
+    grown = kcl.get_symmetrical_cross_section(
+        kf.SymmetricalCrossSection(
+            width=500,
+            enclosure=kcl.get_enclosure(
+                kf.LayerEnclosure(
+                    sections=[(fill, -100), (fill, 1000)],
+                    main_layer=wg,
+                    name="shrunk_and_grown",
+                )
+            ),
+            name="grown_extent",
+        )
+    )
+    assert grown.get_xmax() == 1250
+
+
+def test_symmetric_radius_survives_um_conversion(kcl: kf.KCLayout) -> None:
+    """`radius`/`radius_min` round-trip through the um flavour.
+
+    Regression: `DSymmetricalCrossSection` had no radius fields, so `to_dtype`
+    dropped them and `to_itype` could not restore them — data that survived the
+    file round trip but died on an in-memory unit conversion.
+    """
+    enc = kcl.get_enclosure(
+        kf.LayerEnclosure(
+            sections=[(kf.kdb.LayerInfo(2, 0, "S"), 500)],
+            main_layer=kf.kdb.LayerInfo(1, 0, "WG"),
+            name="radius_um_enc",
+        )
+    )
+    xs = kf.SymmetricalCrossSection(
+        width=1000, enclosure=enc, name="radius_um", radius=10_000, radius_min=5_000
+    )
+
+    dxs = xs.to_dtype(kcl)
+    assert dxs.radius == kcl.to_um(10_000)
+    assert dxs.radius_min == kcl.to_um(5_000)
+
+    back = dxs.to_itype(kcl)
+    assert back.radius == 10_000
+    assert back.radius_min == 5_000
+    assert back == xs
+
+    # An unset radius stays unset rather than becoming 0.
+    no_radius = kf.SymmetricalCrossSection(
+        width=1000, enclosure=enc, name="radius_um_none"
+    )
+    assert no_radius.to_dtype(kcl).radius is None
+    assert no_radius.to_dtype(kcl).to_itype(kcl).radius is None
+    assert no_radius.to_dtype(kcl).radius_min is None
+    assert no_radius.to_dtype(kcl).to_itype(kcl).radius_min is None
+
+
+def test_symmetric_wrapper_radius_from_um(kcl: kf.KCLayout) -> None:
+    """The um wrapper's constructor keeps the radius it was given.
+
+    Including `radius=0`: the constructor used to test the radius for
+    truthiness, so a zero radius was converted to "unset" instead of to 0.
+    """
+    wg = kf.kdb.LayerInfo(1, 0, "WG")
+    slab = kf.kdb.LayerInfo(2, 0, "S")
+    dxs = kf.DCrossSection(
+        kcl,
+        width=1.0,
+        layer=wg,
+        sections=[(slab, 0.5)],
+        radius=10.0,
+        radius_min=5.0,
+        name="wrapper_radius_um",
+    )
+    assert dxs.radius == 10.0
+    assert dxs.radius_min == 5.0
+    assert dxs.base.radius == kcl.to_dbu(10.0)
+    assert dxs.base.radius_min == kcl.to_dbu(5.0)
+
+    zero = kf.DCrossSection(
+        kcl,
+        width=2.0,
+        layer=wg,
+        sections=[(slab, 0.5)],
+        radius=0.0,
+        radius_min=0.0,
+        name="wrapper_radius_um_zero",
+    )
+    assert zero.base.radius == 0
+    assert zero.base.radius_min == 0
+
+    # An omitted radius is still unset.
+    unset = kf.DCrossSection(
+        kcl,
+        width=3.0,
+        layer=wg,
+        sections=[(slab, 0.5)],
+        name="wrapper_radius_um_unset",
+    )
+    assert unset.base.radius is None
+    assert unset.base.radius_min is None


### PR DESCRIPTION
## Summary

P1b of #1054: the two defects (**B10**, **B11**) found while implementing `get_sections()`
in #1061. Both land on the *bare core* — a plain core with no cladding, which is what a
single-section profile is and what a cross section derived from one section for a port (B8)
is — so they want fixing before anything leans on that shape.

### B10 — `get_xmax()` on a profile whose enclosure has no outward bands

`SymmetricalCrossSection.get_xmax` was `width // 2 + max(d_max for every band)`, which
failed two ways:

```python
# no bands at all
kf.SymmetricalCrossSection(
    width=500, enclosure=LayerEnclosure(sections=[], main_layer=WG)
).get_xmax()
# ValueError: max() iterable argument is empty

# only an inward band
kf.SymmetricalCrossSection(
    width=500, enclosure=LayerEnclosure(sections=[(FILL, -100)], main_layer=WG)
).get_xmax()
# 150   ← inside the core, which reaches 250
```

`get_xmin` negates `get_xmax`, so it went with it, and so did both wrappers'
`get_xmin_xmax`. The second case is the one worth flagging: it did not raise, it silently
understated the profile, and it disagreed with `get_sections()`, which has that same profile
correctly reaching ±250.

The invariant is that **the enclosure can only push the extent outwards**, because the core
always reaches `width // 2` on the main layer. So the bands are maxed with `default=0` and
then clamped at 0. Only the empty half was in the issue's write-up; the clamp came out of
probing before editing.

### B11 — radius dropped on the µm conversion

`DSymmetricalCrossSection` had no radius fields at all, so:

```python
xs = SymmetricalCrossSection(..., radius=10000, radius_min=5000)
xs.to_dtype(kcl).to_itype(kcl).radius      # None  (radius_min → None too)
```

Data that survives the *file* round trip but dies on an *in-memory* unit conversion — the
same shape as the defect #1057 closed — and `__eq__` hides it, since radius is
non-identifying metadata by design. `DAsymmetricalCrossSection` carries both already, so this
was the symmetric type lagging rather than a design choice. Fields added, populated in
`to_dtype()`, read back in `to_itype()`.

Also `DCrossSection.__init__` tested the radius for *truthiness*
(`to_dbu(radius) if radius else None`), so a `radius=0` became "unset" instead of 0.

## Second commit: dropping redundant `None` guards

`to_um`/`to_dbu` both have an explicit `None -> None` overload, so
`to_um(x) if x is not None else None` only obscures what the call does. Six of them in
`cross_section.py`, all removed — `AsymmetricalCrossSection.to_dtype`,
`DAsymmetricalCrossSection.to_itype`, `DAsymmetricCrossSection.radius`/`radius_min`, and
`DCrossSection.sections`. `DCrossSection.radius`/`radius_min` already called `to_um`
unguarded on the same `int | None`, so this just makes the file agree with itself.
`DCrossSection.sections` is presumably where the pattern started: `Section.d_min` is
`int | None` by design, so it *looks* like it needs the guard, but the tuple comes out
`(None, float)` either way.

Two look-alikes elsewhere are deliberately left alone, because there the None decides the
*shape* of the result rather than whether a conversion happens: `LayerEnclosure.to_dtype`
picks a 2-tuple or a 3-tuple depending on `d_min`, and `utils/fill.py` picks between a sized
and an unsized DRC expression (where the truthiness is right too — sizing by 0 is a no-op).

Split into its own commit so it can be dropped if you'd rather keep this to the two fixes.

## Test Plan

4 new tests, each verified to **fail without the fix and pass with it**:

- bare core: `get_xmax`/`get_xmin`, both wrappers' `get_xmin_xmax`, and agreement with
  `get_sections()`
- shrink-only enclosure does not pull the extent inside the core, and a band reaching past
  the core still wins
- radius µm round trip in both directions, plus unset staying unset rather than becoming 0
- µm wrapper constructor: a normal radius, `radius=0`, and an omitted radius

(The wrapper test initially passed without the fix, since `radius=10.0` is truthy — hence the
explicit `radius=0` case.)

Full suite green (2107 passed, 4 skipped). `pre-commit` passes on both commits, `ty` included.
